### PR TITLE
fix(useDebounce)

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -26,13 +26,18 @@ function useDebounce<T extends (...args: any[]) => unknown>(
     [wait, options]
   );
 
+  const callbackRef = useRef<T>(callback);
   const debouncedCallbackRef = useRef<DebouncedFunc<T>>(
     createDebouncedCallback(callback)
   );
+    
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
 
   useEffect(() => {
-    debouncedCallbackRef.current = createDebouncedCallback(callback);
-  }, [callback, createDebouncedCallback]);
+    debouncedCallbackRef.current = createDebouncedCallback(callbackRef.current);
+  }, [createDebouncedCallback]);
 
   return debouncedCallbackRef.current;
 }


### PR DESCRIPTION
adds const callbackRef = useRef<T>(callback);

sandbox: https://codesandbox.io/s/usedebounce-forked-6sq8xh
see also: https://stackoverflow.com/questions/59151707/debounce-triggering-multiple-times-in-react

rooks versions <= 5.9.0 did not had that issue