### PR TITLE
for useOutsideClick add bug fix for IOS that occurs only on the real …

### DIFF
--- a/packages/outside-click/src/index.js
+++ b/packages/outside-click/src/index.js
@@ -1,6 +1,9 @@
 import { useLayoutEffect } from "react";
 
 function useOutsideClick(ref, handler, when = true) {
+  if ('ontouchstart' in document.documentElement) {
+    document.body.style.cursor = 'pointer'
+  }
   function handle(e) {
     if (ref && ref.current && !ref.current.contains(e.target)) {
       handler(e);


### PR DESCRIPTION
…device

Even though this appears to work even in xcode ios emulator.  on a REAL ios device this fix is needed for it to function.

```
  if ('ontouchstart' in document.documentElement) {
    document.body.style.cursor = 'pointer'
  }
```