### PR TITLE
Fix helpers/create

### DIFF
--- a/helpers/create/index.ts
+++ b/helpers/create/index.ts
@@ -2,13 +2,22 @@ import inquirer from "inquirer";
 import fs from "fs";
 import fsExtra from "fs-extra";
 import path from "path";
-import replaceString from "replace-string";
-import makeDir from "make-dir";
-import ora from "ora";
-import execa from "execa";
 import truncate from "lodash.truncate";
 import addHookToListAndUpdate from "./addHookToListAndUpdate";
 import { IHookDesc } from "../types";
+
+/**
+ * This function performs a global string replace
+ * @param string String to perform the replacement on
+ * @param needle Value to replace
+ * @param replacement Replacement value
+ * @returns The first argument with all occurrences of the needle changed to the replacement
+ */
+export const replaceString = (
+  string: string,
+  needle: string,
+  replacement: string
+) => string.split(needle).join(replacement);
 
 const PROJECT_ROOT = process.cwd();
 
@@ -62,8 +71,8 @@ function injectValuesIntoTemplate(
 
   let result: string = src;
   result = replaceString(result, "%name%", name);
-  result = replaceString(result, "%directoryName%", directoryName);
-  result = replaceString(result, "%packageName%", packageName);
+  result = replaceString(result, "%directoryName%", directoryName ?? "");
+  result = replaceString(result, "%packageName%", packageName ?? "");
   result = replaceString(result, "%description%", description);
   result = replaceString(result, "%description0%", descriptionArray[0]);
   result = replaceString(result, "%description1%", descriptionArray[1]);
@@ -126,9 +135,8 @@ inquirer.prompt(questions).then((answers) => {
   filesToWrite.map((relativeFilePathFromRootOfModule: any, index) => {
     const srcToWrite = transformedSources[index];
     if (typeof relativeFilePathFromRootOfModule === "function") {
-      relativeFilePathFromRootOfModule = relativeFilePathFromRootOfModule(
-        answers
-      );
+      relativeFilePathFromRootOfModule =
+        relativeFilePathFromRootOfModule(answers);
     }
     const pathToWriteTo = path.join(
       PROJECT_ROOT,

--- a/helpers/docs/index.ts
+++ b/helpers/docs/index.ts
@@ -1,6 +1,5 @@
 import { writeFileSync, readFileSync } from "fs";
 import parseReadme from "./parse-readme";
-import replaceString from "replace-string";
 
 const packageName = process.env.LERNA_PACKAGE_NAME;
 const newReadmeFileName = packageName?.startsWith("@rooks")

--- a/helpers/update-title-card/index.ts
+++ b/helpers/update-title-card/index.ts
@@ -1,10 +1,11 @@
-import replaceString from "replace-string";
 import { camelCase } from "camel-case";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 var currentPath = process.cwd();
 const pkg = require(join(currentPath, "./package.json"));
 import truncate from "lodash.truncate";
+import { replaceString } from "../create";
+
 if (!Array.isArray(pkg.keywords)) {
   pkg.keywords = [];
 }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "remark-frontmatter": "^4.0.1",
     "remark-preset-lint-markdown-style-guide": "^5.1.2",
     "remark-strip-badges": "^6.0.1",
-    "replace-string": "4.0.0",
     "rollup": "^2.33.3",
     "rollup-plugin-dts": "^2.0.1",
     "rollup-plugin-esbuild": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16204,11 +16204,6 @@ replace-homedir@^1.0.0:
     is-absolute "^1.0.0"
     remove-trailing-separator "^1.1.0"
 
-replace-string@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/replace-string/-/replace-string-4.0.0.tgz#2f7270b3e38d118a00ff328481305561c7fe74cf"
-  integrity sha512-fcgyZ62o26oBaihEC302pZQ2WectvmZ4sGOq4Lwa8ad12lPbhIlZCvLpgpI1sOAsbN83kpXiH5KCcr3pcZa8bA==
-
 req-all@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"


### PR DESCRIPTION
This pr fixes errors in helpers/create (`yarn new`) as described in #1012 

It:
- adds `?? ""` in two places to remove the possibility of a value being undefined
- removes the dependency on replace-string, adding a custom implementation

Questions for maintainers:
is helpers/create/index.ts the right location for a custom replaceString? It is also referenced in another helper (helpers/update-title-card/index.ts), so it might be more appropriate to place it in a separate file.