### PR TITLE
docs: fix missing sidebar when click on docmentation

### DIFF
--- a/docs/rooks.md
+++ b/docs/rooks.md
@@ -5,86 +5,12 @@ sidebar_label: rooks
 slug: /
 ---
 
-<br/>
-<br/>
+
 <img src="https://github.com/imbhargav5/rooks/raw/master/.github/assets/logo-dark.png" height="auto" width="100%" />
 
 <br/>
-<br/>
-
-<br/>
-
-## [Complete Documentation](https://react-hooks.org/)
 
 [![Image from Gyazo](https://i.gyazo.com/742dc22ec370af0a96322427b6a32a9b.gif)](https://gyazo.com/742dc22ec370af0a96322427b6a32a9b)
-
-## List of all hooks
-
-<!--hookslist start-->
-
-- [useBoundingclientrectRef](https://react-hooks.org/docs/useBoundingclientrectRef) - A hook that tracks the boundingclientrect of an element. It returns a callbackRef so that the element node if changed is easily tracked.
-- [useBoundingclientrect](https://react-hooks.org/docs/useBoundingclientrect) - A React Hooks package for boundingclientrect
-- [useCountdown](https://react-hooks.org/docs/useCountdown) - Count down to a target timestamp and call callbacks every second (or provided peried)
-- [useCounter](https://react-hooks.org/docs/useCounter) - A React Hooks package for counter
-- [useDebounce](https://react-hooks.org/docs/useDebounce) - Debounce hook for react
-- [useDidMount](https://react-hooks.org/docs/useDidMount) - A React hooks package for componentDidMount
-- [useDidUpdate](https://react-hooks.org/docs/useDidUpdate) - componentDidUpdate hook for react
-- [useDocumentEventListener](https://react-hooks.org/docs/useDocumentEventListener) - A react hook to an event listener to the document object
-- [useEffectOnceWhen](https://react-hooks.org/docs/useEffectOnceWhen) - Runs a callback effect atmost one time when a condition becomes true
-- [useEventListenerRef](https://react-hooks.org/docs/useEventListenerRef) - A react hook to add an event listener to a ref
-- [useForkRef](https://react-hooks.org/docs/useForkRef) - A hook that can combine two refs(mutable or callbackRefs) into a single callbackRef
-- [useFreshRef](https://react-hooks.org/docs/useFreshRef) - Avoid stale state in callbacks with this hook. Auto updates values using a ref.
-- [useFreshTick](https://react-hooks.org/docs/useFreshTick) - Like useFreshRef but specifically for functions
-- [useFullscreen](https://react-hooks.org/docs/useFullscreen) - A React Hooks package for fullscreen.
-- [useInViewRef](https://react-hooks.org/docs/useInViewRef) - Simple hook that monitors element enters or leave the viewport.
-- [useGeolocation](https://react-hooks.org/docs/useGeolocation) - A hook to provide the geolocation info on client side.
-- [useInput](https://react-hooks.org/docs/useInput) - A React Hooks package for input
-- [useIntersectionObserverRef](https://react-hooks.org/docs/useIntersectionObserverRef) - A hook to register an intersection observer listener
-- [useIntervalWhen](https://react-hooks.org/docs/useIntervalWhen) - Sets an interval immediately when a condition is true
-- [useInterval](https://react-hooks.org/docs/useInterval) - A react hook for using setInterval
-- [useIsomorphicEffect](https://react-hooks.org/docs/useIsomorphicEffect) - Resolves to useEffect when window is not in scope and useLayout effect in the browser
-- [useKeyRef](https://react-hooks.org/docs/useKeyRef) - Very similar to useKey but it returns a ref
-- [useKey](https://react-hooks.org/docs/useKey) - Keyboard key handler hook for react
-- [useKeys](https://react-hooks.org/docs/useKeys) - A hook which allows to setup callbacks on multiple keypresses at the same time
-- [useLocalstorageState](https://react-hooks.org/docs/useLocalstorageState) - UseState but auto updates values to localStorage
-- [useLocalstorage](https://react-hooks.org/docs/useLocalstorage) - Local Storage hook for React
-- [useMapState](https://react-hooks.org/docs/useMapState) - A react hook to manage state in a key value pair map.
-- [useMergeRefs](https://react-hooks.org/docs/useMergeRefs) - Merges any number of refs into a single ref
-- [useMouse](https://react-hooks.org/docs/useMouse) - A React Hooks package for mouse
-- [useMultiSelectableList](https://react-hooks.org/docs/useMultiSelectableList) - A custom hook to easily select multiple values from a list
-- [useMutationObserverRef](https://react-hooks.org/docs/useMutationObserverRef) - A hook that tracks mutations of an element. It returns a callbackRef.
-- [useMutationObserver](https://react-hooks.org/docs/useMutationObserver) - A React Hooks package for mutation-observer
-- [useNavigatorLanguage](https://react-hooks.org/docs/useNavigatorLanguage) - A React Hooks package for navigator-language
-- [useOnWindowResize](https://react-hooks.org/docs/useOnWindowResize) - A React hook for window on resize event
-- [useOnWindowScroll](https://react-hooks.org/docs/useOnWindowScroll) - A React hook for window on scroll event
-- [useOnline](https://react-hooks.org/docs/useOnline) - A React Hooks package for online
-- [useOutsideClickRef](https://react-hooks.org/docs/useOutsideClickRef) - A hook that can track a click event outside a ref. Returns a callbackRef.
-- [useOutsideClick](https://react-hooks.org/docs/useOutsideClick) - React hook for tracking clicks outside a ref
-- [usePreviousDifferent](https://react-hooks.org/docs/usePreviousDifferent) - usePreviousDifferent hooks returns the last different value of a variable
-- [usePreviousImmediate](https://react-hooks.org/docs/usePreviousImmediate) - usePreviousImmediate returns the previous value of a variable even if it was the same or different
-- [usePrevious](https://react-hooks.org/docs/usePrevious) - Access the previous value of a variable with this React hook
-- [useQueueState](https://react-hooks.org/docs/useQueueState) - A React hook that manages state in the form of a queue
-- [useRaf](https://react-hooks.org/docs/useRaf) - A continuously running requestAnimationFrame hook for React
-- [useSelect](https://react-hooks.org/docs/useSelect) - A React Hooks package for select
-- [useSelectableList](https://react-hooks.org/docs/useSelectableList) - Easily select a single value from a list of values. very useful for radio buttons, select inputs etc.
-- [useSessionstorageState](https://react-hooks.org/docs/useSessionstorageState) - useState but syncs with sessionstorage
-- [useSessionstorage](https://react-hooks.org/docs/useSessionstorage) - Session storage react hook. Easily manage session storage values
-- [useStackState](https://react-hooks.org/docs/useStackState) - A React hook that manages state in the form of a stack
-- [useThrottle](https://react-hooks.org/docs/useThrottle) - A throttle hook for react
-- [useTimeAgo](https://react-hooks.org/docs/useTimeAgo) - A React Hook to get time ago for timestamp millisecond value
-- [useTimeoutWhen](https://react-hooks.org/docs/useTimeoutWhen) - Takes a callback and fires it when a condition is true
-- [useTimeout](https://react-hooks.org/docs/useTimeout) - A React Hooks package for timeout
-- [useToggle](https://react-hooks.org/docs/useToggle) - A React Hooks package for toggle
-- [useUndoState](https://react-hooks.org/docs/useUndoState) - Drop in replacement for useState hook but with undo functionality.
-- [useUpdateEffect](https://react-hooks.org/docs/useUpdateEffect) - An useEffect that does not run on first render
-- [useVisibilitySensor](https://react-hooks.org/docs/useVisibilitySensor) - A React Hooks package for visibility-sensor
-- [useWillUnmount](https://react-hooks.org/docs/useWillUnmount) - A React hook for componentWillUnmount lifecycle method
-- [useWindowEventListener](https://react-hooks.org/docs/useWindowEventListener) - Adds an event listener to window
-- [useWindowScrollPosition](https://react-hooks.org/docs/useWindowScrollPosition) - A React hook to get the scroll position of the window
-- [useWindowSize](https://react-hooks.org/docs/useWindowSize) - A React Hooks package for window-size
-- [useWorker](https://react-hooks.org/docs/useWorker) - A React Hooks package for worker
-
-<!--hookslist end-->
 
 ## About
 

--- a/sidebars.json
+++ b/sidebars.json
@@ -3,10 +3,7 @@
     {
       "label": "Quick Start",
       "collapsed": false,
-      "items": [
-        "getting-started",
-        "motivation"
-      ],
+      "items": ["getting-started", "motivation", "rooks"],
       "type": "category"
     },
     {


### PR DESCRIPTION
#545

The cause is that we removed 'rooks' page from sidebar, it corresponds to '/docs' route. Clicking on 'Documentation' brings use to '/docs', so i added it back to sidebar to fis it.

If we don't want rooks page at all. We need to change some other page to be '/docs'