### PR TITLE
Fix Options type for visibility-sensor

### DIFF
--- a/packages/visibility-sensor/README.md
+++ b/packages/visibility-sensor/README.md
@@ -70,6 +70,7 @@ The first argument of the `useVisibilitySensor` hook is a ref, the second argume
 `intervalCheck: false` - Accepts `int | bool`, if an `int` is supplied, that will be the interval in `ms` and it keeps checking for visibility
 
 `partialVisibility: false` - Accepts `bool | string` : Tells the hook if partial visibility should be considered as visibility or not. Accepts `false` and directions `top`, `bottom`, `left` and `right`
+
 `containment: null` - A `DOMNode` element which defaults to `window`. The element relative to which visibility is checked against
 
 `scrollCheck: true` - A `bool` to determine whether to check for scroll behavior or not

--- a/packages/visibility-sensor/index.d.ts
+++ b/packages/visibility-sensor/index.d.ts
@@ -1,17 +1,17 @@
 import { Ref } from "react";
 
 type Options = {
-  intervalCheck?: boolean;
-  partialVisibility?: boolean;
-  containment?: HTMLElement;
-  scrollCheck?: boolean;
-  scrollDebounce?: number;
-  scrollThrottle?: number;
-  resizeCheck?: boolean;
-  resizeDebounce?: number;
-  resizeThrottle?: number;
-  shouldCheckOnMount?: boolean;
-  minTopValue?: number;
+  intervalCheck: boolean | number;
+  partialVisibility: boolean | string;
+  containment: HTMLElement | null;
+  scrollCheck: boolean;
+  scrollDebounce: number;
+  scrollThrottle: number;
+  resizeCheck: boolean;
+  resizeDebounce: number;
+  resizeThrottle: number;
+  shouldCheckOnMount: boolean;
+  minTopValue: number;
 };
 
 type VisibilityRect = {
@@ -28,5 +28,5 @@ interface State {
 
 export default function useVisibilitySensor(
   ref: Ref<HTMLElement>,
-  options?: Options
+  options?: Partial<Options>
 ): State;


### PR DESCRIPTION
* make Options partial (I think it's clearer than having all keys ending with `?`)
* fix types according to documentation
* small formatting issue in readme