### PR TITLE
Add eager possibility for useIntervalWhen

### DIFF
--- a/docs/useIntervalWhen.md
+++ b/docs/useIntervalWhen.md
@@ -23,17 +23,42 @@ import { useIntervalWhen } from 'rooks';
 ## Usage
 
 ```jsx
-function Demo() {
-  useIntervalWhen(() => {
-    console.log('runs every 2 seconds');
-  }, 2000);
-  return null;
-}
+function App() {
+  const [value, setValue] = useState(0);
+  const [booleanState, setBooleanState] = useState(true);
 
-render(<Demo />);
+  useIntervalWhen(
+    () => {
+      setValue(value + 10); 
+    },
+    1000,         // run callback every 1 second
+    booleanState, // start the timer when it's true
+    true          // no need to wait for the first interval
+  );
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+    >
+      <h1>Rooks: useIntervalWhen example</h1>
+      <h2>Value: {value}</h2>
+    </div>
+  );
+}
 ```
 
----
+### Arguments
+
+| Argument         | Type     | Description                                              | Default value |
+| ---------------- | -------- | -------------------------------------------------------- | ------------- |
+| callback         | function | Function be invoked after each interval duration         | undefined     |
+| intervalDuration | number   | Duration in milliseconds after which callback is invoked | 0             |
+| when             | boolean  | Only start timer when `when` is true                     | true          |
+| startImmediate   | boolean  | Should the timer start immediately or no                 | false         |
+
+### Returned Object
+
+No return value.
 
 ## Codesandbox Examples
 

--- a/src/__tests__/useIntervalWhen.spec.tsx
+++ b/src/__tests__/useIntervalWhen.spec.tsx
@@ -1,25 +1,31 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook, cleanup } from '@testing-library/react-hooks';
-import { useState } from 'react';
-import TestRenderer from 'react-test-renderer';
-import { useIntervalWhen } from '../hooks/useIntervalWhen';
+import { renderHook, cleanup } from "@testing-library/react-hooks";
+import { useState } from "react";
+import TestRenderer from "react-test-renderer";
+import { useIntervalWhen } from "../hooks/useIntervalWhen";
 
 const { act } = TestRenderer;
 
-describe('useIntervalWhen', () => {
+describe("useIntervalWhen", () => {
   let useHook;
+  const EAGER = true;
 
   beforeEach(() => {
-    useHook = function () {
+    useHook = function (when, eager = false) {
       const [currentValue, setCurrentValue] = useState(0);
       function increment() {
         setCurrentValue(currentValue + 1);
       }
-      useIntervalWhen(() => {
-        increment();
-      }, 1_000);
+      useIntervalWhen(
+        () => {
+          increment();
+        },
+        1_000,
+        when,
+        eager
+      );
 
       return { currentValue };
     };
@@ -30,12 +36,12 @@ describe('useIntervalWhen', () => {
     jest.clearAllTimers();
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(useIntervalWhen).toBeDefined();
   });
-  it('should start timer when started with start function', () => {
+  it("should start timer when started with start function", () => {
     jest.useFakeTimers();
-    const { result } = renderHook(() => useHook());
+    const { result } = renderHook(() => useHook(true));
     act(() => {
       jest.advanceTimersByTime(1_000);
     });
@@ -44,14 +50,17 @@ describe('useIntervalWhen', () => {
     jest.useRealTimers();
   });
 
-  it('should start timer when started with start function in array destructuring', () => {
+  it("should call the callback eagerly", () => {
     jest.useFakeTimers();
-    const { result } = renderHook(() => useHook());
+    const { result } = renderHook(() => useHook(true, EAGER));
+    // The value was already incremented because we use useIntervalWhen in EAGER mode
+    expect(result.current.currentValue).toBe(1);
     act(() => {
       jest.advanceTimersByTime(1_000);
     });
     expect(setInterval).toHaveBeenCalledTimes(1);
-    expect(result.current.currentValue).toBe(1);
+    // The value was incremented twice: one time by the setInterval and one time due to the EAGER
+    expect(result.current.currentValue).toBe(2);
     jest.useRealTimers();
   });
 });

--- a/src/hooks/useIntervalWhen.ts
+++ b/src/hooks/useIntervalWhen.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect } from "react";
 
 /**
  * A setInterval hook that calls a callback after a interval duration
@@ -7,11 +7,13 @@ import { useRef, useEffect } from 'react';
  * @param cb The callback to be invoked after interval
  * @param intervalDurationMs Amount of time in ms after which to invoke
  * @param when The condition which when true, sets the interval
+ * @param eager If the callback should be invoked eagerly
  */
 function useIntervalWhen(
   callback_: () => void,
   intervalDurationMs: number = 0,
-  when: boolean = true
+  when: boolean = true,
+  eager: boolean = false
 ): void {
   const savedRefCallback = useRef<() => any>();
 
@@ -25,6 +27,9 @@ function useIntervalWhen(
 
   useEffect(() => {
     if (when) {
+      if (eager) {
+        callback();
+      }
       const interval = window.setInterval(callback, intervalDurationMs);
 
       return () => {

--- a/src/hooks/useIntervalWhen.ts
+++ b/src/hooks/useIntervalWhen.ts
@@ -7,13 +7,13 @@ import { useRef, useEffect } from "react";
  * @param cb The callback to be invoked after interval
  * @param intervalDurationMs Amount of time in ms after which to invoke
  * @param when The condition which when true, sets the interval
- * @param eager If the callback should be invoked eagerly
+ * @param startImmediate If the callback should be invoked immediately
  */
 function useIntervalWhen(
   callback_: () => void,
   intervalDurationMs: number = 0,
   when: boolean = true,
-  eager: boolean = false
+  startImmediate: boolean = false
 ): void {
   const savedRefCallback = useRef<() => any>();
 
@@ -27,7 +27,7 @@ function useIntervalWhen(
 
   useEffect(() => {
     if (when) {
-      if (eager) {
+      if (startImmediate) {
         callback();
       }
       const interval = window.setInterval(callback, intervalDurationMs);


### PR DESCRIPTION
When using useIntervalWhen there is no possibility to say: invoke the callback right before the interval elapses.
If you use useIntervalWhen for polling a service from the backend this is a very common scenario. 