### PR TITLE
Add param to listen to mousedown instead of click

### DIFF
--- a/packages/outside-click-ref/README.md
+++ b/packages/outside-click-ref/README.md
@@ -35,3 +35,18 @@ function Demo() {
 
 render(<Demo/>)
 ```
+
+### Arguments
+
+| Arguments       | Type      | Description                                                                                                                                      | Default value |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| ref             | React ref | Ref whose outside click needs to be listened to                                                                                                  | N/A           |
+| handler         | function  | Callback to fire on outside click                                                                                                                | N/A           |
+| when            | boolean   | A boolean which activates the hook only when it is true. Useful for conditionally enable the outside click                                       | true          |
+| listenMouseDown | boolean   | A boolean which switches the hook to listen to `mousedown` event instead of `click`. Useful when user might start drag instead of regular clicks | false         |
+
+### Returns an array of 1 value
+
+| Return value | Type         | Description                                                                        | Default value |
+| ------------ | ------------ | ---------------------------------------------------------------------------------- | ------------- |
+| ref          | Callback ref | A callback ref function to use as a ref for the component that needs to be tracked | () => null    |

--- a/packages/outside-click-ref/src/useOutsideClickRef.ts
+++ b/packages/outside-click-ref/src/useOutsideClickRef.ts
@@ -8,17 +8,19 @@ import {
 import { HTMLElementOrNull, CallbackRef } from "shared/utils";
 
 /**
- *  useOutsideClickRef hook
+ * useOutsideClickRef hook
  *
  * Checks if a click happened outside a Ref. Handy for dropdowns, modals and popups etc.
  *
  * @param handler Callback to fire on outside click
- * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
+ * @param when A boolean which activates the hook only when it is true. Useful for conditionally enable the outside click
+ * @param listenMouseDown A boolean which switches the hook to listen to `mousedown` event instead of `click`. Useful when user might start drag instead of regular clicks
  * @returns ref
  */
 function useOutsideClickRef(
   handler: (e: MouseEvent) => any,
-  when: boolean = true
+  when: boolean = true,
+  listenMouseDown: boolean = false
 ): [CallbackRef] {
   const savedHandler = useRef(handler);
 
@@ -33,6 +35,8 @@ function useOutsideClickRef(
     [node]
   );
 
+  const mouseEvent = listenMouseDown ? "mousedown" : "click";
+
   useEffect(() => {
     savedHandler.current = handler;
   });
@@ -43,14 +47,14 @@ function useOutsideClickRef(
 
   useEffect(() => {
     if (when) {
-      document.addEventListener("click", memoizedCallback);
+      document.addEventListener(mouseEvent, memoizedCallback);
       document.addEventListener("ontouchstart", memoizedCallback);
       return () => {
-        document.removeEventListener("click", memoizedCallback);
+        document.removeEventListener(mouseEvent, memoizedCallback);
         document.removeEventListener("ontouchstart", memoizedCallback);
       };
     }
-  }, [when, memoizedCallback]);
+  }, [when, memoizedCallback, mouseEvent]);
 
   return [ref];
 }

--- a/packages/outside-click-ref/test/index.spec.js
+++ b/packages/outside-click-ref/test/index.spec.js
@@ -1,13 +1,112 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
+import React, { useState } from "react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
 import useOutsideClickRef from "..";
 
+function TestComponent() {
+  const [count, setCount] = useState(0);
+  const [when, setWhen] = useState(true);
+  const [listenMouseDown, setListenMouseDown] = useState(false);
+
+  const [ref] = useOutsideClickRef(
+    () => setCount(count + 1),
+    when,
+    listenMouseDown
+  );
+
+  return (
+    <div>
+      <p>Outside</p>
+      <div ref={ref} data-testid="target">
+        <span>Inside Target</span>
+        <button onClick={() => setWhen(!when)}>Toggle when</button>
+        <button onClick={() => setListenMouseDown(!listenMouseDown)}>
+          Toggle listenMouseDown
+        </button>
+      </div>
+      <p data-testid="counter">{count}</p>
+    </div>
+  );
+}
+
+
 describe("useOutsideClickRef", () => {
+  afterEach(cleanup);
+
   it("should be defined", () => {
     expect(useOutsideClickRef).toBeDefined();
   });
-});
 
-// figure out tests
+  it("doesn't execute callback on click on target element", () => {
+    const { getByTestId } = render(<TestComponent />);
+    const target = getByTestId("target");
+    const counter = getByTestId("counter");
+
+    fireEvent.click(target);
+    expect(counter.textContent).toBe("0");
+  });
+
+  it("doesn't execute callback on click inside target element", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const target = getByText("Inside Target");
+    const counter = getByTestId("counter");
+
+    fireEvent.click(target);
+    expect(counter.textContent).toBe("0");
+  });
+
+  it("executes callback on click outside of target element", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const outside = getByText("Outside");
+    const counter = getByTestId("counter");
+
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("1");
+  });
+
+  it("executes callback on click outside only if `when` is `true`", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const outside = getByText("Outside");
+    const togglerWhen = getByText("Toggle when");
+    const counter = getByTestId("counter");
+
+    // `count` is updated on click if `when` is `true` (default)
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("1");
+
+    // Set `when` to `false` and check that `count` is not updated on click
+    fireEvent.click(togglerWhen);
+    fireEvent.click(outside);
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("1");
+
+    // Set `when` to `true` and check that `count` is updated on click
+    fireEvent.click(togglerWhen);
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("2");
+  });
+
+  it("executes callback on mousedown outside only if `listenMouseDown` is `true`", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const outside = getByText("Outside");
+    const togglerEvent = getByText("Toggle listenMouseDown");
+    const counter = getByTestId("counter");
+
+    // `count` is not updated on mousedown if `listenMouseDown` is `false` (default)
+    fireEvent.mouseDown(outside);
+    expect(counter.textContent).toBe("0");
+
+    // Set `listenMouseDown` to `true` and check that `count` is updated on mousedown
+    fireEvent.click(togglerEvent);
+    fireEvent.mouseDown(outside);
+    fireEvent.mouseDown(outside);
+    expect(counter.textContent).toBe("2");
+
+    // Set `listenMouseDown` to `false` and check that `count` is not updated on click
+    fireEvent.click(togglerEvent);
+    fireEvent.mouseDown(outside);
+    expect(counter.textContent).toBe("2");
+  });
+});

--- a/packages/outside-click/README.md
+++ b/packages/outside-click/README.md
@@ -38,3 +38,13 @@ function Demo() {
 
 render(<Demo />);
 ```
+
+
+### Arguments
+
+| Arguments       | Type      | Description                                                                                                                                      | Default value |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| ref             | React ref | Ref whose outside click needs to be listened to                                                                                                  | N/A           |
+| handler         | function  | Callback to fire on outside click                                                                                                                | N/A           |
+| when            | boolean   | A boolean which activates the hook only when it is true. Useful for conditionally enable the outside click                                       | true          |
+| listenMouseDown | boolean   | A boolean which switches the hook to listen to `mousedown` event instead of `click`. Useful when user might start drag instead of regular clicks | false         |

--- a/packages/outside-click/src/useOutsideClick.ts
+++ b/packages/outside-click/src/useOutsideClick.ts
@@ -1,18 +1,20 @@
 import { useEffect, MutableRefObject, useRef, useCallback } from "react";
 
 /**
- *  useOutsideClick hook
+ * useOutsideClick hook
  *
  * Checks if a click happened outside a Ref. Handy for dropdowns, modals and popups etc.
  *
  * @param ref Ref whose outside click needs to be listened to
  * @param handler Callback to fire on outside click
- * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
+ * @param when A boolean which activates the hook only when it is true. Useful for conditionally enable the outside click
+ * @param listenMouseDown A boolean which switches the hook to listen to `mousedown` event instead of `click`. Useful when user might start drag instead of regular clicks
  */
 function useOutsideClick(
   ref: MutableRefObject<HTMLElement>,
   handler: (e: MouseEvent) => any,
-  when: boolean = true
+  when: boolean = true,
+  listenMouseDown: boolean = false
 ): void {
   const savedHandler = useRef(handler);
 
@@ -22,20 +24,22 @@ function useOutsideClick(
     }
   }, []);
 
