### PR TITLE
fix(useOutsideClickRef): fix child update logic and event listener phase

### DIFF
--- a/src/__tests__/useOutsideClick.spec.tsx
+++ b/src/__tests__/useOutsideClick.spec.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  render,
+  cleanup,
+  fireEvent,
+  act,
+  getByTestId,
+} from "@testing-library/react";
+import React, { useRef, useState } from "react";
+import { useOutsideClick } from "../hooks/useOutsideClick";
+
+const VolumeOn = () => (
+  <svg
+    fill="none"
+    stroke="currentColor"
+    width="60"
+    height="60"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"
+    ></path>
+  </svg>
+);
+
+const VolumeOff = () => (
+  <svg
+    fill="none"
+    width="60"
+    height="60"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"
+      clipRule="evenodd"
+    ></path>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"
+    ></path>
+  </svg>
+);
+
+const Button = () => {
+  const [clicked, setClicked] = useState(false);
+
+  return (
+    <div onClick={() => setClicked(!clicked)} data-testid="button">
+      {clicked ? <VolumeOn /> : <VolumeOff />}
+    </div>
+  );
+};
+
+describe("useOutsideClick", () => {
+  let App;
+  beforeEach(() => {
+    App = () => {
+      const [message, setMessage] = useState("");
+      const ref = useRef(null);
+      useOutsideClick(ref, callback);
+      function callback() {
+        setMessage("clicked outside");
+      }
+      return (
+        <div
+          className="App"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+          data-testid="app"
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              width: "100%",
+              backgroundColor: "lightblue",
+            }}
+          >
+            <div
+              className="inside"
+              style={{ backgroundColor: "lightgreen" }}
+              ref={ref}
+            >
+              <h2>This is inside</h2>
+              <Button />
+            </div>
+          </div>
+
+          <div data-testid="message">{message}</div>
+        </div>
+      );
+    };
+  });
+
+  afterEach(cleanup);
+
+  it("should be defined", () => {
+    expect(useOutsideClick).toBeDefined();
+  });
+
+  it("should trigger the calback when click on outide", () => {
+    const { container } = render(<App />);
+    const app = getByTestId(container as HTMLElement, "app");
+    const message = getByTestId(container as HTMLElement, "message");
+    act(() => {
+      fireEvent.click(app);
+    });
+    expect(message.innerHTML).toBe("clicked outside");
+  });
+
+  it("should not trigger the calback when click the volumn button (inside)", () => {
+    const { container } = render(<App />);
+    const button = getByTestId(container as HTMLElement, "button");
+    const message = getByTestId(container as HTMLElement, "message");
+
+    act(() => {
+      fireEvent.click(button);
+    });
+    expect(message.innerHTML).toBe("");
+  });
+});

