### PR TITLE
fix(useGeolocation): catch unhandled error to return error status and message

### DIFF
--- a/packages/geolocation/src/useGeolocation.ts
+++ b/packages/geolocation/src/useGeolocation.ts
@@ -66,13 +66,17 @@ function useGeolocation(
 
   useEffect(() => {
     async function getGeoCode() {
-      const value = await getGeoLocation({
-        when,
-        enableHighAccuracy,
-        timeout,
-        maximumAge
-      });
-      setGeoObj(value);
+      try {
+        const value = await getGeoLocation({
+          when,
+          enableHighAccuracy,
+          timeout,
+          maximumAge
+        });
+        setGeoObj(value);
+      } catch (e) {
+        setGeoObj(e);
+      }
     }
     if (when) {
       getGeoCode();


### PR DESCRIPTION
The function `getGeoLocation` works as expected and rejects the Promise how it should, but inside the `useEffect` there was no catching this error.

Wrapping with a try catch yields the expected behaviour.