### PR TITLE
#734 - does not use the defaultValue on the first render

### DIFF
--- a/src/hooks/useLocalstorage.ts
+++ b/src/hooks/useLocalstorage.ts
@@ -20,6 +20,7 @@ type StorageHandler = StorageHandlerAsArray & StorageHandlerAsObject;
  * @param {string} key - Key of the localStorage object
  * @param {any} defaultValue - Default initial value
  */
+
 function useLocalstorage(key: string, defaultValue: any): StorageHandler {
   const [value, setValue] = useState(getValueFromLocalStorage());
 

--- a/src/hooks/useLocalstorage.ts
+++ b/src/hooks/useLocalstorage.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect, useCallback } from "react";
@@ -21,7 +22,7 @@ type StorageHandler = StorageHandlerAsArray & StorageHandlerAsObject;
  */
 function useLocalstorage(
   key: string,
-  defaultValue: any = null
+  defaultValue: any = [null]
 ): StorageHandler {
   const [value, setValue] = useState(getValueFromLocalStorage());
 
@@ -31,6 +32,7 @@ function useLocalstorage(
       valueLoadedFromLocalStorage === null ||
       valueLoadedFromLocalStorage === "null"
     ) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       set(defaultValue);
     }
   }
@@ -39,7 +41,13 @@ function useLocalstorage(
     if (typeof localStorage === "undefined") {
       return null;
     }
-    const storedValue = localStorage.getItem(key) || "null";
+
+    if (localStorage.getItem(key) === null) {
+      saveValueToLocalStorage(defaultValue);
+    }
+
+    const storedValue: any = localStorage.getItem(key);
+
     try {
       return JSON.parse(storedValue);
     } catch (error) {

--- a/src/hooks/useLocalstorage.ts
+++ b/src/hooks/useLocalstorage.ts
@@ -20,10 +20,7 @@ type StorageHandler = StorageHandlerAsArray & StorageHandlerAsObject;
  * @param {string} key - Key of the localStorage object
  * @param {any} defaultValue - Default initial value
  */
-function useLocalstorage(
-  key: string,
-  defaultValue: any = [null]
-): StorageHandler {
+function useLocalstorage(key: string, defaultValue: any): StorageHandler {
   const [value, setValue] = useState(getValueFromLocalStorage());
 
   function init() {


### PR DESCRIPTION
Added saveValueToLocalStorage function if localStorage.getItem(key) === null to fix the issue and also removed defaultValue value