### PR TITLE
Rerender session hook on remove

### DIFF
--- a/src/hooks/useSessionstorageState.ts
+++ b/src/hooks/useSessionstorageState.ts
@@ -94,8 +94,8 @@ function useSessionstorageState<S>(
   }, []);
 
   const remove = useCallback(() => {
-    __setValue(null);
     sessionStorage.removeItem(key);
+    __setValue(null);
   }, []);
 
   return [value, setValue, remove];

--- a/src/hooks/useSessionstorageState.ts
+++ b/src/hooks/useSessionstorageState.ts
@@ -94,7 +94,7 @@ function useSessionstorageState<S>(
   }, []);
 
   const remove = useCallback(() => {
-	  __setValue(null);
+    __setValue(null);
     sessionStorage.removeItem(key);
   }, []);
 

--- a/src/hooks/useSessionstorageState.ts
+++ b/src/hooks/useSessionstorageState.ts
@@ -94,6 +94,7 @@ function useSessionstorageState<S>(
   }, []);
 
   const remove = useCallback(() => {
+	  __setValue(null);
     sessionStorage.removeItem(key);
   }, []);
 


### PR DESCRIPTION
fixes #780 

This removes the item from session storage, then internally calls the existing setState, setting it to `null`, casing the component to re-render, matching the behavior contract of `useState` in that the component re-renders each time the data is affected.

Note: This is a _breaking_ change.