### PR TITLE
Restart timeout on interval value change

### DIFF
--- a/packages/shared/useTimeout.ts
+++ b/packages/shared/useTimeout.ts
@@ -42,7 +42,7 @@ function useTimeout(
         window.clearTimeout(timeout);
       };
     }
-  }, [isTimeoutActive]);
+  }, [isTimeoutActive, timeoutDelayMs]);
   return {
     clear,
     start,


### PR DESCRIPTION
Currently, `useTimeout` does not react on `timeoutDelayMs` param change.

Example code:

```tsx
function MyComponent() {
    const [interval, setInteval] = useState(0);
    const { start, clear } = useTimeout(() => doSomething(), interval);
    
    return (
      ...
        <input onChage={e => setInterval(e.target.value)} />
      ...
    );
}
```

New `interval` value won't be used until current timeout is finished and new one manually started