### PR TITLE
fix(usegeolocation): rewrites geolocation internals

### DIFF
--- a/docs/useGeolocation.md
+++ b/docs/useGeolocation.md
@@ -24,7 +24,7 @@ import { useGeolocation } from "rooks";
 
 ```jsx
 function App() {
-  const geoObj = useGeolocation();
+  const [geoObj, geoErr] = useGeolocation();
 
   return (
     <div
@@ -47,7 +47,7 @@ render(<App />);
 function App() {
   const [when, setWhen] = React.useState(false);
 
-  const geoObj = useGeolocation({
+  const [geoObj, geoErr] = useGeolocation({
     when,
   });
 
@@ -72,6 +72,19 @@ function App() {
 }
 render(<App />);
 ```
+
+### Arguments
+
+| Argument           | Type                  | Description           | Default value                                                                               |
+|--------------------|-----------------------|-----------------------|---------------------------------------------------------------------------------------------|
+| geoLocationOptions | UseGeolocationOptions | options for this hook | { enableHighAccuracy: false, maximumAge: 0, timeout: Number.POSITIVE_INFINITY, when: true } |
+                                                                          
+### Returns an array of 2 values
+
+| Return value   | Type                | Description            | Default value |
+|----------------|---------------------|------------------------|---------------|
+| geoObject      | GeolocationPosition | Get geolocation result | null          |
+| geoObjectError | Error               | Get geolocation error  | null          |
 
 ## Codesandbox Example
 

--- a/src/__tests__/useGeolocation.spec.tsx
+++ b/src/__tests__/useGeolocation.spec.tsx
@@ -1,108 +1,108 @@
 /**
  * @jest-environment jsdom
  */