--- a/src/__tests__/useOutsideClickRef.spec.tsx
+++ b/src/__tests__/useOutsideClickRef.spec.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  render,
+  cleanup,
+  fireEvent,
+  act,
+  getByTestId,
+} from "@testing-library/react";
+import React, { useState } from "react";
+import { useOutsideClickRef } from "../hooks/useOutsideClickRef";
+
+const VolumeOn = () => (
+  <svg
+    fill="none"
+    stroke="currentColor"
+    width="60"
+    height="60"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"
+    ></path>
+  </svg>
+);
+
+const VolumeOff = () => (
+  <svg
+    fill="none"
+    width="60"
+    height="60"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"
+      clipRule="evenodd"
+    ></path>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"
+    ></path>
+  </svg>
+);
+
+const Button = () => {
+  const [clicked, setClicked] = useState(false);
+
+  return (
+    <div onClick={() => setClicked(!clicked)} data-testid="button">
+      {clicked ? <VolumeOn /> : <VolumeOff />}
+    </div>
+  );
+};
+
+describe("useOutsideClickRef", () => {
+  let App;
+  beforeEach(() => {
+    App = () => {
+      const [message, setMessage] = useState("");
+      const [ref] = useOutsideClickRef(callback);
+      function callback() {
+        setMessage("clicked outside");
+      }
+      return (
+        <div
+          className="App"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+          data-testid="app"
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              width: "100%",
+              backgroundColor: "lightblue",
+            }}
+          >
+            <div
+              className="inside"
+              style={{ backgroundColor: "lightgreen" }}
+              ref={ref}
+            >
+              <h2>This is inside</h2>
+              <Button />
+            </div>
+          </div>
+
+          <div data-testid="message">{message}</div>
+        </div>
+      );
+    };
+  });
+
+  afterEach(cleanup);
+
+  it("should be defined", () => {
+    expect(useOutsideClickRef).toBeDefined();
+  });
+
+  it("should trigger the calback when click on outide", () => {
+    const { container } = render(<App />);
+    const app = getByTestId(container as HTMLElement, "app");
+    const message = getByTestId(container as HTMLElement, "message");
+    act(() => {
+      fireEvent.click(app);
+    });
+    expect(message.innerHTML).toBe("clicked outside");
+  });
+
+  it("should not trigger the calback when click the volumn button (inside)", () => {
+    const { container } = render(<App />);
+    const button = getByTestId(container as HTMLElement, "button");
+    const message = getByTestId(container as HTMLElement, "message");
+
+    act(() => {
+      fireEvent.click(button);
+    });
+    expect(message.innerHTML).toBe("");
+  });
+});

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,5 +1,5 @@
-import type { MutableRefObject } from 'react';
-import { useEffect, useRef, useCallback } from 'react';
+import type { MutableRefObject } from "react";
+import { useEffect, useRef, useCallback } from "react";
 
 /**
  *  useOutsideClick hook
@@ -10,7 +10,7 @@ import { useEffect, useRef, useCallback } from 'react';
  * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
  */
 function useOutsideClick(
-  ref: MutableRefObject<HTMLElement>,
+  ref: MutableRefObject<HTMLElement | null>,
   handler: (e: MouseEvent) => any,
   when: boolean = true
 ): void {
@@ -28,12 +28,12 @@ function useOutsideClick(
 
   useEffect(() => {
     if (when) {
-      document.addEventListener('click', memoizedCallback);
-      document.addEventListener('ontouchstart', memoizedCallback);
+      document.addEventListener("click", memoizedCallback, true);
+      document.addEventListener("ontouchstart", memoizedCallback, true);
 
       return () => {
-        document.removeEventListener('click', memoizedCallback);
-        document.removeEventListener('ontouchstart', memoizedCallback);
+        document.removeEventListener("click", memoizedCallback, true);
+        document.removeEventListener("ontouchstart", memoizedCallback, true);
       };
     }
   }, [ref, handler, when]);

--- a/src/hooks/useOutsideClickRef.ts
+++ b/src/hooks/useOutsideClickRef.ts
@@ -4,8 +4,8 @@ import {
   useRef,
   useCallback,
   useState,
-} from 'react';
-import type { HTMLElementOrNull, CallbackRef } from '../utils/utils';
+} from "react";
+import type { HTMLElementOrNull, CallbackRef } from "../utils/utils";
 
 /**
  * useOutsideClickRef hook
@@ -25,9 +25,10 @@ function useOutsideClickRef(
 
   const memoizedCallback = useCallback(
     (e: MouseEvent) => {
-      if (node && !node.contains(e.target as Element)) {
-        savedHandler.current(e);
+      if (!node || node.contains(e.target as Element)) {
+        return;
       }
+      savedHandler.current(e);
     },
     [node]
   );
@@ -42,12 +43,12 @@ function useOutsideClickRef(
 
   useEffect(() => {
     if (when) {
-      document.addEventListener('click', memoizedCallback);
-      document.addEventListener('ontouchstart', memoizedCallback);
+      document.addEventListener("click", memoizedCallback, true);
+      document.addEventListener("ontouchstart", memoizedCallback, true);
 
       return () => {
-        document.removeEventListener('click', memoizedCallback);
-        document.removeEventListener('ontouchstart', memoizedCallback);
+        document.removeEventListener("click", memoizedCallback, true);
+        document.removeEventListener("ontouchstart", memoizedCallback, true);
       };
     }
   }, [when, memoizedCallback]);

--- a/src/hooks/useOutsideClickRef.ts
+++ b/src/hooks/useOutsideClickRef.ts
@@ -25,10 +25,9 @@ function useOutsideClickRef(
 
   const memoizedCallback = useCallback(
     (e: MouseEvent) => {
-      if (!node || node.contains(e.target as Element)) {
-        return;
+      if (node && !node.contains(e.target as Element)) {
+        savedHandler.current(e);
       }
-      savedHandler.current(e);
     },
     [node]
   );


### PR DESCRIPTION
issue #530 

The main cause is that the callback is called in event bubbling phase which happens after the click event for icon change