### PR TITLE
chore(useMapState): Fix typo in tests

### DIFF
--- a/src/__tests__/useMapState.spec.tsx
+++ b/src/__tests__/useMapState.spec.tsx
@@ -107,7 +107,7 @@ describe("useMapState", () => {
     });
     expect(result.current[0]).toEqual({ b: 3 });
   });
-  it("should work when value to remove doesnot exist", () => {
+  it("should work when value to remove does not exist", () => {
     const { result } = renderHook(() => useMapState({ a: 1, b: 2, c: 3 }));
     act(() => {
       result.current[1].remove("d");
@@ -136,14 +136,14 @@ describe("useMapState", () => {
     });
     expect(result.current[0]).toEqual({ b: 3, e: 6 });
   });
-  it("should work when value to removeMultiple doesnot exist", () => {
+  it("should work when value to removeMultiple does not exist", () => {
     const { result } = renderHook(() => useMapState({ a: 1, b: 2, c: 3 }));
     act(() => {
       result.current[1].removeMultiple("d", "e");
     });
     expect(result.current[0]).toEqual({ a: 1, b: 2, c: 3 });
   });
-  it("should work when some values to removeMultiple doesnot exist", () => {
+  it("should work when some values to removeMultiple does not exist", () => {
     const { result } = renderHook(() => useMapState({ a: 1, b: 2, c: 3 }));
     act(() => {
       result.current[1].removeMultiple("a", "e");


### PR DESCRIPTION
Changed `doesnot` to `does not`. Idk if this is a `fix` or a `chore` because it doesn't change actual code, just tests.