### PR TITLE
chore: twist eslint setup and dependency specification

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,9 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
-  "eslint.workingDirectories": ["./"],
+  "eslint.workingDirectories": [
+    "./",
+    { "pattern": "./apps/*/" },
+    { "pattern": "./packages/*/" }
+  ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {

--- a/apps/website/.eslintignore
+++ b/apps/website/.eslintignore
@@ -1,0 +1,1 @@
+.eslintrc.js

--- a/apps/website/.eslintrc.js
+++ b/apps/website/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   root: true,
   extends: ["custom"],
   parserOptions: {
-    project: ["./tsconfig.json"],
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
   },
 };

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -17,7 +17,7 @@
     "react-is": "^18.2.0",
     "react-syntax-highlighter": "^15.5.0",
     "remark-remove-comments": "^0.2.0",
-    "rooks": "6.2.0"
+    "rooks": "*"
   },
   "devDependencies": {
     "@mdx-js/loader": "^2.1.2",
@@ -33,7 +33,6 @@
     "remark-gfm": "^3.0.1",
     "remark-html": "^15.0.1",
     "remark-remove-comments": "^0.2.0",
-    "rooks": "6.2.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -17,7 +17,7 @@
     "react-is": "^18.2.0",
     "react-syntax-highlighter": "^15.5.0",
     "remark-remove-comments": "^0.2.0",
-    "rooks": "*"
+    "rooks": "6.2.0"
   },
   "devDependencies": {
     "@mdx-js/loader": "^2.1.2",
@@ -33,6 +33,7 @@
     "remark-gfm": "^3.0.1",
     "remark-html": "^15.0.1",
     "remark-remove-comments": "^0.2.0",
+    "rooks": "6.2.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   },


### PR DESCRIPTION
- fixed some eslint setup problems
- use `*` to specify the local `packages/rooks` in website dependencies

This way, you can just rebuild rooks to test it locally by:
```sh
# terminal 1
yarn dev
# terminal 2
yarn --cwd packages/rooks build
```

Please tell me if you disagree with any of these changes.