### PR TITLE
Add optional properties to useTimeAgo Options

### DIFF
--- a/packages/time-ago/src/useTimeAgo.ts
+++ b/packages/time-ago/src/useTimeAgo.ts
@@ -32,7 +32,7 @@ function reducer(state: string, action: any) {
   }
 }
 
-function useTimeAgo(input: any, argOpts: Options): string {
+function useTimeAgo(input: any, argOpts?: Options): string {
   const opts = Object.assign({}, argOpts, defaultOpts);
   const { intervalMs, locale, relativeDate } = opts;
   const [state, dispatcher] = useReducer(

--- a/packages/time-ago/src/useTimeAgo.ts
+++ b/packages/time-ago/src/useTimeAgo.ts
@@ -7,9 +7,9 @@ const defaultOpts = {
 };
 
 interface Options {
-  intervalMs: number;
-  locale: string;
-  relativeDate: any;
+  intervalMs?: number;
+  locale?: string;
+  relativeDate?: any;
 }
 
 function computeTimeAgo(input, locale, relativeDate) {


### PR DESCRIPTION
Currently, you must set up options.
This will not allow you to call the function using the default value.

With this fix, the option will no longer be mandatory.