### PR TITLE
Fix useDidUpdate to make it work with Strict Effects

### DIFF
--- a/src/hooks/useDidUpdate.ts
+++ b/src/hooks/useDidUpdate.ts
@@ -26,6 +26,9 @@ function useDidUpdate(callback: () => any, conditions?: any[]): void {
     } else {
       hasMountedRef.current = true;
     }
+    return () => {
+      hasMountedRef.current = false;
+    }
   }, conditions);
 }
 

--- a/src/hooks/useDidUpdate.ts
+++ b/src/hooks/useDidUpdate.ts
@@ -26,10 +26,13 @@ function useDidUpdate(callback: () => any, conditions?: any[]): void {
     } else {
       hasMountedRef.current = true;
     }
+  }, conditions);
+  
+  useEffect(() => {
     return () => {
       hasMountedRef.current = false;
     }
-  }, conditions);
+  }, [])
 }
 
 export { useDidUpdate };


### PR DESCRIPTION
> With the release of React 18, StrictMode gets an additional behavior to ensure it's compatible with reusable state. When StrictMode is enabled, **React intentionally double-invokes effects (mount -> unmount -> mount) for newly mounted components**. [Source](https://github.com/reactwg/react-18/discussions/19)

So, it's essential that the `hasMountedRef` is reset when unmounting otherwise it won't behave desirably when wrapped inside StrictMode.