### PR TITLE
typo

### DIFF
--- a/packages/shared/useInput.ts
+++ b/packages/shared/useInput.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, ChangeEvent } from "react";
 
-type InputChangeEvent = React.ChangeEvent<HTMLInputElement>;
+type InputChangeEvent = ChangeEvent<HTMLInputElement>;
 
 interface InputHandler {
   /**


### PR DESCRIPTION
Since we have already import `ChangeEvent`, `React.ChangeEvent` is become redundant.