### PR TITLE
Disable useWindowEventListener warning logs in production.

### DIFF
--- a/src/hooks/useWindowEventListener.ts
+++ b/src/hooks/useWindowEventListener.ts
@@ -27,9 +27,10 @@ function useWindowEventListener(
       isLayoutEffect
     );
   } else {
-    console.warn(
-      "useWindowEventListener can't attach an event listener as window is undefined."
-    );
+    if (process.env.NODE_ENV==='development')
+      console.warn(
+        "useWindowEventListener can't attach an event listener as window is undefined."
+      );
   }
 }
 


### PR DESCRIPTION
This hook currently clutters logs on SSR.