### PR TITLE
using array instead of object so variables can be renamed easily

### DIFF
--- a/packages/localstorage/README.md
+++ b/packages/localstorage/README.md
@@ -26,10 +26,10 @@ import useLocalstorage from "@rooks/use-localstorage";
 
 ```jsx
 function Demo() {
-  const { value, set, remove } = useLocalstorage("my-value", 0);
+  const [value, set, remove] = useLocalstorage("my-value", 0);
   return (
     <p>
-      Value is {value}{" "}
+      Value is {value}
       <button onClick={() => set(value !== null ? value + 1 : 0)}>
         Increment
       </button>

--- a/packages/localstorage/README.md
+++ b/packages/localstorage/README.md
@@ -27,6 +27,8 @@ import useLocalstorage from "@rooks/use-localstorage";
 ```jsx
 function Demo() {
   const [value, set, remove] = useLocalstorage("my-value", 0);
+  // Can also be used as {value, set, remove}
+
   return (
     <p>
       Value is {value}

--- a/packages/localstorage/src/useLocalstorage.ts
+++ b/packages/localstorage/src/useLocalstorage.ts
@@ -1,12 +1,29 @@
 import { useState, useEffect } from "react";
 
+interface StorageHandlerAsObject {
+  value: any;
+  set: (newValue: any) => void;
+  remove: () => void;
+}
+
+interface StorageHandlerAsArray extends Array<any> {
+  0: any;
+  1: (newValue: any) => void;
+  2: () => void;
+}
+
+interface StorageHandler extends StorageHandlerAsArray {}
+
 /**
  * useLocalStorage hook
  *
  * @param {string} key - Key of the localStorage object
  * @param {any} defaultValue - Default initial value
  */
-function useLocalStorage(key: string, defaultValue: any = null) {
+function useLocalStorage(
+  key: string,
+  defaultValue: any = null
+): StorageHandler {
   const [value, setValue] = useState(getValueFromLocalStorage());
 
   function init() {
@@ -71,9 +88,13 @@ function useLocalStorage(key: string, defaultValue: any = null) {
     };
   });
 
-  const handler = [value, set, remove];
+  let handler: unknown;
+  (handler as StorageHandlerAsArray) = [value, set, remove];
+  (handler as StorageHandlerAsObject).value = value;
+  (handler as StorageHandlerAsObject).set = set;
+  (handler as StorageHandlerAsObject).remove = remove;
 
-  return handler;
+  return handler as StorageHandlerAsArray & StorageHandlerAsObject;
 }
 
 export { useLocalStorage };

--- a/packages/localstorage/src/useLocalstorage.ts
+++ b/packages/localstorage/src/useLocalstorage.ts
@@ -1,11 +1,5 @@
 import { useState, useEffect } from "react";
 
-interface LocalStorageHandler {
-  value: any;
-  set: (newValue: any) => void;
-  remove: () => void;
-}
-
 /**
  * useLocalStorage hook
  *
@@ -77,11 +71,7 @@ function useLocalStorage(key: string, defaultValue: any = null) {
     };
   });
 
-  const handler: LocalStorageHandler = {
-    value,
-    set,
-    remove
-  };
+  const handler = [value, set, remove];
 
   return handler;
 }

--- a/packages/sessionstorage/README.md
+++ b/packages/sessionstorage/README.md
@@ -25,6 +25,8 @@ import useSessionstorage from "@rooks/use-sessionstorage";
 ```jsx
 function Demo() {
   const [value, set, remove] = useSessionstorage("my-value", 0);
+  // Can also be used as {value, set, remove}
+
   return (
     <p>
       Value is {value}{" "}

--- a/packages/sessionstorage/README.md
+++ b/packages/sessionstorage/README.md
@@ -24,7 +24,7 @@ import useSessionstorage from "@rooks/use-sessionstorage";
 
 ```jsx
 function Demo() {
-  const { value, set, remove } = useSessionstorage("my-value", 0);
+  const [value, set, remove] = useSessionstorage("my-value", 0);
   return (
     <p>
       Value is {value}{" "}

--- a/packages/sessionstorage/src/useSessionstorage.ts
+++ b/packages/sessionstorage/src/useSessionstorage.ts
@@ -1,5 +1,19 @@
 import { useEffect, useReducer } from "react";
 
+interface StorageHandlerAsObject {
+  value: any;
+  set: (newValue: any) => void;
+  remove: () => void;
+}
+
+interface StorageHandlerAsArray extends Array<any> {
+  0: any;
+  1: (newValue: any) => void;
+  2: () => void;
+}
+
+interface StorageHandler extends StorageHandlerAsArray {}
+
 function reducer(state, action) {
   switch (action.type) {
     case "set":
@@ -9,7 +23,7 @@ function reducer(state, action) {
   }
 }
 
-function useSessionStorage(key: string, defaultValue = null) {
+function useSessionStorage(key: string, defaultValue = null): StorageHandler {
   const [value, dispatch] = useReducer(reducer, getValueFromSessionStorage());
 
   function init() {
@@ -76,7 +90,13 @@ function useSessionStorage(key: string, defaultValue = null) {
     };
   }, []);
 
-  return [value, set, remove];
+  let handler: unknown;
+  (handler as StorageHandlerAsArray) = [value, set, remove];
+  (handler as StorageHandlerAsObject).value = value;
+  (handler as StorageHandlerAsObject).set = set;
+  (handler as StorageHandlerAsObject).remove = remove;
+
+  return handler as StorageHandlerAsArray & StorageHandlerAsObject;
 }
 
 export { useSessionStorage };

--- a/packages/sessionstorage/src/useSessionstorage.ts
+++ b/packages/sessionstorage/src/useSessionstorage.ts
@@ -1,4 +1,4 @@
-import { useState, useReducer, useEffect } from "react";
+import { useEffect, useReducer } from "react";
 
 function reducer(state, action) {
   switch (action.type) {
@@ -76,11 +76,7 @@ function useSessionStorage(key: string, defaultValue = null) {
     };
   }, []);
 
-  return {
-    value,
-    set,
-    remove
-  };
+  return [value, set, remove];
 }
 
 export { useSessionStorage };

--- a/packages/storybook/.storybook/addons.js
+++ b/packages/storybook/.storybook/addons.js
@@ -1,4 +1,5 @@
 import registerWithPanelTitle from "storybook-readme/registerWithPanelTitle";
+import '@storybook/addon-storysource/register';
 registerWithPanelTitle("Docs");
 //import "@storybook/addon-actions/register";
 //import "@storybook/addon-knobs/register";

--- a/packages/storybook/.storybook/webpack.config.js
+++ b/packages/storybook/.storybook/webpack.config.js
@@ -1,6 +1,6 @@
 module.exports = function({ config }) {
   config.module.rules.push({
-    test: /\.jsx?$/,
+    test: /\.js?$/,
     loaders: [require.resolve("@storybook/addon-storysource/loader")],
     enforce: "pre"
   });

--- a/packages/storybook/src/localstorage.js
+++ b/packages/storybook/src/localstorage.js
@@ -3,8 +3,30 @@ import { storiesOf } from "@storybook/react";
 import useLocalstorage from "@rooks/use-localstorage";
 import README from "@rooks/use-localstorage/README.md";
 
+/**
+ * Array Destructuring
+ */
 function UseLocalstorageDemo() {
-  const [value, set, remove] = useLocalstorage("my-value", 0);
+  const [myValue, setMyValue, removeMyValue] = useLocalstorage("my-value", 0);
+  return (
+    <>
+      <h1>Please check localstorage for changes</h1>
+      <p>
+        Value is {myValue}
+        <button onClick={() => setMyValue(myValue !== null ? myValue + 1 : 0)}>
+          Increment
+        </button>
+        <button onClick={removeMyValue}>Remove </button>
+      </p>
+    </>
+  );
+}
+
+/**
+ * Object Destructuring
+ */
+function UseLocalstorageDemoObject() {
+  const { value, set, remove } = useLocalstorage("my-value", 0);
   return (
     <>
       <h1>Please check localstorage for changes</h1>
@@ -25,4 +47,5 @@ storiesOf("useLocalstorage", module)
       sidebar: README
     }
   })
-  .add("basic example", () => <UseLocalstorageDemo />);
+  .add("basic example", () => <UseLocalstorageDemo />)
+  .add("use object destructuring", () => <UseLocalstorageDemoObject />);

--- a/packages/storybook/src/localstorage.js
+++ b/packages/storybook/src/localstorage.js
@@ -4,12 +4,12 @@ import useLocalstorage from "@rooks/use-localstorage";
 import README from "@rooks/use-localstorage/README.md";
 
 function UseLocalstorageDemo() {
-  const { value, set, remove } = useLocalstorage("my-value", 0);
+  const [value, set, remove] = useLocalstorage("my-value", 0);
   return (
     <>
       <h1>Please check localstorage for changes</h1>
       <p>
-        Value is {value}{" "}
+        Value is {value}
         <button onClick={() => set(value !== null ? value + 1 : 0)}>
           Increment
         </button>

--- a/packages/storybook/src/sessionstorage.js
+++ b/packages/storybook/src/sessionstorage.js
@@ -1,15 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { storiesOf } from "@storybook/react";
 import useSessionstorage from "@rooks/use-sessionstorage";
 import README from "@rooks/use-sessionstorage/README.md";
 
 function UseSessionstorageDemo() {
-  const { value, set, remove } = useSessionstorage("my-value", 0);
+  const [value, set, remove] = useSessionstorage("my-value", 0);
   return (
     <>
       <h1>Please check localstorage for changes</h1>
       <p>
-        Value is {value}{" "}
+        Value is {value}
         <button onClick={() => set(value !== null ? parseFloat(value) + 1 : 0)}>
           Increment
         </button>

--- a/packages/storybook/src/sessionstorage.js
+++ b/packages/storybook/src/sessionstorage.js
@@ -3,8 +3,34 @@ import { storiesOf } from "@storybook/react";
 import useSessionstorage from "@rooks/use-sessionstorage";
 import README from "@rooks/use-sessionstorage/README.md";
 
+/**
+ * Array Destructuring
+ */
 function UseSessionstorageDemo() {
-  const [value, set, remove] = useSessionstorage("my-value", 0);
+  const [myValue, setMyValue, removeMyValye] = useSessionstorage("my-value", 0);
+  return (
+    <>
+      <h1>Please check sessionstorage for changes</h1>
+      <p>
+        Value is {myValue}
+        <button
+          onClick={() =>
+            setMyValue(myValue !== null ? parseFloat(myValue) + 1 : 0)
+          }
+        >
+          Increment
+        </button>
+        <button onClick={removeMyValye}>Remove </button>
+      </p>
+    </>
+  );
+}
+
+/**
+ * Object Destructuring
+ */
+function UseSessionstorageDemoObject() {
+  const { value, set, remove } = useSessionstorage("my-value", 0);
   return (
     <>
       <h1>Please check sessionstorage for changes</h1>
@@ -25,4 +51,5 @@ storiesOf("useSessionstorage", module)
       sidebar: README
     }
   })
-  .add("basic example", () => <UseSessionstorageDemo />);
+  .add("basic example", () => <UseSessionstorageDemo />)
+  .add("use object destructuring", () => <UseSessionstorageDemoObject />);

--- a/packages/storybook/src/sessionstorage.js
+++ b/packages/storybook/src/sessionstorage.js
@@ -7,7 +7,7 @@ function UseSessionstorageDemo() {
   const [value, set, remove] = useSessionstorage("my-value", 0);
   return (
     <>
-      <h1>Please check localstorage for changes</h1>
+      <h1>Please check sessionstorage for changes</h1>
       <p>
         Value is {value}
         <button onClick={() => set(value !== null ? parseFloat(value) + 1 : 0)}>


### PR DESCRIPTION
## Why this change?
- Using array over object for destructring allows user to easily use flexible variable names
- Official react also uses the same approach for hooks like [`useEffect`](https://reactjs.org/docs/hooks-effect.html).

```jsx
// Previously
const {value, set, remove} = useLocalstorage("my-value", 0);

// With array flexible variable naming
const [myValue, setMyValue, removeMyValue] = useLocalstorage("my-value", 0);
```