### PR TITLE
useUndoState hook

### DIFF
--- a/packages/storybook/src/index.js
+++ b/packages/storybook/src/index.js
@@ -32,6 +32,7 @@ import "./time-ago";
 import "./throttle";
 import "./timeout";
 import "./toggle";
+import "./undo-state";
 import "./visibility-sensor";
 import "./will-unmount";
 import "./window-size";

--- a/packages/storybook/src/undo-state.js
+++ b/packages/storybook/src/undo-state.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import useUndoState from '@rooks/use-undo-state';
+import README from '@rooks/use-undo-state/README.md';
+
+const UndoStateDemo = () => {
+    const [value, setValue, undo] = useUndoState(0)
+
+    return (
+        <div>
+            <div>Current value: {value}</div>
+            <button onClick={() => setValue(value + 1)}>
+                Increment
+            </button>
+            <button onClick={undo}>
+                Undo
+            </button>
+        </div>
+    )
+}
+
+storiesOf('useUndoState', module)
+    .addParameters({
+        readme: {
+            sidebar: README
+        }
+    })
+    .add('basic example', () => <UndoStateDemo />);

--- a/packages/undo-state/.babelrc
+++ b/packages/undo-state/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react", "babel-preset-minify"]
+}

--- a/packages/undo-state/.eslintrc
+++ b/packages/undo-state/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": ["rooks"]
+}

--- a/packages/undo-state/.npmignore
+++ b/packages/undo-state/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+*.log

--- a/packages/undo-state/README.md
+++ b/packages/undo-state/README.md
@@ -21,10 +21,79 @@ import useUndoState from "@rooks/use-undo-state"
 ### Usage
 
 ```jsx
-function Demo() {
-  useUndoState();
-  return null
+const Demo = () => {
+  const [value, setValue, undo] = useUndoState(0)
+
+  return (
+    <div>
+      <span>Current value: {value}</span>
+      <button onClick={() => setValue(value + 1)}>
+        Increment
+      </button>
+      <button onClick={undo} data-testid="undo">
+        Undo
+      </button>
+    </div>
+  )
 }
 
 render(<Demo/>)
+```
+
+You can pass any kind of value to hook just like React's own useState.
+
+```jsx
+const Demo = () => {
+  const [value, setValue, undo] = useUndoState({ data: 42 })
+
+  return (
+    <div>
+      <span>Current value: {value}</span>
+      <button onClick={() => setValue({ data: value.data + 1 })}>
+        Increment object data
+      </button>
+      <button onClick={undo} data-testid="undo">
+        Undo
+      </button>
+    </div>
+  )
+}
+
+render(<Demo/>)
+```
+
+Setter function can also be used with callback just like React's own useState.
+
+```javascript
+const [value, setValue, undo] = useUndoState({ data: 42 })
+
+() => setValue(current => current + 1)
+```
+
+```jsx
+const Demo = () => {
+  const [value, setValue, undo] = useUndoState(0)
+
+  return (
+    <div>
+      <span>Current value: {value}</span>
+      <button onClick={() => setValue(current => current + 1)}>
+        Increment
+      </button>
+      <button onClick={undo} data-testid="undo">
+        Undo
+      </button>
+    </div>
+  )
+}
+
+render(<Demo/>)
+```
+
+To preserve memory you can limit number of steps that will be preserved in undo history.
+
+```javascript
+const [value, setValue, undo] = useUndoState(0, { maxSize: 30 })
+
+// now when calling undo only last 30 changes to the value will be preserved
 ```

