### PR TITLE
Fixing intersection observer issue and added hooks eslint plugin

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -33,7 +33,9 @@ module.exports = {
     "no-console": [0],
     "no-mixed-spaces-and-tabs": [0],
     "react/react-in-jsx-scope": [0],
-    "react/display-name": [0]
+    "react/display-name": [0],
+    "react-hooks/rules-of-hooks": [2],
+    "react-hooks/exhaustive-deps": [1]
   },
-  plugins: ["react"]
+  plugins: ["react", "react-hooks"]
 };

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "babel-eslint": "10.0.3",
     "eslint": "5.12.1",
-    "eslint-plugin-react": "7.12.4"
+    "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "^2.0.1"
   }
 }

--- a/packages/intersectionobserver/src/useIntersectionObserver.ts
+++ b/packages/intersectionobserver/src/useIntersectionObserver.ts
@@ -36,7 +36,7 @@ function IntersectionObserverReducer(state: any, action: Iaction) {
 }
 
 const checkFeasibility = () => {
-  let MyWindow = window as any;
+  const MyWindow = window as any;
   if (!MyWindow || !MyWindow.IntersectionObserver) {
     console.warn(
       "Intersection Observer is not supported in the current browser / environment"
@@ -84,12 +84,14 @@ const defaultVisibilityCondition = (entry: IntersectionObserverEntry) => {
   return false;
 };
 
+const defaultThreshold = [0, 1];
+
 function useIntersectionObserver(
   options: IOptions
 ): useIntersectionObserverReturn {
   const defaultOptions = {
     rootMargin: "0px 0px 0px 0px",
-    threshold: [0, 1],
+    threshold: defaultThreshold,
     when: true,
     visibilityCondition: defaultVisibilityCondition
   };
@@ -117,6 +119,7 @@ function useIntersectionObserver(
   React.useEffect(() => {
     visibilityConditionRef.current = visibilityCondition;
   });
+
   React.useEffect(() => {
     savedCallbackRef.current = callback;
   });
@@ -187,7 +190,15 @@ function useIntersectionObserver(
         };
       }
     }
-  }, [rootMargin, when, savedCallbackRef, threshold]);
+  }, [
+    rootMargin,
+    when,
+    savedCallbackRef,
+    threshold,
+    element,
+    handleIntersectionObserve,
+    root
+  ]);
 
   const callbackRef = React.useCallback((node: HTMLElement) => {
     setElement(node);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4650,7 +4650,7 @@ commander@2.17.x, commander@~2.17.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.11.0, commander@^2.19.0, commander@^2.8.1, commander@~2.20.0:
+commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@^2.8.1, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -5779,6 +5779,11 @@ escodegen@^1.9.0, escodegen@^1.9.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-plugin-react-hooks@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz#e898ec26a0a335af6f7b0ad1f0bedda7143ed756"
+  integrity sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==
 
 eslint-plugin-react@7.12.4:
   version "7.12.4"
@@ -12155,7 +12160,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@^0.5.9, source-map-support@~0.5.6:
+source-map-support@^0.5.6, source-map-support@^0.5.9, source-map-support@~0.5.12, source-map-support@~0.5.6:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
   integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
@@ -12682,7 +12687,7 @@ terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.2.4, terser-webpack-plugi
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@3.14, terser@^3.14.1, terser@^4.1.2:
+terser@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.14.1.tgz#cc4764014af570bc79c79742358bd46926018a32"
   integrity sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==
@@ -12690,6 +12695,15 @@ terser@3.14, terser@^3.14.1, terser@^4.1.2:
     commander "~2.17.1"
     source-map "~0.6.1"
     source-map-support "~0.5.6"
+
+terser@^4.1.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.1.tgz#09820bcb3398299c4b48d9a86aefc65127d0ed65"
+  integrity sha512-pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 test-exclude@^4.2.1:
   version "4.2.3"


### PR DESCRIPTION
Following issues were fixed : 
1. Intersection observer was going onto infinite loop, can be seen by keeping alog in storybook example as the threshold new array reference is create on every render

2. Added the eslint for react hooks as discussed in  https://github.com/imbhargav5/rooks/issues/129
While doing that, I figured out the eslint config is considering certain typescript syntax as errors.E.g
window as IWindow. I think there is a need to add typescript eslint rules to the project.

I think eslint plugin will prevent such mistakes where dependencies are missed in hooks.

Let me know what are your thoughts , regfarding linting rules for tyopescript.