-import { useGeolocation } from '../hooks/useGeolocation';
+import React from "react";
+import {
+  render,
+  getByTestId,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import { cleanup } from "@testing-library/react-hooks";
+import { useGeolocation } from "../hooks/useGeolocation";
 
-// describe("useGeolocation", () => {
-//   let App;
-//   beforeEach(() => {
-//     const mockGeolocation = {
-//       getCurrentPosition: jest.fn()
-//         .mockImplementationOnce((success) => Promise.resolve(success({
-//           coords: {
-//             latitude: 51.1,
-//             longitude: 45.3
-//           }
-//         })))
-//     };
+describe("useGeolocation", () => {
+  let App;
+  beforeEach(() => {
+    const mockGeolocation = {
+      getCurrentPosition: jest.fn().mockImplementationOnce((success) =>
+        Promise.resolve(
+          success({
+            coords: {
+              latitude: 51.1,
+              longitude: 45.3,
+            },
+          })
+        )
+      ),
+    };
 
-//     global.navigator.geolocation = mockGeolocation;
+    // @ts-ignore
+    global.navigator.geolocation = mockGeolocation;
 
-//     App = function (props) {
-//       let { customRef } = props
-//       if (!customRef) {
-//         customRef = React.useRef(0)
-//       }
-//       const [when, setWhen] = React.useState(false);
-//       const renderCountRef = customRef
-//       const geoObj = useGeolocation({
-//         when
-//       });
+    App = function (props) {
+      let { customRef } = props;
+      if (!customRef) {
+        customRef = React.useRef(0);
+      }
+      const [when, setWhen] = React.useState(false);
+      const renderCountRef = customRef;
+      const [geoObj, geoErr] = useGeolocation({
+        when,
+      });
 
-//       React.useEffect(() => {
-//         renderCountRef.current++
-//       })
+      React.useEffect(() => {
+        renderCountRef.current++;
+      });
 
-//       return (
-//         <div className="App">
-//           <button
-//             data-testid="get-geolocation-btn"
-//             onClick={() => {
-//               setWhen(true);
-//             }}
-//           >
-//             Get Geolocation
-//           </button>
-//           <p data-testid="geo-info">{geoObj && JSON.stringify(geoObj)}</p>
-//         </div>
-//       );
-//     }
-//     //end
-//   });
-//   afterEach(cleanup);
+      return (
+        <div className="App">
+          <button
+            data-testid="get-geolocation-btn"
+            onClick={() => {
+              setWhen(true);
+            }}
+          >
+            Get Geolocation
+          </button>
+          <p data-testid="geo-info">{geoObj && JSON.stringify(geoObj)}</p>
+        </div>
+      );
+    };
+    //end
+  });
+  afterEach(cleanup);
 
-//   it("should be defined", () => {
-//     expect(useGeolocation).toBeDefined();
-//   });
-
-//   it("click on get geolocation gives geolocation", async () => {
-//     let container
-//     act(() => {
-//       container = render(<App />).container;
-//     })
-
-//     const getGeolocationBtn = getByTestId(container, "get-geolocation-btn");
-//     const geoInfoPElem = getByTestId(container, "geo-info");
-
-//     act(() => {
-//       fireEvent.click(getGeolocationBtn)
-//     })
-//     await wait()
-//     const y = JSON.parse(geoInfoPElem.innerHTML)
-//     expect(`${y.lat}`).toBe("51.1")
-//     expect(`${y.lng}`).toBe("45.3")
-//     expect(y.isError).toBe(false)
-//     expect(y.message).toBe("")
-
-//   })
-
-//   it("render should not happen infinitely, when 'when' attribute changes to true ", async () => {
-//     let container
-//     let customRef
-//     function TestComp() {
-//       customRef = React.useRef(0)
-//       return (
-//         <App customRef={customRef} />
-//       )
-
-//     }
-//     act(() => {
-//       container = render(<TestComp />).container;
-//     })
-//     const getGeolocationBtn = getByTestId(container, "get-geolocation-btn");
-//     act(() => {
-//       fireEvent.click(getGeolocationBtn)
-//     })
-//     await wait()
-//     expect(customRef.current).toBe(3)
-
-//   })
-// });
-
-// // figure out tests
-
-describe('useGeolocation', () => {
-  it('is defined', () => {
+  it("should be defined", () => {
     expect(useGeolocation).toBeDefined();
+  });
+
+  it("click on get geolocation gives geolocation", async () => {
+    let container;
+    act(() => {
+      container = render(<App />).container;
+    });
+
+    const getGeolocationBtn = getByTestId(container, "get-geolocation-btn");
+    const geoInfoPElem = getByTestId(container, "geo-info");
+
+    act(() => {
+      fireEvent.click(getGeolocationBtn);
+    });
+    await waitFor(() => {
+      const { coords } = JSON.parse(geoInfoPElem.innerHTML);
+      expect(`${coords.latitude}`).toBe("51.1");
+      expect(`${coords.longitude}`).toBe("45.3");
+    });
+  });
+
+  it("render should not happen infinitely, when 'when' attribute changes to true ", async () => {
+    let container;
+    let customRef;
+    function TestComp() {
+      customRef = React.useRef(0);
+      return <App customRef={customRef} />;
+    }
+    act(() => {
+      container = render(<TestComp />).container;
+    });
+    const getGeolocationBtn = getByTestId(container, "get-geolocation-btn");
+    act(() => {
+      fireEvent.click(getGeolocationBtn);
+    });
+    await waitFor(() => {
+      expect(customRef.current).toBe(3);
+    });
   });
 });

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -15,18 +15,21 @@ const getGeoLocation = (
 ): Promise<GeolocationPosition> => {
   return new Promise((resolve, reject) => {
     if (navigator.geolocation) {
+      const handleAbort = () => {
+        reject(new Error("Aborted"));
+      };
       navigator.geolocation.getCurrentPosition(
         (result: GeolocationPosition) => {
+          controller.signal.removeEventListener("abort", handleAbort);
           resolve(result);
         },
         (error) => {
+          controller.signal.removeEventListener("abort", handleAbort);
           reject(error);
         },
         options
       );
-      controller.signal.addEventListener("abort", () => {
-        reject(new Error("Aborted"));
-      });
+      controller.signal.addEventListener("abort", handleAbort);
     } else {
       reject(new Error("Geolocation is not supported for this Browser/OS."));
     }


### PR DESCRIPTION
Fixes geolocation internals. Uses AbortController for unmount cleanup. Removes unnecessary types.

BREAKING CHANGE: Geolocation now returns the native geolocation position and error (if exists) in a
tuple.

re #577