+  const mouseEvent = listenMouseDown ? "mousedown" : "click";
+
   useEffect(() => {
     savedHandler.current = handler;
   });
 
   useEffect(() => {
     if (when) {
-      document.addEventListener("click", memoizedCallback);
+      document.addEventListener(mouseEvent, memoizedCallback);
       document.addEventListener("ontouchstart", memoizedCallback);
       return () => {
-        document.removeEventListener("click", memoizedCallback);
+        document.removeEventListener(mouseEvent, memoizedCallback);
         document.removeEventListener("ontouchstart", memoizedCallback);
       };
     }
-  }, [ref, handler, when]);
+  }, [ref, handler, when, mouseEvent]);
 }
 
 export { useOutsideClick };

--- a/packages/outside-click/test/index.spec.js
+++ b/packages/outside-click/test/index.spec.js
@@ -1,13 +1,114 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
+import React, { useState, useRef } from "react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
 import useOutsideClick from "..";
 
+function TestComponent() {
+  const [count, setCount] = useState(0);
+  const [when, setWhen] = useState(true);
+  const [listenMouseDown, setListenMouseDown] = useState(false);
+  const ref = useRef();
+
+  useOutsideClick(
+    ref,
+    () => setCount(count + 1),
+    when,
+    listenMouseDown
+  );
+
+  return (
+    <div>
+      <p>Outside</p>
+      <div ref={ref} data-testid="target">
+        <span>Inside Target</span>
+        <button onClick={() => setWhen(!when)}>Toggle when</button>
+        <button onClick={() => setListenMouseDown(!listenMouseDown)}>
+          Toggle listenMouseDown
+        </button>
+      </div>
+      <p data-testid="counter">{count}</p>
+    </div>
+  );
+}
+
+
 describe("useOutsideClick", () => {
+  afterEach(cleanup);
+
   it("should be defined", () => {
     expect(useOutsideClick).toBeDefined();
   });
-});
 
