### PR TITLE
fix touch bug, update types, and add tests for useOutsideClick

### DIFF
--- a/src/__tests__/useOutsideClick.spec.tsx
+++ b/src/__tests__/useOutsideClick.spec.tsx
@@ -29,13 +29,6 @@ const App = ({ condition }: { condition?: boolean }) => {
   );
 };
 
-const touchByTestId = (testId: string) => {
-  const target = screen.getByTestId(testId);
-  act(() => {
-    fireEvent.touchStart(target);
-  });
-};
-
 /*
  * This just runs each test using a touch event and a click event,
  * replacing "click" in the name with "touch"
@@ -50,6 +43,13 @@ const itClickAndTouch = (
       fireEvent.click(target);
     });
   };
+  const touchByTestId = (testId: string) => {
+    const target = screen.getByTestId(testId);
+    act(() => {
+      fireEvent.touchStart(target);
+    });
+  };
+
   it(name, () => {
     fn(clickByTestId);
   });

--- a/src/__tests__/useOutsideClick.spec.tsx
+++ b/src/__tests__/useOutsideClick.spec.tsx
@@ -1,0 +1,100 @@
+import {
+  render,
+  cleanup,
+  fireEvent,
+  act,
+  screen,
+} from '@testing-library/react';
+import React, { useRef } from 'react';
+import { useOutsideClick } from '../hooks/useOutsideClick';
+
+const cb = jest.fn();
+
+// condition does not have default value so we can test default of hook
+const App = ({ condition }: { condition?: boolean }) => {
+  const containerRef = useRef(null);
+  useOutsideClick(containerRef, cb, condition);
+
+  return (
+    <div data-testid="app">
+      <div data-testid="parent">
+        Clicking here fires event.
+        <div ref={containerRef} data-testid="container">
+          Clicking here does nothing.
+          <div data-testid="child">Clicking here also does nothing.</div>
+        </div>
+        <div data-testid="outside">Clicking here fires event.</div>
+      </div>
+    </div>
+  );
+};
+
+const clickByTestId = (testId: string) => {
+  const target = screen.getByTestId(testId);
+  act(() => {
+    fireEvent.click(target);
+  });
+};
+
+describe('useOutsideClick', () => {
+  afterEach(() => {
+    cleanup();
+    jest.resetAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(useOutsideClick).toBeDefined();
+  });
+
+  it('should not fire event when clicking inside container', () => {
+    render(<App />);
+    clickByTestId('container');
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('should not fire event when clicking child inside container', () => {
+    render(<App />);
+    clickByTestId('child');
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('should fire event when clicking parent of container', () => {
+    render(<App />);
+    clickByTestId('parent');
+    expect(cb).toHaveBeenCalledTimes(1);
+    clickByTestId('child');
+    clickByTestId('container');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fire event when clicking sibling of container', () => {
+    render(<App />);
+    clickByTestId('outside');
+    expect(cb).toHaveBeenCalledTimes(1);
+    clickByTestId('child');
+    clickByTestId('container');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not fire event if condition disabled', () => {
+    render(<App condition={false} />);
+    ['parent', 'child', 'outside', 'container'].forEach((id) =>
+      clickByTestId(id)
+    );
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('should change whether firing when updating `when`', () => {
+    const { rerender } = render(<App condition={false} />);
+    clickByTestId('container');
+    clickByTestId('parent');
+    expect(cb).toHaveBeenCalledTimes(0);
+    rerender(<App condition={true} />);
+    clickByTestId('container');
+    clickByTestId('parent');
+    expect(cb).toHaveBeenCalledTimes(1);
+    rerender(<App condition={false} />);
+    clickByTestId('container');
+    clickByTestId('parent');
+  });
+});

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -9,9 +9,9 @@ import { useEffect, useRef, useCallback } from 'react';
  * @param handler Callback to fire on outside click
  * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
  */
-function useOutsideClick(
-  ref: MutableRefObject<HTMLElement>,
-  handler: (e: MouseEvent) => any,
+function useOutsideClick<T extends HTMLElement = HTMLElement>(
+  ref: MutableRefObject<T | null>, // initially html element refs will be null
+  handler: (e: MouseEvent | TouchEvent) => any, // click | ontouchstart
   when: boolean = true
 ): void {
   const savedHandler = useRef(handler);

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -29,11 +29,11 @@ function useOutsideClick<T extends HTMLElement = HTMLElement>(
   useEffect(() => {
     if (when) {
       document.addEventListener('click', memoizedCallback);
-      document.addEventListener('ontouchstart', memoizedCallback);
+      document.addEventListener('touchstart', memoizedCallback);
 
       return () => {
         document.removeEventListener('click', memoizedCallback);
-        document.removeEventListener('ontouchstart', memoizedCallback);
+        document.removeEventListener('touchstart', memoizedCallback);
       };
     }
   }, [ref, handler, when]);

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -11,12 +11,12 @@ import { useEffect, useRef, useCallback } from 'react';
  */
 function useOutsideClick<T extends HTMLElement = HTMLElement>(
   ref: MutableRefObject<T | null>, // initially html element refs will be null
-  handler: (e: MouseEvent | TouchEvent) => any, // click | ontouchstart
+  handler: (e: MouseEvent) => any,
   when: boolean = true
 ): void {
   const savedHandler = useRef(handler);
 
-  const memoizedCallback = useCallback((e: MouseEvent) => {
+  const memoizedCallback = useCallback((e: MouseEvent | TouchEvent) => {
     if (ref && ref.current && !ref.current.contains(e.target as Element)) {
       savedHandler.current(e);
     }


### PR DESCRIPTION
- Adds tests for useOutsideClick (100% file test coverage)
- Adds optional generic parameter for the ref type
- Fixes the handler event type to include touch events
- Adds tests that include both touch and click events. Initially the touch tests were failing so this also:
- Fixes bug with `ontouchstart` being specified where `touchstart` was expected (for some reason typescript doesn't call this out but when the hook is copied into my own application it did -- I wonder if the tsconfig for this app needs updated?)