### PR TITLE
Ensure visibility check doesn't throw warnings on SSR

### DIFF
--- a/packages/shared/useVisibilitySensor.ts
+++ b/packages/shared/useVisibilitySensor.ts
@@ -3,6 +3,7 @@
 // And is rewritten for hooks api
 
 import { useEffect, useReducer, useLayoutEffect } from "react";
+import { useIsomorphicEffect } from "./useIsomorphicEffect";
 
 function normalizeRect(rect) {
   if (rect.width === undefined) {
@@ -201,7 +202,7 @@ function useVisibilitySensor(ref, opts) {
   }
 
   // If scroll check is needed
-  useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (scrollCheck) {
       return createListener("scroll", scrollDebounce, scrollThrottle);
     }
@@ -209,7 +210,7 @@ function useVisibilitySensor(ref, opts) {
 
   // if resize check is needed
 
-  useLayoutEffect(() => {
+  useIsomorphicEffect(() => {
     if (resizeCheck) {
       return createListener("resize", resizeDebounce, resizeThrottle);
     }


### PR DESCRIPTION
Use the existing isomorphic hook to prevent warnings