### PR TITLE
chore(docs): fix typo of the GitHub name

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,7 +92,7 @@ module.exports = {
         },
         {
           href: "https://github.com/imbhargav5/rooks",
-          label: "Github",
+          label: "GitHub",
           position: "right",
         },
         {
@@ -163,7 +163,7 @@ module.exports = {
           title: "More",
           items: [
             {
-              label: "Github",
+              label: "GitHub",
               to: "https://github.com/imbhargav5/rooks",
             },
             //           {


### PR DESCRIPTION
It's is a small improvement of GitHub's name. 
The right way to write the GitHub name is using the "H" character in uppercase.

https://github.com/logos

ps: I hope my contribution can help you. 
Awesome project, congrats! =D