### PR TITLE
Localstorage and Sessionstorage typo fix

### DIFF
--- a/packages/localstorage/src/index.ts
+++ b/packages/localstorage/src/index.ts
@@ -1,1 +1,1 @@
-export { useLocalStorage as default } from "./useLocalstorage";
+export { useLocalstorage as default } from "./useLocalstorage";

--- a/packages/localstorage/src/useLocalstorage.ts
+++ b/packages/localstorage/src/useLocalstorage.ts
@@ -15,12 +15,12 @@ interface StorageHandlerAsArray extends Array<any> {
 interface StorageHandler extends StorageHandlerAsArray {}
 
 /**
- * useLocalStorage hook
+ * useLocalstorage hook
  *
  * @param {string} key - Key of the localStorage object
  * @param {any} defaultValue - Default initial value
  */
-function useLocalStorage(
+function useLocalstorage(
   key: string,
   defaultValue: any = null
 ): StorageHandler {
@@ -97,4 +97,4 @@ function useLocalStorage(
   return handler as StorageHandlerAsArray & StorageHandlerAsObject;
 }
 
-export { useLocalStorage };
+export { useLocalstorage };

--- a/packages/localstorage/test/index.spec.js
+++ b/packages/localstorage/test/index.spec.js
@@ -5,7 +5,7 @@ import React from "react";
 import useLocalstorage from "..";
 import { render, cleanup, getByTestId, fireEvent, act } from "@testing-library/react";
 
-describe("useLocalStorage defined", () => {
+describe("useLocalstorage defined", () => {
   it("should be defined", () => {
     expect(useLocalstorage).toBeDefined();
   });

--- a/packages/sessionstorage/src/index.ts
+++ b/packages/sessionstorage/src/index.ts
@@ -1,1 +1,1 @@
-export { useSessionStorage as default } from "./useSessionstorage";
+export { useSessionstorage as default } from "./useSessionstorage";

--- a/packages/sessionstorage/src/useSessionstorage.ts
+++ b/packages/sessionstorage/src/useSessionstorage.ts
@@ -23,7 +23,7 @@ function reducer(state, action) {
   }
 }
 
-function useSessionStorage(key: string, defaultValue = null): StorageHandler {
+function useSessionstorage(key: string, defaultValue = null): StorageHandler {
   const [value, dispatch] = useReducer(reducer, getValueFromSessionStorage());
 
   function init() {
@@ -99,4 +99,4 @@ function useSessionStorage(key: string, defaultValue = null): StorageHandler {
   return handler as StorageHandlerAsArray & StorageHandlerAsObject;
 }
 
-export { useSessionStorage };
+export { useSessionstorage };


### PR DESCRIPTION
Resolves #148  

- classname from `useLocalStorage` to `useLocalstorage`
- classname from `useSessionStorage` to `useSessionstorage`