### PR TITLE
feat: add more methods for useStackState

### DIFF
--- a/src/__tests__/useQueueState.spec.ts
+++ b/src/__tests__/useQueueState.spec.ts
@@ -17,7 +17,7 @@ describe("useQueueState", () => {
     const [, controls] = result.current;
     expect(controls.length).toBe(3);
   });
-  it.only("should enqueue correctly", () => {
+  it("should enqueue correctly", () => {
     const { result, rerender } = renderHook(() => useQueueState([1, 2, 3]));
     // test memo
     const enqueueBeforeRerender = result.current[1].enqueue;
@@ -69,7 +69,7 @@ describe("useQueueState", () => {
     expect(result.current[1].length).toEqual(3);
   });
   it("handles empty arrays", () => {
-    const { result } = renderHook(() => useQueueState([]));
+    const { result } = renderHook(() => useQueueState<number>([]));
     act(() => {
       result.current[1].dequeue();
     });

--- a/src/__tests__/useStackState.spec.ts
+++ b/src/__tests__/useStackState.spec.ts
@@ -107,4 +107,13 @@ describe("useStackState", () => {
     expect(result.current[1].length).toEqual(0);
     expect(result.current[2]).toEqual([]);
   });
+
+  it("should clear the stack", () => {
+    const { result } = renderHook(() => useStackState([1, 2, 3]));
+    expect(result.current[1].length).toEqual(3);
+    act(() => {
+      result.current[1].clear();
+    });
+    expect(result.current[1].isEmpty()).toBe(true);
+  });
 });

--- a/src/__tests__/useStackState.spec.ts
+++ b/src/__tests__/useStackState.spec.ts
@@ -76,7 +76,7 @@ describe("useStackState", () => {
     expect(result.current[1].length).toEqual(3);
   });
   it("handles empty arrays", () => {
-    const { result } = renderHook(() => useStackState([]));
+    const { result } = renderHook(() => useStackState<number>([]));
 
     act(() => {
       result.current[1].pop();

--- a/src/hooks/useQueueState.ts
+++ b/src/hooks/useQueueState.ts
@@ -1,21 +1,18 @@
 import { useCallback, useState } from "react";
 
-function useQueueState(
-  initialList: any[]
-): [
-  any[],
+function useQueueState<T>(initialList: T[]): [
+  T[],
   {
-    enqueue: (item: any) => number;
-    dequeue: () => any | undefined;
-    peek: () => any | undefined;
+    enqueue: (item: T) => number;
+    dequeue: () => T | undefined;
+    peek: () => T | undefined;
     length: number;
   }
 ] {
-  const [list, setList] = useState([...initialList]);
-  const length = list.length;
+  const [list, setList] = useState<T[]>([...initialList]);
 
   const enqueue = useCallback(
-    (item: any) => {
+    (item: T) => {
       const newList = [...list, item];
 
       setList(newList);
@@ -37,7 +34,7 @@ function useQueueState(
   }, [list]);
 
   const peek = useCallback(() => {
-    if (length > 0) {
+    if (list.length > 0) {
       return list[0];
     }
 
@@ -47,7 +44,7 @@ function useQueueState(
   const controls = {
     dequeue,
     enqueue,
-    length,
+    length: list.length,
     peek,
   };
 

--- a/src/hooks/useStackState.ts
+++ b/src/hooks/useStackState.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState } from "react";
 
-function useStackState(
-  initialList: any[]
-): [
+function useStackState(initialList: any[]): [
   any[],
   {
+    clear: () => void;
+    isEmpty: () => boolean;
     push: (item: any) => number;
     pop: () => any | undefined;
     peek: () => any | undefined;
@@ -44,14 +44,20 @@ function useStackState(
   }, [list]);
 
   const peek = useCallback(() => {
-    if (length > 0) {
-      return list[length - 1];
+    if (list.length > 0) {
+      return list[list.length - 1];
     }
 
     return undefined;
   }, [list]);
 
+  const clear = () => setList([]);
+
+  const isEmpty = useCallback(() => list.length === 0, [list]);
+
   const controls = {
+    clear,
+    isEmpty,
     length,
     peek,
     pop,

--- a/src/hooks/useStackState.ts
+++ b/src/hooks/useStackState.ts
@@ -1,21 +1,21 @@
 import { useCallback, useMemo, useState } from "react";
 
-function useStackState(initialList: any[]): [
-  any[],
+function useStackState<T>(initialList: T[]): [
+  T[],
   {
     clear: () => void;
     isEmpty: () => boolean;
-    push: (item: any) => number;
-    pop: () => any | undefined;
-    peek: () => any | undefined;
+    push: (item: T) => number;
+    pop: () => T | undefined;
+    peek: () => T | undefined;
     length: number;
   },
-  any[]
+  T[]
 ] {
-  const [list, setList] = useState([...initialList]);
+  const [list, setList] = useState<T[]>([...initialList]);
   const length = list.length;
 
-  const listInReverse = useMemo(() => {
+  const listInReverse = useMemo<T[]>(() => {
     const reverseList = [...list];
     reverseList.reverse();
 
@@ -23,7 +23,7 @@ function useStackState(initialList: any[]): [
   }, [list]);
 
   const push = useCallback(
-    (item: any) => {
+    (item: T) => {
       const newList = [...list, item];
       setList(newList);
 


### PR DESCRIPTION
Changes to `useStackState` hook:

1. Added `clear` and `isEmpty` methods. 
2. Added unit testings for the above methods.
3. Use `list.length` instead of `length` in the closure to solve this eslint warning.
4. Use generics instead of `any` type. Related issue https://github.com/imbhargav5/rooks/issues/586