### PR TITLE
fix: remove useRaf resetting startTime on every tick

### DIFF
--- a/src/hooks/useRaf.ts
+++ b/src/hooks/useRaf.ts
@@ -25,7 +25,6 @@ export function useRaf(
 
     function tick() {
       const timeElapsed = Date.now() - startTime;
-      startTime = Date.now();
       loop();
       savedCallback.current && savedCallback.current(timeElapsed);
     }


### PR DESCRIPTION
This is a fix for bug #1044.