### PR TITLE
fix(usefullscreen): removes polyfill, usage changes

### DIFF
--- a/docs/useFullscreen.md
+++ b/docs/useFullscreen.md
@@ -6,7 +6,9 @@ sidebar_label: useFullscreen
 
 ## About
 
-Use full screen api for making beautiful and emersive experinces.
+Use full screen api for making beautiful and emersive experinces. 
+
+### Note: You might need to add a polyfill. Check usage section.
 
 ## Installation
 
@@ -15,6 +17,7 @@ Use full screen api for making beautiful and emersive experinces.
 ## Importing the hook
 
 ```javascript
+import 'fullscreen-polyfill' // or any polyfill of your choice
 import { useFullscreen } from "rooks";
 ```
 

--- a/src/hooks/useDocumentEventListener.ts
+++ b/src/hooks/useDocumentEventListener.ts
@@ -1,4 +1,4 @@
-import { useGlobalObjectEventListener } from './useGlobalObjectEventListener';
+import { useGlobalObjectEventListener } from "./useGlobalObjectEventListener";
 
 /**
  *  useDocumentEventListener hook
@@ -13,11 +13,16 @@ import { useGlobalObjectEventListener } from './useGlobalObjectEventListener';
  */
 function useDocumentEventListener(
   eventName: string,
-  callback: (...args: any) => void,
-  listenerOptions: any = {},
+  callback: (...args: unknown[]) => unknown,
+  listenerOptions: unknown = {},
   isLayoutEffect: boolean = false
 ): void {
-  if (typeof document !== 'undefined') {
+  if (typeof document === "undefined") {
+    console.warn(
+      "useDocumentEventListener can't attach an event listener as document is undefined."
+    );
+  } else {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     useGlobalObjectEventListener(
       document,
       eventName,
@@ -25,10 +30,6 @@ function useDocumentEventListener(
       listenerOptions,
       true,
       isLayoutEffect
-    );
-  } else {
-    console.warn(
-      "useDocumentEventListener can't attach an event listener as document is undefined."
     );
   }
 }

--- a/src/hooks/useFullscreen.ts
+++ b/src/hooks/useFullscreen.ts
@@ -9,210 +9,85 @@ type OnChangeEventCallback = (
   isOpen: boolean
 ) => any;
 
-type NormalizedFullscreenApi = {
-  requestFullscreen: string;
-  exitFullscreen: string;
-  fullscreenElement: string;
-  fullscreenEnabled: string;
-  fullscreenchange: string;
-  fullscreenerror: string;
-};
-
-const getFullscreenControls = (): NormalizedFullscreenApi => {
-  const functionMap = [
-    [
-      "requestFullscreen",
-      "exitFullscreen",
-      "fullscreenElement",
-      "fullscreenEnabled",
-      "fullscreenchange",
-      "fullscreenerror",
-    ],
-    // New WebKit
-    [
-      "webkitRequestFullscreen",
-      "webkitExitFullscreen",
-      "webkitFullscreenElement",
-      "webkitFullscreenEnabled",
-      "webkitfullscreenchange",
-      "webkitfullscreenerror",
-    ],
-    // Old WebKit
-    [
-      "webkitRequestFullScreen",
-      "webkitCancelFullScreen",
-      "webkitCurrentFullScreenElement",
-      "webkitCancelFullScreen",
-      "webkitfullscreenchange",
-      "webkitfullscreenerror",
-    ],
-    [
-      "mozRequestFullScreen",
-      "mozCancelFullScreen",
-      "mozFullScreenElement",
-      "mozFullScreenEnabled",
-      "mozfullscreenchange",
-      "mozfullscreenerror",
-    ],
-    [
-      "msRequestFullscreen",
-      "msExitFullscreen",
-      "msFullscreenElement",
-      "msFullscreenEnabled",
-      "MSFullscreenChange",
-      "MSFullscreenError",
-    ],
-  ];
-
-  const returnValue = {} as NormalizedFullscreenApi;
-
-  functionMap.forEach((functionSet) => {
-    if (functionSet && functionSet[1] in document) {
-      functionSet.forEach((_function, index) => {
-        returnValue[functionMap[0][index]] = functionSet[index];
-      });
-    }
-  });
-
-  return returnValue;
-};
 type NoopFunction = () => void;
 
 type FullscreenApi = {
   isEnabled: boolean;
-  toggle: NoopFunction | ((element?: HTMLElement) => Promise<unknown>); // toggle
-
-  /** @deprecated Please use useFullScreen({onChange : function() {}}) instead. */
-  onChange: NoopFunction | ((callback: OnChangeEventCallback) => void); // onchange
-
-  /** @deprecated Please use useFullScreen({onError : function() {}}) instead. */
-  onError: NoopFunction | ((callback: EventCallback) => void); // onerror
-  request: NoopFunction | ((element?: HTMLElement) => Promise<unknown>); // request
-  exit: NoopFunction | (() => Promise<unknown>); // exit
-  isFullscreen: boolean; // isFullscreen
-  element: HTMLElement | null | undefined;
+  toggle: NoopFunction | ((element?: Element) => Promise<unknown>);
+  request: NoopFunction | ((element?: Element) => Promise<unknown>);
+  exit: NoopFunction | (() => Promise<unknown>);
+  isFullscreen: boolean;
+  element: Element | null;
 };
 
 const noop: NoopFunction = () => {};
 
-const defaultValue: FullscreenApi = {
-  // isFullscreen
-  element: undefined,
-
-  // request
-  exit: noop,
-
-  isEnabled: false,
-
-  // exit
-  isFullscreen: false,
-
-  // toggle
-  onChange: noop,
-
-  // onchange
-  onError: noop,
-
-  // onerror
-  request: noop,
-
-  toggle: noop,
-};
-
-type RequestFullscreenOptions = {
-  // string will help to ease type casting
-  navigationUI?: string | "auto" | "hide" | "show";
-};
-
 type FullScreenOptions = {
   onChange?: OnChangeEventCallback;
   onError?: EventCallback;
-  requestFullscreenOptions?: RequestFullscreenOptions;
+  requestFullscreenOptions?: FullscreenOptions;
 };
 
-function warnDeprecatedOnChangeAndOnErrorUsage() {
-  warning(
-    false,
-    `Using onChange and onError from the return value is deprecated and 
-    will be removed in the next major version. 
-    Please use it with arguments instead. 
-    For eg: useFullscreen({onChange: function() {}, onError: function(){}})
-  `
-  );
-}
-
-/**
- * useFullscreen
- * A hook that helps make the document fullscreen
- */
-function useFullscreen(
+// The actual hook
+const useFullscreenInternal = (
   options: FullScreenOptions = {}
-): FullscreenApi | undefined {
-  if (typeof window === "undefined") {
-    return defaultValue;
-  }
+): FullscreenApi | undefined => {
+  // grab the options
   const {
     onChange: onChangeArgument,
     onError: onErrorArgument,
     requestFullscreenOptions = {},
   } = options;
 
-  const fullscreenControls = getFullscreenControls();
+  // state to manage full screen state and the element being fullscreened
   const [isFullscreen, setIsFullscreen] = useState(
-    Boolean(document[fullscreenControls.fullscreenElement])
+    Boolean(document.fullscreenElement)
   );
-  const [element, setElement] = useState(
-    document[fullscreenControls.fullscreenElement]
+  const [element, setElement] = useState(document.fullscreenElement);
+
+  // request function
+  const request = useCallback(
+    async (requestedElement?: Element) => {
+      try {
+        const elementToRequestFullscreenOn =
+          requestedElement ?? document.documentElement;
+
+        return await elementToRequestFullscreenOn.requestFullscreen(
+          requestFullscreenOptions
+        );
+      } catch (error) {
+        console.log(error);
+      }
+
+      return undefined;
+    },
+    [requestFullscreenOptions]
   );
 
-  const request = useCallback(async (element?: HTMLElement) => {
-    try {
-      const finalElement = element || document.documentElement;
-
-      return await finalElement[fullscreenControls.requestFullscreen](
-        requestFullscreenOptions
-      );
-    } catch (error) {
-      console.log(error);
-    }
-  }, []);
-
+  // exit fullscreen version
   const exit = useCallback(async () => {
     if (element) {
       try {
-        return await document[fullscreenControls.exitFullscreen]();
+        return await document.exitFullscreen();
       } catch (error) {
         console.warn(error);
       }
+
+      return undefined;
     }
   }, [element]);
 
+  // toggle function
   const toggle = useCallback(
-    (newElement?: HTMLElement) =>
+    (newElement?: Element) =>
       Boolean(element) ? exit() : newElement ? request(newElement) : null,
-    [element]
+    [element, exit, request]
   );
 
-  const onChangeDeprecatedHandlerRef = useRef<Function>(noop);
-  const onErrorDeprecatedHandlerRef = useRef<Function>(noop);
-
-  // Hack to not break it for everyone
-  // Honestly these two functions are tragedy and must be removed in v5
-  const onChangeDeprecated = useCallback((callback: OnChangeEventCallback) => {
-    warnDeprecatedOnChangeAndOnErrorUsage();
-
-    return (onChangeDeprecatedHandlerRef.current = callback);
-  }, []);
-
-  const onErrorDeprecated = useCallback((callback: EventCallback) => {
-    warnDeprecatedOnChangeAndOnErrorUsage();
-
-    return (onErrorDeprecatedHandlerRef.current = callback);
-  }, []);
-
-  useDocumentEventListener(fullscreenControls.fullscreenchange, (event) => {
-    const currentFullscreenElement =
-      document[fullscreenControls.fullscreenElement];
+  // fullscreenchange event listener
+  // it should handle state accordingly
+  useDocumentEventListener("fullscreenchange", (event) => {
+    const currentFullscreenElement = document.fullscreenElement;
     const isOpen = Boolean(currentFullscreenElement);
     if (isOpen) {
       // fullscreen was enabled
@@ -224,24 +99,52 @@ function useFullscreen(
       setElement(null);
     }
     onChangeArgument?.call(document, event, isOpen);
-    onChangeDeprecatedHandlerRef.current?.call(document, event, isOpen);
   });
 
-  useDocumentEventListener(fullscreenControls.fullscreenerror, (event) => {
+  // fullscreen error handler
+  useDocumentEventListener("fullscreenerror", (event) => {
     onErrorArgument?.call(document, event);
-    onErrorDeprecatedHandlerRef.current?.call(document, event);
   });
 
   return {
     element,
     exit,
-    isEnabled: Boolean(document[fullscreenControls.fullscreenEnabled]),
+    isEnabled: Boolean(document.fullscreenEnabled),
     isFullscreen,
-    onChange: onChangeDeprecated,
-    onError: onErrorDeprecated,
     request,
     toggle,
   };
-}
+};
+
+/**
+ * useFullscreen
+ * A hook that helps make the document fullscreen
+ */
+const useFullscreen = (
+  options: FullScreenOptions = {}
+): FullscreenApi | undefined => {
+  if (typeof window === "undefined") {
+    return {
+      // isFullscreen
+      element: null,
+
+      // request
+      exit: noop,
+
+      isEnabled: false,
+
+      // exit
+      isFullscreen: false,
+
+      // onerror
+      request: noop,
+
+      toggle: noop,
+    };
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useFullscreenInternal(options);
+};
 
 export { useFullscreen };


### PR DESCRIPTION
Removes polyfill, removes deprecated return values .

BREAKING CHANGE: onError and onChange in the return value are removed. (They were earlier
deprecated)

re #579