### PR TITLE
useIntervalWhen in useCountdown

### DIFF
--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useInterval } from './useInterval';
+import { useIntervalWhen } from './useIntervalWhen';
 
 type CountdownOptions = {
   interval?: number;
@@ -21,7 +21,7 @@ function useCountdown(endTime: Date, options: CountdownOptions = {}): number {
   const restTime = endTime.getTime() - time.getTime();
   const count = restTime > 0 ? Math.ceil(restTime / interval) : 0;
 
-  useInterval(onTick, count ? interval : null, true);
+  useIntervalWhen(onTick, count ? interval : null, true, true);
 
   return count;
 

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -21,7 +21,7 @@ function useCountdown(endTime: Date, options: CountdownOptions = {}): number {
   const restTime = endTime.getTime() - time.getTime();
   const count = restTime > 0 ? Math.ceil(restTime / interval) : 0;
 
-  useIntervalWhen(onTick, count ? interval : null, true, true);
+  useIntervalWhen(onTick, count ? interval : undefined, true, true);
 
   return count;
 


### PR DESCRIPTION
This resolves a deprecation notice in the console whenever I use `useCountdown`.

```
Warning: useInterval is deprecated, it will be removed in rooks v7. Please use useIntervalWhen instead. 
```