--- a/packages/undo-state/README.md
+++ b/packages/undo-state/README.md
@@ -1,0 +1,30 @@
+# @rooks/use-undo-state
+
+### Drop in replacement for useState hook but with undo functionality.
+
+[![Build Status](https://travis-ci.org/imbhargav5/rooks.svg?branch=master)](https://travis-ci.org/imbhargav5/rooks) ![](https://img.shields.io/npm/v/@rooks/use-undo-state/latest.svg) ![](https://img.shields.io/npm/l/@rooks/use-undo-state.svg) ![](https://img.shields.io/bundlephobia/min/@rooks/use-undo-state.svg) ![](https://img.shields.io/david/imbhargav5/rooks.svg?path=packages%2Fundo-state)
+
+<a href="https://spectrum.chat/rooks"><img src="https://withspectrum.github.io/badge/badge.svg" alt="Join the community on Spectrum"/></a>
+
+### Installation
+
+```
+npm install --save @rooks/use-undo-state
+```
+
+### Importing the hook
+
+```javascript
+import useUndoState from "@rooks/use-undo-state"
+```
+
+### Usage
+
+```jsx
+function Demo() {
+  useUndoState();
+  return null
+}
+
+render(<Demo/>)
+```

--- a/packages/undo-state/README.md
+++ b/packages/undo-state/README.md
@@ -15,7 +15,7 @@ npm install --save @rooks/use-undo-state
 ### Importing the hook
 
 ```javascript
-import useUndoState from "@rooks/use-undo-state"
+import useUndoState from '@rooks/use-undo-state'
 ```
 
 ### Usage
@@ -30,7 +30,7 @@ const Demo = () => {
       <button onClick={() => setValue(value + 1)}>
         Increment
       </button>
-      <button onClick={undo} data-testid="undo">
+      <button onClick={undo}>
         Undo
       </button>
     </div>
@@ -52,7 +52,7 @@ const Demo = () => {
       <button onClick={() => setValue({ data: value.data + 1 })}>
         Increment object data
       </button>
-      <button onClick={undo} data-testid="undo">
+      <button onClick={undo}>
         Undo
       </button>
     </div>
@@ -80,7 +80,7 @@ const Demo = () => {
       <button onClick={() => setValue(current => current + 1)}>
         Increment
       </button>
-      <button onClick={undo} data-testid="undo">
+      <button onClick={undo}>
         Undo
       </button>
     </div>

--- a/packages/undo-state/index.d.ts
+++ b/packages/undo-state/index.d.ts
@@ -1,0 +1,1 @@
+export default function useUndoState():void

--- a/packages/undo-state/package.json
+++ b/packages/undo-state/package.json
@@ -1,0 +1,40 @@
+{
+  "main": "lib/index.js",
+  "jsnext:main": "lib/index.esm.js",
+  "module": "lib/index.esm.js",
+  "types": "lib/index.d.ts",
+  "license": "MIT",
+  "description": "Drop in replacement for useState hook but with undo functionality.",
+  "name": "@rooks/use-undo-state",
+  "homepage": "https://react-hooks.org/hook/use-undo-state",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/imbhargav5/rooks.git"
+  },
+  "scripts": {
+    "test": "jest",
+    "lint": "eslint src test",
+    "clean": "rimraf lib",
+    "prebuild": "yarn clean",
+    "build": "rollup -c ../../scripts/rollup.config.js",
+    "prepublish": "yarn run build",
+    "pregenerate:types": "rimraf index.d.ts",
+    "generate:types": "tsc"
+  },
+  "keywords": [
+    "use",
+    "react",
+    "hooks",
+    "rooks",
+    "react-hooks.org"
+  ],
+  "peerDependencies": {
+    "react": ">=16.8.0"
+  },
+  "version": "0.0.0",
+  "_id": "@rooks/use-undo-state@",
+  "readme": "ERROR: No README data found!",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/undo-state/src/index.d.ts
+++ b/packages/undo-state/src/index.d.ts
@@ -1,0 +1,7 @@
+interface UndoStateOptions {
+    maxSize: number | undefined
+}
+  
+export { UndoStateOptions }
+
+export default function useUndoState(defaultValue: any, { maxSize }: UndoStateOptions): [any, Function, Function]

--- a/packages/undo-state/src/index.ts
+++ b/packages/undo-state/src/index.ts
@@ -1,0 +1,1 @@
+export { default as useUndoState } from "./useUndoState";

--- a/packages/undo-state/src/index.ts
+++ b/packages/undo-state/src/index.ts
@@ -1,1 +1,3 @@
-export { default as useUndoState } from "./useUndoState";
+import useUndoState from './useUndoState'
+
+export default useUndoState

--- a/packages/undo-state/src/useUndoState.ts
+++ b/packages/undo-state/src/useUndoState.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react'
+import { UndoStateOptions } from './index.d'
+
+const defaultOptions: UndoStateOptions = { maxSize: undefined }
+
+/**
+ * Drop in replacement for useState hook but with undo functionality.
+ *
+ * @param {any} defaultValue
+ * @param {UndoStateOptions} [{ maxSize }=defaultOptions]
+ * @returns {[any, Function, Function]}
+ */
+const useUndoState = (defaultValue: any, { maxSize }: UndoStateOptions = defaultOptions): [any, (prevState: any) => any, Function] => {
+    const [value, setValue] = useState([defaultValue])
+
+    const push = useCallback(
+        (setterOrValue) => {
+            return setValue((current) => {
+                const restValues =
+                    current.length >= maxSize ? current.slice(0, maxSize) : current
+
+                if (typeof setterOrValue === "function") {
+                    return [setterOrValue(current[0]), ...restValues]
+                } else {
+                    return [setterOrValue, ...restValues]
+                }
+            })
+        },
+        [maxSize]
+    )
+
+    const undo = useCallback(() => {
+        return setValue((current) => {
+            if (current.length === 1) {
+                return current
+            }
+
+            const [, ...values] = current
+
+            return values
+        })
+    }, [])
+
+    return [value[0], push, undo]
+}
+
+export default useUndoState

--- a/packages/undo-state/test/index.spec.js
+++ b/packages/undo-state/test/index.spec.js
@@ -1,13 +1,104 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
-import useUndoState from "..";
+import React from "react"
+import useUndoState from ".."
+import { render, cleanup, fireEvent, act } from "@testing-library/react"
 
-describe("useUndoState", () => {
-  it("should be defined", () => {
-    expect(useUndoState).toBeDefined();
-  });
-});
+// eslint-disable-next-line react/prop-types
+const App = ({ defaultValue, options }) => {
+  const [value, setValue, undo] = useUndoState(defaultValue, options)
+
+  return (
+    <div>
+      <button onClick={() => setValue(current => (current || 0) + 1)} data-testid="value">
+        {value}
+      </button>
+      <button onClick={undo} data-testid="undo">
+        Undo
+      </button>
+    </div>
+  )
+}
+
+describe('useUndoState', () => {
+  afterEach(cleanup)
+
+  it('should be defined', () => {
+    expect(useUndoState).toBeDefined()
+  })
+
+  it('should honor default value', () => {
+    const { getByTestId } = render(<App defaultValue={42} />)
+    const button = getByTestId('value')
+
+    expect(button.innerHTML).toBe('42')
+  })
+
+  it('should show latest value', () => {
+    const { getByTestId } = render(<App />)
+    const button = getByTestId('value')
+
+    act(() => {
+      fireEvent.click(button)
+    })
+
+    expect(button.innerHTML).toBe('1')
+  })
+
+  it('should show previous value after undo', () => {
+    const { getByTestId } = render(<App />)
+    const button = getByTestId('value')
+    const undoButton = getByTestId('undo')
+
+    act(() => {
+      fireEvent.click(button)
+      fireEvent.click(button)
+      fireEvent.click(undoButton)
+    })
+
+    expect(button.innerHTML).toBe('1')
+  })
+
+  it('should show initial value after multiple undo', () => {
+    const { getByTestId } = render(<App defaultValue={42} />)
+    const button = getByTestId('value')
+    const undoButton = getByTestId('undo')
+
+    act(() => {
+      fireEvent.click(button)
+      fireEvent.click(button)
+      fireEvent.click(button)
+      
+      fireEvent.click(undoButton)
+      fireEvent.click(undoButton)
+      fireEvent.click(undoButton)
+      fireEvent.click(undoButton)
+      fireEvent.click(undoButton)
+    })
+
+    expect(button.innerHTML).toBe('42')
+  })
+
+  it('should respect maxSize option', () => {
+    const { getByTestId } = render(<App defaultValue={42} options={{ maxSize: 2 }} />)
+    const button = getByTestId('value')
+    const undoButton = getByTestId('undo')
+
+    act(() => {
+      fireEvent.click(button)
+      fireEvent.click(button)
+      fireEvent.click(button)
+      fireEvent.click(button)
+      
+      fireEvent.click(undoButton)
+      fireEvent.click(undoButton)
+      fireEvent.click(undoButton)
+      fireEvent.click(undoButton)
+    })
+
+    expect(button.innerHTML).toBe('44')
+  })
+})
 
 // figure out tests

--- a/packages/undo-state/test/index.spec.js
+++ b/packages/undo-state/test/index.spec.js
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import useUndoState from "..";
+
+describe("useUndoState", () => {
+  it("should be defined", () => {
+    expect(useUndoState).toBeDefined();
+  });
+});
+
+// figure out tests


### PR DESCRIPTION
## useUndoState hook

Drop in replacement for useState hook but with undo functionality.

Only difference is that hook returns third undo function parameter that when called undo's the last step.

Also for memory optimization the hook accepts `options.maxSize` argument that limits how many steps are preserved in history.

```jsx
const Demo = () => {
  const [value, setValue, undo] = useUndoState(0)

  return (
    <div>
      <span>Current value: {value}</span>
      <button onClick={() => setValue(value + 1)}>
        Increment
      </button>
      <button onClick={undo}>
        Undo
      </button>
    </div>
  )
}

render(<Demo/>)
```

You can pass any kind of value to hook just like React's own useState.

```jsx
const Demo = () => {
  const [value, setValue, undo] = useUndoState({ data: 42 })

  return (
    <div>
      <span>Current value: {value}</span>
      <button onClick={() => setValue({ data: value.data + 1 })}>
        Increment object data
      </button>
      <button onClick={undo}>
        Undo
      </button>
    </div>
  )
}

render(<Demo/>)
```

Setter function can also be used with callback just like React's own useState.

```javascript
const [value, setValue, undo] = useUndoState({ data: 42 })

() => setValue(current => current + 1)
```

```jsx
const Demo = () => {
  const [value, setValue, undo] = useUndoState(0)

  return (
    <div>
      <span>Current value: {value}</span>
      <button onClick={() => setValue(current => current + 1)}>
        Increment
      </button>
      <button onClick={undo}>
        Undo
      </button>
    </div>
  )
}

render(<Demo/>)
```

To preserve memory you can limit number of steps that will be preserved in undo history.

```javascript
const [value, setValue, undo] = useUndoState(0, { maxSize: 30 })

// now when calling undo only last 30 changes to the value will be preserved
```