### PR TITLE
fix: keyup cannot be detected when blocked by alert etc.

### DIFF
--- a/data/docs/useKeys.md
+++ b/data/docs/useKeys.md
@@ -26,7 +26,7 @@ export default function App() {
     ["ControlLeft", "KeyS"],
     () => {
       alert("you presses ctrlLeft + s");
-      setFirstCallbackCallCount(firstCallbackCallCount + 1);
+      setFirstCallbackCallCount((curr) => curr + 1);
     },
     {
       target: containerRef,
@@ -35,7 +35,7 @@ export default function App() {
   );
   useKeys(
     ["m", "r"],
-    event => {
+    (event) => {
       // event.stopPropagation();
       console.log("here you go m and r");
     },

--- a/packages/rooks/src/__tests__/useKeys.spec.tsx
+++ b/packages/rooks/src/__tests__/useKeys.spec.tsx
@@ -20,7 +20,7 @@ describe("useKeys", () => {
       const documentRef = useRef(document);
       const inputRef = useRef(null);
       const [isEventActive, setIsEventActive] = useState(true);
-      // eslint-disable-next-line @typescript-eslint/naming-convention, react/hook-use-state
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       const [testValue, _setTestValue] = useState(0);
       const [firstCallbackCallCount, setFirstCallbackCallCount] = useState(0);
       useKeys(
@@ -74,10 +74,12 @@ describe("useKeys", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKeys).toBeDefined();
   });
 
   it("should trigger the calback when pressed m + r", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const firstcallbackP = getByTestId(
       container as HTMLElement,
@@ -95,6 +97,7 @@ describe("useKeys", () => {
   });
 
   it("should trigger the callback when pressed ctrlLeft + s", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
 
     const firstcallbackP = getByTestId(
@@ -113,6 +116,7 @@ describe("useKeys", () => {
   });
 
   it("should not trigger whenever 'when ' value is false and trigger whenever'when' value is true", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
 
     const firstcallbackP = getByTestId(
@@ -177,6 +181,7 @@ describe("useKeys: continuous mode", () => {
   afterEach(cleanup);
 
   it("should trigger continuously whenever 'continuous' is true", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
 
     const testValueElement = getByTestId(container as HTMLElement, "value");

--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -134,6 +134,38 @@ function useKeys(
 
     return noop;
   }, [when, target, keysList, handleKeyDown, handleKeyUp]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const originalAlert = window.alert;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      window.alert = (message?: any) => {
+        for (const identifier of keysList) {
+          PressedKeyMapping[identifier] = undefined;
+        }
+        return originalAlert(message);
+      };
+
+      const originalConfirm = window.confirm;
+      window.confirm = (message?: string | undefined) => {
+        for (const identifier of keysList) {
+          PressedKeyMapping[identifier] = undefined;
+        }
+        return originalConfirm(message);
+      };
+
+      const originalPrompt = window.prompt;
+      window.prompt = (
+        message?: string | undefined,
+        _default?: string | undefined
+      ) => {
+        for (const identifier of keysList) {
+          PressedKeyMapping[identifier] = undefined;
+        }
+        return originalPrompt(message, _default);
+      };
+    }
+  }, [PressedKeyMapping, keysList]);
 }
 
 export { useKeys };

--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -22,6 +22,10 @@ type Options = {
    * remove the eventlistener if any
    */
   when?: boolean;
+  /**
+   * opt-in to prevent alert, confirm and prompt from causing the eventlistener to lose track of keyup events.
+   */
+  preventLostKeyup?: boolean;
 };
 /**
  * defaultOptions which will be merged with passed in options
@@ -45,7 +49,7 @@ function useKeys(
   options?: Options
 ): void {
   const internalOptions = { ...defaultOptions, ...options };
-  const { target, when, continuous } = internalOptions;
+  const { target, when, continuous, preventLostKeyup } = internalOptions;
   const savedCallback = useRef<(event: KeyboardEvent) => void>(callback);
   /**
    * PressedKeyMapping will do the bookkeeping the pressed keys
@@ -136,6 +140,7 @@ function useKeys(
   }, [when, target, keysList, handleKeyDown, handleKeyUp]);
 
   useEffect(() => {
+    if (preventLostKeyup !== true) return noop;
     if (typeof window !== "undefined") {
       const originalAlert = window.alert;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -164,8 +169,15 @@ function useKeys(
         }
         return originalPrompt(message, _default);
       };
+
+      return () => {
+        window.alert = originalAlert;
+        window.confirm = originalConfirm;
+        window.prompt = originalPrompt;
+      };
     }
-  }, [PressedKeyMapping, keysList]);
+    return noop;
+  }, [PressedKeyMapping, keysList, preventLostKeyup]);
 }
 
 export { useKeys };


### PR DESCRIPTION
useKeys seems to work fine except when interrupted by `alert`. 
After some investigation, it seems that `alert` will block js execution and there is no way but to overwrite `window.alert`.

Also, I could not find a way to include the alert in the test, so I could not add new test cases.

## References
- https://stackoverflow.com/a/4867114/8776028
- https://stackoverflow.com/a/13593319/8776028

---
close #1018 