### PR TITLE
fix: remove code components for mdx

### DIFF
--- a/apps/website/src/components/MDXRenderer/components.tsx
+++ b/apps/website/src/components/MDXRenderer/components.tsx
@@ -1,6 +1,7 @@
 import { Spacer, Text } from "@nextui-org/react";
 import Image from "next/image";
 import {
+  ComponentProps,
   ComponentPropsWithoutRef,
   PropsWithRef,
   ReactElement,
@@ -10,6 +11,7 @@ import Highlight, { defaultProps } from "prism-react-renderer";
 import theme from "prism-react-renderer/themes/dracula";
 import { styled } from "@stitches/react";
 import { Sandpack } from "@codesandbox/sandpack-react";
+import { MDXProvider } from "@mdx-js/react";
 import {
   FirstLevelHeadline,
   SecondLevelHeadline,
@@ -115,7 +117,7 @@ const StyledTable = styled("table", {
   },
 });
 
-export const components = {
+export const components: ComponentProps<typeof MDXProvider>["components"] = {
   img: ResponsiveImage,
   h1: (props: ComponentPropsWithoutRef<"h1">) => (
     <FirstLevelHeadline {...props} />
@@ -128,6 +130,5 @@ export const components = {
   ),
   p: (props: ComponentPropsWithoutRef<"p">) => <Text as="p" {...props} />,
   pre: Code,
-  code: Code,
   table: StyledTable,
 };


### PR DESCRIPTION
I am not familiar with mdx and not sure about the difference between `code` and `pre`, but removing `code` seems to fix the issue.

Before:
<img width="815" alt="スクリーンショット 2022-08-04 16 44 41" src="https://user-images.githubusercontent.com/17402261/182833986-8a24f479-0204-40dd-a3c7-ef7cca5eff2d.png">


After:
<img width="806" alt="スクリーンショット 2022-08-04 20 12 14" src="https://user-images.githubusercontent.com/17402261/182833919-8d0961c6-15f4-4bdb-97b7-03a3ccd773f5.png">


close #1208