### PR TITLE
chore: remove yarn dev; format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,21 @@
-### Creating a new hook
+# Contributing
 
-#### New hook
+## Creating a new hook
+
+### New hook
 
 From the root of the project run `yarn new`. This should start the process to create a new hook and set up the package.
 
-#### Current hooks fixes / updates
+### Current hooks fixes / updates
 
 Make sure you have Yarn package manager installed globally on your machine.
 
 From the root of the project:
 
 - run `yarn install`
-- run `yarn run build`
-- run `yarn run dev`
+- run `yarn build`
 
-### Contributing Guidelines
+## Contributing Guidelines
 
 When adding a new hook, please make sure that
 


### PR DESCRIPTION
I realized `yarn dev` is not in package.json.
I formatted the markdown by the way.