### PR TITLE
fix: change useFullscreen hook return type (it never returns undefined)

### DIFF
--- a/src/hooks/useFullscreen.ts
+++ b/src/hooks/useFullscreen.ts
@@ -147,7 +147,7 @@ function warnDeprecatedOnChangeAndOnErrorUsage() {
  */
 function useFullscreen(
   options: FullScreenOptions = {}
-): FullscreenApi | undefined {
+): FullscreenApi {
   if (typeof window === "undefined") {
     console.warn("useFullscreen: window is undefined.");
 


### PR DESCRIPTION
As per #877, the useFullscreen hook has an incorrect typing of a return value. 