### PR TITLE
feat: Add useAsyncEffect

### DIFF
--- a/docs/useAsyncEffect.md
+++ b/docs/useAsyncEffect.md
@@ -1,0 +1,46 @@
+---
+id: useAsyncEffect
+title: useAsyncEffect
+sidebar_label: useAsyncEffect
+---
+
+
+## About
+A version of useEffect that accepts an async function
+
+
+[//]: # (Main)
+
+## Installation
+
+```
+npm install rooks
+```
+
+## Importing the hook
+
+```javascript
+import {useAsyncEffect} from "rooks"
+```
+
+## Usage
+
+```jsx
+function Demo() {
+  useAsyncEffect();
+  return null
+}
+
+render(<Demo/>)
+```
+
+---
+
+## Codesandbox Examples
+
+### Basic Usage
+
+
+---
+## Join Bhargav's discord server
+You can click on the floating discord icon at the bottom right of the screen and talk to us in our server.

--- a/docs/useAsyncEffect.md
+++ b/docs/useAsyncEffect.md
@@ -6,10 +6,10 @@ sidebar_label: useAsyncEffect
 
 
 ## About
-A version of useEffect that accepts an async function
+This is a version of useEffect that accepts an async function.
 
+`useEffect` only works with effect functions that run synchronously. The go-to solution for most people is to simply run an async function inside `useEffect`, but that approach has a lot of gotchas involving React state manipulation.
 
-[//]: # (Main)
 
 ## Installation
 
@@ -20,27 +20,72 @@ npm install rooks
 ## Importing the hook
 
 ```javascript
-import {useAsyncEffect} from "rooks"
+import { useAsyncEffect } from "rooks"
 ```
 
 ## Usage
 
+### Basic usage
+
 ```jsx
-function Demo() {
-  useAsyncEffect();
+function SimpleDemo() {
+  useAsyncEffect(async (signal) => {
+    console.log("I'm an async function!")
+  }, []);
+
   return null
 }
 
-render(<Demo/>)
+render(<SimpleDemo />)
+```
+
+### Usage with React state
+
+If you are going to modify React state inside `useAsyncEffect`, you have to check for cancellation signals. Otherwise, your components might start behaving unexpectedly.
+
+```jsx
+function StatefulDemo() {
+  const [counter, setCounter] = useState(0)
+
+  useAsyncEffect(async (signal) => {
+    await longOperation()
+
+    // This is the line you should include before changing state
+    if (signal.aborted) return
+
+    setCounter((oldCounter) => oldCounter + 1)
+  }, []);
+
+  return (
+    <div>
+      The count is: {counter}
+    </div>
+  )
+}
+
+render(<StatefulDemo />)
+```
+
+### Cleanup functions
+
+`useAsyncEffect` supports cleanup functions. For information about cleanup functions, see the [React docs](https://reactjs.org/docs/hooks-effect.html#effects-with-cleanup).
+
+```jsx
+function CleanupDemo() {
+  useAsyncEffect(async (signal) => {
+    const interval = setInterval(doSomething, 200)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, []);
+
+  return null
+}
+
+render(<CleanupDemo />)
 ```
 
 ---
-
-## Codesandbox Examples
-
-### Basic Usage
-
-
----
-## Join Bhargav's discord server
+## Join Bhargav's Discord server
 You can click on the floating discord icon at the bottom right of the screen and talk to us in our server.

--- a/docs/useAsyncEffect.md
+++ b/docs/useAsyncEffect.md
@@ -6,10 +6,11 @@ sidebar_label: useAsyncEffect
 
 
 ## About
-This is a version of useEffect that accepts an async function.
+This is a version of `useEffect` that accepts an async function.
 
 `useEffect` only works with effect functions that run synchronously. The go-to solution for most people is to simply run an async function inside `useEffect`, but that approach has a lot of gotchas involving React state manipulation.
 
+[//]: # 'Main'
 
 ## Installation
 
@@ -39,6 +40,8 @@ function SimpleDemo() {
 render(<SimpleDemo />)
 ```
 
+[Find this example on CodeSandbox](https://codesandbox.io/s/rough-fire-c22p6p)
+
 ### Usage with React state
 
 If you are going to modify React state inside `useAsyncEffect`, you have to check for cancellation signals. Otherwise, your components might start behaving unexpectedly.
@@ -66,9 +69,13 @@ function StatefulDemo() {
 render(<StatefulDemo />)
 ```
 
+[Find this example on CodeSandbox](https://codesandbox.io/s/jovial-surf-bjvefr)
+
 ### Cleanup functions
 
 `useAsyncEffect` supports cleanup functions. For information about cleanup functions, see the [React docs](https://reactjs.org/docs/hooks-effect.html#effects-with-cleanup).
+
+The cleanup functions will be ran when something in the dependency array changes AND your async function resolves.
 
 ```jsx
 function CleanupDemo() {
@@ -85,6 +92,8 @@ function CleanupDemo() {
 
 render(<CleanupDemo />)
 ```
+
+[Find this example on CodeSandbox](https://codesandbox.io/s/pedantic-faraday-77sjnc)
 
 ---
 ## Join Bhargav's Discord server

--- a/helpers/hooks-list.json
+++ b/helpers/hooks-list.json
@@ -1,6 +1,10 @@
 {
   "hooks": [
     {
+      "name": "useAsyncEffect",
+      "description": "A version of useEffect that accepts an async function"
+    },
+    {
       "name": "useBoundingclientrect",
       "description": "getBoundingClientRect hook for React."
     },

--- a/src/__tests__/useAsyncEffect.spec.ts
+++ b/src/__tests__/useAsyncEffect.spec.ts
@@ -101,6 +101,11 @@ describe("useAsyncEffect", () => {
 
     setTimeout(() => {
       expect(consoleSpy).toHaveBeenCalledTimes(1);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "You should NEVER throw inside useAsyncEffect. This means the cleanup function will not run, which can cause unintended side effects. Please wrap your useAsyncEffect function in a try/catch."
+        )
+      );
       done();
     });
   });

--- a/src/__tests__/useAsyncEffect.spec.ts
+++ b/src/__tests__/useAsyncEffect.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react-hooks";
+import React, { useEffect, useState } from "react";
+import { act } from "react-test-renderer";
+import { useAsyncEffect } from "../hooks/useAsyncEffect";
+
+describe("useAsyncEffect", () => {
+  it("should be defined", () => {
+    expect(useAsyncEffect).toBeDefined();
+  });
+
+  it("runs the callback", async () => {
+    const { waitFor, result } = renderHook(() => {
+      const [value, setValue] = useState(false);
+
+      useAsyncEffect(async () => {
+        setValue(true);
+      }, []);
+
+      return value;
+    });
+
+    expect(result.all[0]).toBe(false);
+    await expect(waitFor(() => result.current)).resolves.toBeUndefined();
+  });
+
+  it("sends the abort signal", async () => {
+    const { waitFor, result } = renderHook(() => {
+      const [aborted, setAborted] = useState(false);
+      const [forceUnload, setForceUnload] = useState(0);
+
+      useAsyncEffect(
+        async (signal) => {
+          const listener = () => setAborted(true);
+          signal.addEventListener("abort", listener);
+
+          return () => signal.removeEventListener("abort", listener);
+        },
+        [forceUnload]
+      );
+
+      return { aborted, forceUnload, setForceUnload };
+    });
+
+    expect(result.current.aborted).toBe(false);
+
+    act(() => {
+      result.current.setForceUnload((old) => old + 1);
+    });
+
+    await expect(
+      waitFor(() => result.current.aborted)
+    ).resolves.toBeUndefined();
+  });
+});
+
+it("runs the cleanup function", async () => {
+  const { waitFor, result } = renderHook(() => {
+    const [cleanupRan, setCleanupRan] = useState(false);
+    const [forceUnload, setForceUnload] = useState(0);
+
+    useAsyncEffect(
+      async (signal) => {
+        return () => setCleanupRan(true);
+      },
+      [forceUnload]
+    );
+
+    return { cleanupRan, forceUnload, setForceUnload };
+  });
+
+  expect(result.current.cleanupRan).toBe(false);
+
+  act(() => {
+    result.current.setForceUnload((old) => old + 1);
+  });
+
+  await expect(
+    waitFor(() => result.current.cleanupRan)
+  ).resolves.toBeUndefined();
+});

--- a/src/__tests__/useAsyncEffect.spec.ts
+++ b/src/__tests__/useAsyncEffect.spec.ts
@@ -23,7 +23,10 @@ describe("useAsyncEffect", () => {
     });
 
     expect(result.all[0]).toBe(false);
-    await expect(waitFor(() => result.current)).resolves.toBeUndefined();
+
+    await act(async () => {
+      await expect(waitFor(() => result.current)).resolves.toBeUndefined();
+    });
   });
 
   it("sends the abort signal", async () => {
@@ -50,9 +53,11 @@ describe("useAsyncEffect", () => {
       result.current.setForceUnload((old) => old + 1);
     });
 
-    await expect(
-      waitFor(() => result.current.aborted)
-    ).resolves.toBeUndefined();
+    await act(async () => {
+      await expect(
+        waitFor(() => result.current.aborted)
+      ).resolves.toBeUndefined();
+    });
   });
 
   it("runs the cleanup function", async () => {

--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -4,9 +4,9 @@ type Effect = (signal: AbortSignal) => Promise<void | CleanupFunction>;
 type CleanupFunction = () => void;
 
 /**
- *
- * @param effect
- * @param deps
+ * A version of useEffect that accepts an async function
+ * @param effect Async function that can return a cleanup function and takes in an AbortSignal
+ * @param deps If present, effect will only activate if the values in the list change
  */
 function useAsyncEffect(effect: Effect, deps?: DependencyList) {
   useEffect(() => {

--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -1,0 +1,24 @@
+import React, { DependencyList, useEffect } from "react";
+
+type Effect = (signal: AbortSignal) => Promise<void | CleanupFunction>;
+type CleanupFunction = () => void;
+
+/**
+ *
+ * @param effect
+ * @param deps
+ * @param cleanup
+ */
+function useAsyncEffect(effect: Effect, deps?: DependencyList) {
+  useEffect(() => {
+    const controller = new AbortController();
+
+    effect(controller.signal).then((cleanupFunction) => {
+      typeof cleanupFunction === "function" && cleanupFunction();
+    });
+
+    return () => controller.abort();
+  }, deps);
+}
+
+export { useAsyncEffect };

--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -12,17 +12,23 @@ function useAsyncEffect(effect: Effect, deps?: DependencyList) {
   useEffect(() => {
     const controller = new AbortController();
 
-    effect(controller.signal)
-      .then((cleanupFunction) => {
-        typeof cleanupFunction === "function" && cleanupFunction();
-      })
-      .catch(() => {
-        console.error(
-          "You should NEVER throw inside useAsyncEffect. This means the cleanup function will not run, which can cause unintended side effects. Please wrap your useAsyncEffect function in a try/catch."
-        );
-      });
+    const effectPromise = effect(controller.signal).catch(() => {
+      console.error(
+        "You should NEVER throw inside useAsyncEffect. This means the cleanup function will not run, which can cause unintended side effects. Please wrap your useAsyncEffect function in a try/catch."
+      );
+    });
 
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      runCleanup();
+
+      async function runCleanup() {
+        const cleanupFunction = await effectPromise;
+        if (cleanupFunction) {
+          cleanupFunction();
+        }
+      }
+    };
   }, deps);
 }
 

--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -7,15 +7,20 @@ type CleanupFunction = () => void;
  *
  * @param effect
  * @param deps
- * @param cleanup
  */
 function useAsyncEffect(effect: Effect, deps?: DependencyList) {
   useEffect(() => {
     const controller = new AbortController();
 
-    effect(controller.signal).then((cleanupFunction) => {
-      typeof cleanupFunction === "function" && cleanupFunction();
-    });
+    effect(controller.signal)
+      .then((cleanupFunction) => {
+        typeof cleanupFunction === "function" && cleanupFunction();
+      })
+      .catch(() => {
+        console.error(
+          "You should NEVER throw inside useAsyncEffect. This means the cleanup function will not run, which can cause unintended side effects. Please wrap your useAsyncEffect function in a try/catch."
+        );
+      });
 
     return () => controller.abort();
   }, deps);


### PR DESCRIPTION
As per #1142, this PR adds the useAsyncEffect hook.

It turns out that cancelling promises with an AbortController is impossible in JS. Instead, this code gives the user the option to cancel their own effect function by providing an AbortSignal to them.