### PR TITLE
fix: Remove console.warn in SSR

### DIFF
--- a/src/__tests__/generalSsrTests.spec.ts
+++ b/src/__tests__/generalSsrTests.spec.ts
@@ -6,8 +6,6 @@ import { useFullscreen } from "../hooks/useFullscreen";
 import { useIntervalWhen } from "../hooks/useIntervalWhen";
 import { useLocalstorage } from "../hooks/useLocalstorage";
 import { useLocalstorageState } from "../hooks/useLocalstorageState";
-import { useOnWindowResize } from "../hooks/useOnWindowResize";
-import { useOnWindowScroll } from "../hooks/useOnWindowScroll";
 import { useOnline } from "../hooks/useOnline";
 import { useSessionstorage } from "../hooks/useSessionstorage";
 import { useThrottle } from "../hooks/useThrottle";
@@ -21,16 +19,6 @@ describe("when window is undefined", () => {
 
   afterEach(() => {
     consoleSpy.mockClear();
-  });
-
-  it("useOnWindowResize logs warning", () => {
-    renderHook(() => useOnWindowResize(mockCallback));
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("useOnWindowScroll logs warning", () => {
-    renderHook(() => useOnWindowScroll(mockCallback));
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
   });
 
   it("useIntervalWhen logs warning", () => {

--- a/src/hooks/useOnWindowResize.ts
+++ b/src/hooks/useOnWindowResize.ts
@@ -15,20 +15,14 @@ function useOnWindowResize(
   when: boolean = true,
   isLayoutEffect: boolean = false
 ) {
-  if (typeof window !== "undefined") {
-    useGlobalObjectEventListener(
-      window,
-      "resize",
-      callback,
-      { passive: true },
-      when,
-      isLayoutEffect
-    );
-  } else {
-    console.warn(
-      "useOnWindowResize can't attach an event listener as window is undefined."
-    );
-  }
+  useGlobalObjectEventListener(
+    window,
+    "resize",
+    callback,
+    { passive: true },
+    when,
+    isLayoutEffect
+  );
 }
 
 export { useOnWindowResize };

--- a/src/hooks/useOnWindowScroll.ts
+++ b/src/hooks/useOnWindowScroll.ts
@@ -14,20 +14,14 @@ function useOnWindowScroll(
   when: boolean = true,
   isLayoutEffect: boolean = false
 ): void {
-  if (typeof window !== "undefined") {
-    useGlobalObjectEventListener(
-      window,
-      "scroll",
-      callback,
-      { passive: true },
-      when,
-      isLayoutEffect
-    );
-  } else {
-    console.warn(
-      "useOnWindowScroll can't attach an event listener as window is undefined."
-    );
-  }
+  useGlobalObjectEventListener(
+    window,
+    "scroll",
+    callback,
+    { passive: true },
+    when,
+    isLayoutEffect
+  );
 }
 
 export { useOnWindowScroll };


### PR DESCRIPTION
The warning was unnecessary for several reasons.

First, The only way to detect SSR seemed to be using `window === undefined`, so detecting it and warning it is redundant.
Reference: https://github.com/alex-cory/use-ssr/blob/master/useSSR.ts

Secondly, in other place rooks calling `useGlobalObjectEventListener`, it does not detect `window === undefined`.
Reference:
https://github.com/imbhargav5/rooks/blob/bcd25dff395a82d51d27d4e1faac3bbbfe1dcd08/src/hooks/useDocumentEventListener.ts#L20
https://github.com/imbhargav5/rooks/blob/bcd25dff395a82d51d27d4e1faac3bbbfe1dcd08/src/hooks/useWindowEventListener.ts#L20

Finally, it violates conditional hooks call rule. The eslint shows error `React Hooks must be called in the exact same order in every component render.`
Reference: https://reactjs.org/docs/hooks-rules.html#gatsby-focus-wrapper

---
close #1029 
