### PR TITLE
Fix infinite loop issue and add test case for it

### DIFF
--- a/packages/geolocation/src/useGeolocation.ts
+++ b/packages/geolocation/src/useGeolocation.ts
@@ -62,17 +62,22 @@ function useGeolocation(
   geoLocationOptions: IOptions = defaultGeoLocationOptions
 ) {
   const [geoObj, setGeoObj] = useState(null);
-  const { when } = geoLocationOptions;
+  const { when, enableHighAccuracy, timeout, maximumAge } = geoLocationOptions;
 
   useEffect(() => {
     async function getGeoCode() {
-      const value = await getGeoLocation(geoLocationOptions);
+      const value = await getGeoLocation({
+        when,
+        enableHighAccuracy,
+        timeout,
+        maximumAge
+      });
       setGeoObj(value);
     }
     if (when) {
       getGeoCode();
     }
-  }, [when, geoLocationOptions]);
+  }, [when, enableHighAccuracy, timeout, maximumAge]);
 
   return geoObj;
 }

--- a/packages/geolocation/test/index.spec.js
+++ b/packages/geolocation/test/index.spec.js
@@ -27,12 +27,20 @@ describe("useGeolocation", () => {
 
     global.navigator.geolocation = mockGeolocation;
 
-    App = function () {
+    App = function (props) {
+      let { customRef } = props
+      if (!customRef) {
+        customRef = React.useRef(0)
+      }
       const [when, setWhen] = React.useState(false);
-
+      const renderCountRef = customRef
       const geoObj = useGeolocation({
         when
       });
+
+      React.useEffect(() => {
+        renderCountRef.current++
+      })
 
       return (
         <div className="App">
@@ -80,6 +88,29 @@ describe("useGeolocation", () => {
 
 
   })
+
+  it("render should not happen infinitely, when 'when' attribute changes to true ", async () => {
+    let container
+    let customRef
+    function TestComp() {
+      customRef = React.useRef(0)
+      return (
+        <App customRef={customRef} />
+      )
+
+    }
+    act(() => {
+      container = render(<TestComp />).container;
+    })
+    const getGeolocationBtn = getByTestId(container, "get-geolocation-btn");
+    act(() => {
+      fireEvent.click(getGeolocationBtn)
+    })
+    await wait()
+    expect(customRef.current).toBe(3)
+
+  })
 });
 
 // figure out tests
+


### PR DESCRIPTION
This pr fixes the issue mentioned in issue [https://github.com/imbhargav5/rooks/issues/103](url)

1. Fix the infinite loop issue:
Happening due to the options object being sent as a new reference always and effect running again and again. Now I have spread the options

2. Add test case for the infinite loop issue. 
