### PR TITLE
Change callback param type definition to optional

### DIFF
--- a/src/hooks/useIntersectionObserverRef.ts
+++ b/src/hooks/useIntersectionObserverRef.ts
@@ -17,7 +17,7 @@ const config: IntersectionObserverInit = {
  * @param {IntersectionObserverInit} options
  */
 function useIntersectionObserverRef(
-  callback?: IntersectionObserverCallback,
+  callback: IntersectionObserverCallback | undefined,
   options: IntersectionObserverInit = config
 ): [CallbackRef] {
   const { root = null, rootMargin, threshold } = options;

--- a/src/hooks/useIntersectionObserverRef.ts
+++ b/src/hooks/useIntersectionObserverRef.ts
@@ -17,7 +17,7 @@ const config: IntersectionObserverInit = {
  * @param {IntersectionObserverInit} options
  */
 function useIntersectionObserverRef(
-  callback: IntersectionObserverCallback,
+  callback?: IntersectionObserverCallback,
   options: IntersectionObserverInit = config
 ): [CallbackRef] {
   const { root = null, rootMargin, threshold } = options;


### PR DESCRIPTION
In the changed `useIntersectionObserverRef` [#889](https://github.com/imbhargav5/rooks/pull/889),
observation could be stopped by passing undefined to callback,
but callback was not optional, so undefined could not be passed in TS.
So I fixed the type definition.