### PR TITLE
Return the navigator language property as is

### DIFF
--- a/packages/navigator-language/src/useNavigatorLanguage.ts
+++ b/packages/navigator-language/src/useNavigatorLanguage.ts
@@ -6,5 +6,5 @@
  * @return {string|null}
  */
 export function useNavigatorLanguage(): string | null {
-  return navigator.language
+  return navigator.language;
 }

--- a/packages/navigator-language/src/useNavigatorLanguage.ts
+++ b/packages/navigator-language/src/useNavigatorLanguage.ts
@@ -1,5 +1,3 @@
-import { useState, useEffect } from "react";
-
 /**
  * useNavigatorLanguage hook
  *
@@ -8,9 +6,5 @@ import { useState, useEffect } from "react";
  * @return {string|null}
  */
 export function useNavigatorLanguage(): string | null {
-  const [language, setLanguage] = useState(null);
-  useEffect(() => {
-    setLanguage(navigator.language || navigator["userLanguage"]);
-  }, []);
-  return language;
+  return navigator.language
 }


### PR DESCRIPTION
This removes the useState and useEffect hook calls and just returns the value on the navigator as is.
It should stop unwanted reflow caused by the effect updating the state on load.

closes [#212]