-// figure out tests
+  it("doesn't execute callback on click on target element", () => {
+    const { getByTestId } = render(<TestComponent />);
+    const target = getByTestId("target");
+    const counter = getByTestId("counter");
+
+    fireEvent.click(target);
+    expect(counter.textContent).toBe("0");
+  });
+
+  it("doesn't execute callback on click inside target element", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const target = getByText("Inside Target");
+    const counter = getByTestId("counter");
+
+    fireEvent.click(target);
+    expect(counter.textContent).toBe("0");
+  });
+
+  it("executes callback on click outside of target element", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const outside = getByText("Outside");
+    const counter = getByTestId("counter");
+
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("1");
+  });
+
+  it("executes callback on click outside only if `when` is `true`", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const outside = getByText("Outside");
+    const togglerWhen = getByText("Toggle when");
+    const counter = getByTestId("counter");
+
+    // `count` is updated on click if `when` is `true` (default)
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("1");
+
+    // Set `when` to `false` and check that `count` is not updated on click
+    fireEvent.click(togglerWhen);
+    fireEvent.click(outside);
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("1");
+
+    // Set `when` to `true` and check that `count` is updated on click
+    fireEvent.click(togglerWhen);
+    fireEvent.click(outside);
+    expect(counter.textContent).toBe("2");
+  });
+
+  it("executes callback on mousedown outside only if `listenMouseDown` is `true`", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    const outside = getByText("Outside");
+    const togglerEvent = getByText("Toggle listenMouseDown");
+    const counter = getByTestId("counter");
+
+    // `count` is not updated on mousedown if `listenMouseDown` is `false` (default)
+    fireEvent.mouseDown(outside);
+    expect(counter.textContent).toBe("0");
+
+    // Set `listenMouseDown` to `true` and check that `count` is updated on mousedown
+    fireEvent.click(togglerEvent);
+    fireEvent.mouseDown(outside);
+    fireEvent.mouseDown(outside);
+    expect(counter.textContent).toBe("2");
+
+    // Set `listenMouseDown` to `false` and check that `count` is not updated on click
+    fireEvent.click(togglerEvent);
+    fireEvent.mouseDown(outside);
+    expect(counter.textContent).toBe("2");
+  });
+});


### PR DESCRIPTION
Fixes #199

After few attempts (to overengineer things) it looks like it shouldn't be a big deal to just reassign events when `listenMouseDown` changes, and now it's inline with `when` behavior.

I haven't found tests/story/readme description for `when` parameter, do I need to add these for `listenMouseDown` everything in scope of this PR?

Looks like failure related to #172 and not PR changes.

UPD. Looks like I've missed that this repo already have `@testing-library/react`. Tried to play with tests https://codesandbox.io/s/bold-flower-k3b5u so shouldn't be too hard to add them to this repo.