### PR TITLE
chore: resolve eslint error

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -45,7 +45,6 @@ module.exports = {
     "import/no-unassigned-import": 0,
     "import/no-unresolved": 0,
     "max-nested-callbacks": 0,
-    "unicorn/no-reduce": 0,
     "import/no-extraneous-dependencies": 0,
     radix: 0,
     "func-style": 0,

--- a/packages/rooks/.eslintignore
+++ b/packages/rooks/.eslintignore
@@ -1,0 +1,1 @@
+.eslintrc.js

--- a/packages/rooks/.eslintrc.js
+++ b/packages/rooks/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ["custom"],
   parserOptions: {
-    project: ["./tsconfig.json"],
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
   },
 };

--- a/packages/rooks/src/__tests__/shared.spec.ts
+++ b/packages/rooks/src/__tests__/shared.spec.ts
@@ -26,141 +26,167 @@ import { useWindowSize } from "../hooks/useWindowSize";
 
 describe("useBoundingClientRect", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useBoundingclientrect).toBeDefined();
   });
 });
 
 describe("useBoundingclientrectRef", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useBoundingclientrectRef).toBeDefined();
   });
 });
 
 describe("useDidUpdate", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useDidUpdate).toBeDefined();
   });
 });
 
 describe("useForkRef", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useForkRef).toBeDefined();
   });
 });
 
 describe("useInput", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useInput).toBeDefined();
   });
 });
 
 describe("useIntersectionObserverRef", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useIntersectionObserverRef).toBeDefined();
   });
 });
 
 describe("useIsomorphicEffect", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useIsomorphicEffect).toBeDefined();
   });
 });
 
 describe("useKey", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useKey).toBeDefined();
   });
 });
 
 describe("useKeys", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useKey).toBeDefined();
   });
 });
 
 describe("useMouse", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useMouse).toBeDefined();
   });
 });
 describe("useMutationObserver", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useMutationObserver).toBeDefined();
   });
 });
 describe("useMutationObserverRef", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useMutationObserverRef).toBeDefined();
   });
 });
 describe("useNavigatorLanguage", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useNavigatorLanguage).toBeDefined();
   });
 });
 describe("useOnWindowResize", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useOnWindowResize).toBeDefined();
   });
 });
 describe("useOnWindowScroll", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useOnWindowScroll).toBeDefined();
   });
 });
 describe("useOnline", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useOnline).toBeDefined();
   });
 });
 describe("useOutsideClick", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useOutsideClick).toBeDefined();
   });
 });
 describe("useOutsideClickRef", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useOutsideClickRef).toBeDefined();
   });
 });
 describe("useRaf", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useRaf).toBeDefined();
   });
 });
 describe("useSelect", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useSelect).toBeDefined();
   });
 });
 describe("useSelectableList", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useSelectableList).toBeDefined();
   });
 });
 describe("useThrottle", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useThrottle).toBeDefined();
   });
 });
 
 describe("useToggle", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useToggle).toBeDefined();
   });
 });
 describe("useUndoState", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useUndoState).toBeDefined();
   });
 });
 describe("useWillUnmount", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useWillUnmount).toBeDefined();
   });
 });
 describe("useWindowSize", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useWindowSize).toBeDefined();
   });
 });

--- a/packages/rooks/src/__tests__/useCountdown.spec.tsx
+++ b/packages/rooks/src/__tests__/useCountdown.spec.tsx
@@ -4,6 +4,7 @@ jest.useFakeTimers();
 
 describe("useCountdown", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useCountdown).toBeDefined();
   });
   // it('works', () => {

--- a/packages/rooks/src/__tests__/useCounter.spec.tsx
+++ b/packages/rooks/src/__tests__/useCounter.spec.tsx
@@ -6,14 +6,17 @@ const { act } = TestRenderer;
 
 describe("useCounter", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useCounter).toBeDefined();
   });
   it("should initialize correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useCounter(0));
 
     expect(result.current.value).toBe(0);
   });
   it("should increment", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useCounter(0));
 
     act(() => {
@@ -35,6 +38,7 @@ describe("useCounter", () => {
     expect(result.current.value).toBe(2);
   });
   it("should decrement", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useCounter(0));
     act(() => {
       result.current.decrement();
@@ -54,6 +58,7 @@ describe("useCounter", () => {
     expect(result.current.value).toBe(-2);
   });
   it("should incrementBy", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useCounter(5));
 
     act(() => {
@@ -75,6 +80,7 @@ describe("useCounter", () => {
     expect(result.current.value).toBe(26);
   });
   it("should decrementBy", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useCounter(5));
 
     act(() => {

--- a/packages/rooks/src/__tests__/useDebounce.spec.tsx
+++ b/packages/rooks/src/__tests__/useDebounce.spec.tsx
@@ -10,6 +10,7 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("useDebounce", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useDebounce).toBeDefined();
   });
 });

--- a/packages/rooks/src/__tests__/useDebouncedValue.spec.ts
+++ b/packages/rooks/src/__tests__/useDebouncedValue.spec.ts
@@ -10,10 +10,12 @@ describe("useDebouncedValue", () => {
     jest.useRealTimers();
   });
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useDebouncedValue).toBeDefined();
   });
 
   it("should initialize with first value if timeout is not reached and initializeWithNull is false", () => {
+    expect.hasAssertions();
     const mockValue = "mock_value";
     const { result } = renderHook(() => useDebouncedValue(mockValue, 200));
 
@@ -23,6 +25,7 @@ describe("useDebouncedValue", () => {
   });
 
   it("should return null if the timeout has not been reached and initializeWithNull is true", () => {
+    expect.hasAssertions();
     const mockValue = "mock_value";
 
     const { result } = renderHook(() =>
@@ -35,6 +38,7 @@ describe("useDebouncedValue", () => {
   });
 
   it("should returns updated value if the timeout has been reached and initializeWithNull is true", () => {
+    expect.hasAssertions();
     const mockValue = "mock_value";
     let result;
     act(() => {
@@ -57,6 +61,7 @@ describe("useDebouncedValue", () => {
   });
 
   it("should respect the timeout value if initializedWithNull is true", () => {
+    expect.hasAssertions();
     const mockValue = "mock_value";
     const mockTimeout = 200;
 
@@ -85,6 +90,7 @@ describe("useDebouncedValue", () => {
     ["mock_item_1", "mock_item_2"],
     { another_key: "another_value", key: "value" },
   ])("should work with different types of values", (mockValue) => {
+    expect.hasAssertions();
     const { result } = renderHook(() =>
       useDebouncedValue(mockValue, 200, { initializeWithNull: true })
     );

--- a/packages/rooks/src/__tests__/useDidMount.spec.ts
+++ b/packages/rooks/src/__tests__/useDidMount.spec.ts
@@ -4,10 +4,10 @@ import { useDidMount } from "../hooks/useDidMount";
 
 describe("useDidMount", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useDidMount).toBeDefined();
   });
   describe("base", () => {
-    // eslint-disable-next-line unicorn/consistent-function-scoping
     let useHook = () => {
       return {
         value: 0,

--- a/packages/rooks/src/__tests__/useDidUpdate.spec.tsx
+++ b/packages/rooks/src/__tests__/useDidUpdate.spec.tsx
@@ -6,7 +6,6 @@ import React, { useState } from "react";
 import { useDidUpdate } from "../hooks/useDidUpdate";
 
 describe("useDidUpdate", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let App = () => <div />;
   beforeEach(() => {
     App = () => {
@@ -82,7 +81,6 @@ describe("useDidUpdate", () => {
 });
 
 describe("useDidUpdate tests", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let App = () => <div />;
   beforeEach(() => {
     App = () => {

--- a/packages/rooks/src/__tests__/useDidUpdate.spec.tsx
+++ b/packages/rooks/src/__tests__/useDidUpdate.spec.tsx
@@ -33,22 +33,26 @@ describe("useDidUpdate", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useDidUpdate).toBeDefined();
   });
 
   it("initializes correctly", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const renderedElement = getByTestId("element");
     expect(Number.parseInt(String(renderedElement.textContent))).toBe(0);
   });
 
   it("does not get called on mount", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const renderedElement = getByTestId("element");
     expect(Number.parseInt(String(renderedElement.textContent))).toBe(0);
   });
 
   it("gets called if a state value changes", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const renderedElement = getByTestId("element");
     const valueElement = getByTestId("value");
@@ -62,6 +66,7 @@ describe("useDidUpdate", () => {
   });
 
   it("does not get called if state value has not updated", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const renderedElement = getByTestId("element");
     const valueElement = getByTestId("value");
@@ -108,6 +113,7 @@ describe("useDidUpdate tests", () => {
   afterEach(cleanup);
 
   it("warns if conditionals is empty array", () => {
+    expect.hasAssertions();
     const spy = jest.spyOn(global.console, "warn");
     render(<App />);
     // eslint-disable-next-line jest/prefer-called-with

--- a/packages/rooks/src/__tests__/useDimensionsRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useDimensionsRef.spec.tsx
@@ -10,6 +10,7 @@ import { DOMRectPolyfill } from "../utils/domrect-polyfill";
 
 describe("useDimensionsRef", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useDimensionsRef).toBeDefined();
   });
 
@@ -30,6 +31,7 @@ describe("useDimensionsRef", () => {
         .mockImplementation(() => new window.DOMRect(0, 0, 120, 300));
       jest
         .spyOn(window, "requestAnimationFrame")
+        // eslint-disable-next-line @typescript-eslint/ban-types
         .mockImplementation((callback: Function) => callback());
 
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -56,6 +58,7 @@ describe("useDimensionsRef", () => {
     });
 
     it("gets called if a state value changes", () => {
+      expect.hasAssertions();
       const { getByTestId } = render(<App />);
       const valueElement = getByTestId("value");
       expect(valueElement.textContent).toBe("120");

--- a/packages/rooks/src/__tests__/useDocumentEventListener.spec.tsx
+++ b/packages/rooks/src/__tests__/useDocumentEventListener.spec.tsx
@@ -10,9 +10,11 @@ const { act } = TestRenderer;
 
 describe("useDocumentEventListener", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useDocumentEventListener).toBeDefined();
   });
   it("should return a undefined", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() =>
       useDocumentEventListener("click", () => {
         console.log("clicked");
@@ -36,11 +38,13 @@ describe("useDocumentEventListener jsx", () => {
   });
 
   it("should not call callback by default", () => {
+    expect.hasAssertions();
     render(<TestJSX />);
     expect(mockCallback).toHaveBeenCalledTimes(0);
   });
 
   it("should not call callback when event fires", () => {
+    expect.hasAssertions();
     render(<TestJSX />);
     act(() => {
       fireEvent.click(document);
@@ -67,12 +71,14 @@ describe("useDocumentEventListener state variables", () => {
   });
 
   it("should not call callback by default", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(Number.parseInt(valueElement.innerHTML)).toBe(0);
   });
 
   it("should not call callback when event fires", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(Number.parseInt(valueElement.innerHTML)).toBe(0);

--- a/packages/rooks/src/__tests__/useDocumentEventListener.spec.tsx
+++ b/packages/rooks/src/__tests__/useDocumentEventListener.spec.tsx
@@ -24,9 +24,7 @@ describe("useDocumentEventListener", () => {
 });
 
 describe("useDocumentEventListener jsx", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let mockCallback = () => {};
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let TestJSX = () => null;
   beforeEach(() => {
     mockCallback = jest.fn(() => {});
@@ -58,7 +56,6 @@ describe("useDocumentEventListener jsx", () => {
 });
 
 describe("useDocumentEventListener state variables", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let TestJSX = () => <div />;
   beforeEach(() => {
     TestJSX = () => {

--- a/packages/rooks/src/__tests__/useEffectOnceWhen.spec.tsx
+++ b/packages/rooks/src/__tests__/useEffectOnceWhen.spec.tsx
@@ -30,6 +30,7 @@ describe("useEffectOnceWhen", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useEffectOnceWhen).toBeDefined();
   });
 

--- a/packages/rooks/src/__tests__/useEffectOnceWhen.spec.tsx
+++ b/packages/rooks/src/__tests__/useEffectOnceWhen.spec.tsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 import { useEffectOnceWhen } from "../hooks/useEffectOnceWhen";
 
 describe("useEffectOnceWhen", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let useHook = function () {
     const [value, setValue] = useState(0);
     const [isEnabled, setIsEnabled] = useState(false);

--- a/packages/rooks/src/__tests__/useEventListenerRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useEventListenerRef.spec.tsx
@@ -24,7 +24,6 @@ describe("useEventListenerRef", () => {
 });
 
 describe("useEventListenerRef jsx", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let mockCallback = () => {};
   let TestJSX = () => <div />;
   beforeEach(() => {

--- a/packages/rooks/src/__tests__/useEventListenerRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useEventListenerRef.spec.tsx
@@ -10,9 +10,11 @@ const { act } = TestRenderer;
 
 describe("useEventListenerRef", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useEventListenerRef).toBeDefined();
   });
   it("should return a callback ref", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() =>
       useEventListenerRef("click", () => {
         console.log("clicked");
@@ -40,11 +42,13 @@ describe("useEventListenerRef jsx", () => {
   });
 
   it("should not call callback by default", () => {
+    expect.hasAssertions();
     render(<TestJSX />);
     expect(mockCallback).toHaveBeenCalledTimes(0);
   });
 
   it("should not call callback when event fires", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const displayElement = getByTestId(container as HTMLElement, "element");
     act(() => {
@@ -79,12 +83,14 @@ describe("useEventListenerRef state variables", () => {
   });
 
   it("should not call callback by default", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(Number.parseInt(valueElement.innerHTML)).toBe(0);
   });
 
   it("should not call callback when event fires", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const displayElement = getByTestId(container as HTMLElement, "element");
     const valueElement = getByTestId(container as HTMLElement, "value");

--- a/packages/rooks/src/__tests__/useForkRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useForkRef.spec.tsx
@@ -26,10 +26,12 @@ describe("useForkRef", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useForkRef).toBeDefined();
   });
 
   it("should be called on mouse events", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const displayElement = getByTestId(container as HTMLElement, "element");
     act(() => {

--- a/packages/rooks/src/__tests__/useForkRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useForkRef.spec.tsx
@@ -8,7 +8,6 @@ import { useForkRef } from "../hooks/useForkRef";
 const { act } = TestRenderer;
 
 describe("useForkRef", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let mockCallback = () => {};
   let TestJSX = () => <div />;
   beforeEach(() => {

--- a/packages/rooks/src/__tests__/useFreshRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useFreshRef.spec.tsx
@@ -41,9 +41,11 @@ describe.skip("useFreshRef", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useFreshRef).toBeDefined();
   });
   it("should increment correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(useHook);
     act(() => {
       jest.advanceTimersByTime(5_000);

--- a/packages/rooks/src/__tests__/useFreshTick.spec.tsx
+++ b/packages/rooks/src/__tests__/useFreshTick.spec.tsx
@@ -61,9 +61,11 @@ describe.skip("useFreshTick", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useFreshTick).toBeDefined();
   });
   it("should increment correctly", () => {
+    expect.hasAssertions();
     const { result, unmount } = renderHook(() => useHook());
     void act(() => {
       jest.advanceTimersByTime(5_000);

--- a/packages/rooks/src/__tests__/useFullscreen.spec.tsx
+++ b/packages/rooks/src/__tests__/useFullscreen.spec.tsx
@@ -3,6 +3,7 @@ import { useFullscreen } from "../hooks/useFullscreen";
 
 describe("useFullscreen", () => {
   it("should forward requestFullscreenOptions to requestFullscreen", () => {
+    expect.hasAssertions();
     document.exitFullscreen = jest.fn();
     const element = { requestFullscreen: jest.fn() };
     const mockRequestFullscreenOptions = { navigationUI: "show" };

--- a/packages/rooks/src/__tests__/useGetIsMounted.spec.ts
+++ b/packages/rooks/src/__tests__/useGetIsMounted.spec.ts
@@ -3,22 +3,26 @@ import { useGetIsMounted } from "../hooks/useGetIsMounted";
 
 describe("useGetIsMounted", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useGetIsMounted).toBeDefined();
   });
 
   it("should return a function", () => {
+    expect.hasAssertions();
     const hook = renderHook(() => useGetIsMounted());
 
     expect(typeof hook.result.current).toBe("function");
   });
 
   it("should return true if component is mounted", () => {
+    expect.hasAssertions();
     const hook = renderHook(() => useGetIsMounted());
 
     expect(hook.result.current()).toBe(true);
   });
 
   it("should return false if component is unmounted", () => {
+    expect.hasAssertions();
     const hook = renderHook(() => useGetIsMounted());
 
     hook.unmount();

--- a/packages/rooks/src/__tests__/useInput.spec.tsx
+++ b/packages/rooks/src/__tests__/useInput.spec.tsx
@@ -25,6 +25,7 @@ describe("useInput", () => {
     afterEach(cleanup);
 
     it("memo", () => {
+      expect.hasAssertions();
       const { result, rerender } = renderHook(() => useInput("hello"));
       const onChangeBeforeRerender = result.current.onChange;
       rerender();
@@ -46,14 +47,17 @@ describe("useInput", () => {
     });
 
     it("should be defined", () => {
+      expect.hasAssertions();
       expect(useInput).toBeDefined();
     });
     it("sets initial value correctly", () => {
+      expect.hasAssertions();
       const { getByTestId } = render(<App />);
       const inputElement = getByTestId("input-element") as HTMLInputElement;
       expect(inputElement.value).toBe("hello");
     });
     it("updates value correctly", () => {
+      expect.hasAssertions();
       const { getByTestId } = render(<App />);
       const inputElement = getByTestId("input-element") as HTMLInputElement;
       const displayElement = getByTestId("display-element") as HTMLInputElement;
@@ -108,6 +112,7 @@ describe("useInput", () => {
     afterEach(cleanup);
 
     it("does not update if validate returns false", () => {
+      expect.hasAssertions();
       const { getByTestId } = render(<App />);
       const inputElement = getByTestId("input-element") as HTMLInputElement;
       act(() => {
@@ -120,6 +125,7 @@ describe("useInput", () => {
       expect(Number.parseInt(inputElement.value)).toBe(5);
     });
     it("updates if validate returns true", () => {
+      expect.hasAssertions();
       const { getByTestId } = render(<App />);
       const inputElement = getByTestId("input-element") as HTMLInputElement;
       act(() => {
@@ -132,6 +138,7 @@ describe("useInput", () => {
       expect(Number.parseInt(inputElement.value)).toBe(9);
     });
     it("validate can be used to compare possible newvalue with current value", () => {
+      expect.hasAssertions();
       const { getByTestId } = render(
         <App
           validate={(newValue, currentValue) => newValue % currentValue !== 0}
@@ -176,6 +183,7 @@ describe("useInput", () => {
     afterEach(cleanup);
 
     it("updates value of input if initial value changes", () => {
+      expect.hasAssertions();
       const { getByTestId } = render(<App />);
       const inputElement1 = getByTestId("input-element1") as HTMLInputElement;
       const inputElement2 = getByTestId("input-element2") as HTMLInputElement;

--- a/packages/rooks/src/__tests__/useIntervalWhen.spec.tsx
+++ b/packages/rooks/src/__tests__/useIntervalWhen.spec.tsx
@@ -49,9 +49,11 @@ describe("useIntervalWhen", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useIntervalWhen).toBeDefined();
   });
   it("should start timer when started with start function", () => {
+    expect.hasAssertions();
     jest.useFakeTimers();
     const { result } = renderHook(() => useHook(true));
     void act(() => {
@@ -63,6 +65,7 @@ describe("useIntervalWhen", () => {
   });
 
   it("should call the callback eagerly", () => {
+    expect.hasAssertions();
     jest.useFakeTimers();
     const { result } = renderHook(() => useHook(true, EAGER));
     // The value was already incremented because we use useIntervalWhen in EAGER mode

--- a/packages/rooks/src/__tests__/useIntervalWhen.spec.tsx
+++ b/packages/rooks/src/__tests__/useIntervalWhen.spec.tsx
@@ -14,7 +14,6 @@ type UseHook = (
   currentValue: number;
 };
 describe("useIntervalWhen", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let useHook: UseHook = () => ({
     currentValue: 5,
   });
@@ -24,7 +23,7 @@ describe("useIntervalWhen", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.spyOn(global, "setInterval");
-    useHook = function (when: boolean, eager: boolean = false) {
+    useHook = function (when: boolean, eager = false) {
       const [currentValue, setCurrentValue] = useState(0);
       function increment() {
         setCurrentValue(currentValue + 1);

--- a/packages/rooks/src/__tests__/useKey.spec.tsx
+++ b/packages/rooks/src/__tests__/useKey.spec.tsx
@@ -53,10 +53,12 @@ describe("useKey", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKey).toBeDefined();
   });
 
   it("should trigger the calback when pressed on document or target", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const inputElement = getByTestId(container as HTMLElement, "input");
@@ -112,10 +114,12 @@ describe("non array input", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKey).toBeDefined();
   });
 
   it("should trigger the calback when pressed on document or target", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const inputElement = getByTestId(container as HTMLElement, "input");
@@ -188,10 +192,12 @@ describe("when", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKey).toBeDefined();
   });
 
   it("should not trigger whenever 'when ' value is false and trigger when 'when' is true", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     console.log("container.innerHTML before", container.innerHTML);
     const valueElement = getByTestId(container as HTMLElement, "value");

--- a/packages/rooks/src/__tests__/useKeyBindings.spec.tsx
+++ b/packages/rooks/src/__tests__/useKeyBindings.spec.tsx
@@ -59,10 +59,12 @@ describe("useKeyBindings", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKeyBindings).toBeDefined();
   });
 
   it("should trigger the calback when pressed on document or target", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const inputElement = getByTestId(container as HTMLElement, "input");

--- a/packages/rooks/src/__tests__/useKeyRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useKeyRef.spec.tsx
@@ -44,10 +44,12 @@ describe("useKeyRef", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKeyRef).toBeDefined();
   });
 
   it("should trigger the calback when pressed on document or target", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const inputElement = getByTestId(container as HTMLElement, "input");
@@ -93,10 +95,12 @@ describe("non array input", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKeyRef).toBeDefined();
   });
 
   it("should trigger the calback when pressed on document or target", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const inputElement = getByTestId(container as HTMLElement, "input");
@@ -154,10 +158,12 @@ describe("when", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useKeyRef).toBeDefined();
   });
 
   it("should not trigger whenever 'when ' value is false and trigger when 'when' is true", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     console.log("container.innerHTML before", container.innerHTML);
     const valueElement = getByTestId(container as HTMLElement, "value");

--- a/packages/rooks/src/__tests__/useLifecycleLogger.spec.ts
+++ b/packages/rooks/src/__tests__/useLifecycleLogger.spec.ts
@@ -9,9 +9,11 @@ describe("useLifecycleLogger", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useLifecycleLogger).toBeDefined();
   });
   it("should work without arguments", () => {
+    expect.hasAssertions();
     const { unmount } = renderHook(() => useLifecycleLogger());
 
     expect(logSpy).toHaveBeenCalledTimes(1);
@@ -20,6 +22,7 @@ describe("useLifecycleLogger", () => {
     expect(logSpy).toHaveBeenCalledTimes(2);
   });
   it("should log the provided args on mount", () => {
+    expect.hasAssertions();
     const args = ["foo", "bar"];
     const { unmount } = renderHook(() => useLifecycleLogger("Test1", args));
 
@@ -30,6 +33,7 @@ describe("useLifecycleLogger", () => {
   });
 
   it("should log when the component has unmounted", () => {
+    expect.hasAssertions();
     const args = ["foo", "bar"];
     const { unmount } = renderHook(() => useLifecycleLogger("Test2", args));
 
@@ -39,6 +43,7 @@ describe("useLifecycleLogger", () => {
   });
 
   it("should log updates as args change", () => {
+    expect.hasAssertions();
     const { unmount, rerender } = renderHook(
       ({ componentName, args }) => useLifecycleLogger(componentName, args),
       {

--- a/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
@@ -15,6 +15,7 @@ import { useLocalstorageState } from "../hooks/useLocalstorageState";
 
 describe("useLocalstorageState defined", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useLocalstorageState).toBeDefined();
   });
 });
@@ -50,6 +51,7 @@ describe("useLocalstorageState basic", () => {
   afterEach(cleanup);
 
   it("memo", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() =>
       useLocalstorageState("key1", "value")
     );
@@ -64,12 +66,14 @@ describe("useLocalstorageState basic", () => {
   });
 
   it("initializes correctly", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(valueElement.innerHTML).toBe("hello");
   });
 
   it("setting the new value", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const setToNewValueButton = getByTestId(
       container as HTMLElement,
@@ -84,6 +88,7 @@ describe("useLocalstorageState basic", () => {
 
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("unsetting the value", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const unsetValueButton = getByTestId(
       container as HTMLElement,

--- a/packages/rooks/src/__tests__/useMapState.spec.tsx
+++ b/packages/rooks/src/__tests__/useMapState.spec.tsx
@@ -14,13 +14,16 @@ type Map = {
 
 describe("useMapState", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useMapState).toBeDefined();
   });
   it("should initialize correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useMapState<Map, keyof Map>({ a: 1 }));
     expect(result.current[0]).toEqual({ a: 1 });
   });
   it("should set a new value correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1 })
     );
@@ -44,6 +47,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ a: 1, b: 2, c: 2 });
   });
   it("set should update old value correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useMapState<Map, keyof Map>({ a: 1 }));
     act(() => {
       result.current[1].set("a", 2);
@@ -51,6 +55,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ a: 2 });
   });
   it("should set multiple new values correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1 })
     );
@@ -72,6 +77,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ a: 1, b: 2, c: 3, d: 4 });
   });
   it("setMultiple should update old value correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1 })
     );
@@ -100,6 +106,7 @@ describe("useMapState", () => {
     expect(result.current[1].has("c")).toBeTruthy();
   });
   it("should remove existing values correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1, b: 3 })
     );
@@ -124,6 +131,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ b: 3 });
   });
   it("should work when value to remove does not exist", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1, b: 2, c: 3 })
     );
@@ -133,6 +141,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ a: 1, b: 2, c: 3 });
   });
   it("should remove multiple existing values correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1, b: 3, c: 5 })
     );
@@ -155,6 +164,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ b: 3, e: 6 });
   });
   it("should work when value to removeMultiple does not exist", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1, b: 2, c: 3 })
     );
@@ -164,6 +174,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ a: 1, b: 2, c: 3 });
   });
   it("should work when some values to removeMultiple does not exist", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1, b: 2, c: 3 })
     );
@@ -173,6 +184,7 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({ b: 2, c: 3 });
   });
   it("should removeAll values", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: 1, b: 2, c: 3 })
     );

--- a/packages/rooks/src/__tests__/useMediaMatch.spec.tsx
+++ b/packages/rooks/src/__tests__/useMediaMatch.spec.tsx
@@ -14,6 +14,7 @@ describe("useMediaMatch", () => {
   });
 
   it("should track a boolean", async () => {
+    expect.hasAssertions();
     const matchMedia = jest.fn<MediaQueryList, [string]>();
     const addEventListener = jest.fn<
       void,

--- a/packages/rooks/src/__tests__/useMouse.spec.tsx
+++ b/packages/rooks/src/__tests__/useMouse.spec.tsx
@@ -10,10 +10,12 @@ describe.skip("useMouse", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useMouse).toBeDefined();
   });
 
   it("should default with null values", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useMouse());
     expect(result.current).toBe({
       x: null,

--- a/packages/rooks/src/__tests__/useMutationObserver.spec.tsx
+++ b/packages/rooks/src/__tests__/useMutationObserver.spec.tsx
@@ -4,6 +4,7 @@ import { useMutationObserver } from "../hooks/useMutationObserver";
 
 describe("useMutationObserver", () => {
   it("should watch for children changes being made to the DOM node", () => {
+    expect.hasAssertions();
     let id = 1;
     const TestComp = () => {
       const ref = useRef<HTMLUListElement>(null);
@@ -16,7 +17,6 @@ describe("useMutationObserver", () => {
 
       useMutationObserver(ref, (mutations) => {
         for (const mutation of mutations) {
-          // eslint-disable-next-line jest/no-conditional-in-test
           if (mutation.type === "childList") {
             for (const node of Array.from(mutation.addedNodes)) {
               console.log(`${node.textContent} has been added to todo list.`);
@@ -57,7 +57,6 @@ describe("useMutationObserver", () => {
           <div ref={ref}>status: coding</div>
           <button
             onClick={() => {
-              // eslint-disable-next-line jest/no-conditional-in-test
               if (ref.current) {
                 ref.current.textContent = "status: Gaming";
               }
@@ -74,9 +73,7 @@ describe("useMutationObserver", () => {
     const button = screen.getByText(/start to play game!/iu);
     fireEvent.click(button);
     await waitFor(() => {
-      // eslint-disable-next-line jest/prefer-called-with
       expect(listener1).toHaveBeenCalled();
-      // eslint-disable-next-line jest/prefer-called-with
       expect(listener2).toHaveBeenCalled();
     });
   });
@@ -99,7 +96,6 @@ describe("useMutationObserver", () => {
           <div ref={ref}>status: coding</div>
           <button
             onClick={() => {
-              // eslint-disable-next-line jest/no-conditional-in-test
               if (ref.current) {
                 ref.current.textContent = "status: Gaming";
               }
@@ -126,9 +122,7 @@ describe("useMutationObserver", () => {
     const TestComp = () => {
       const ref = useRef<HTMLDivElement>(null);
 
-      // eslint-disable-next-line unicorn/consistent-function-scoping
       const listener = (_: unknown, observer: MutationObserver) => {
-        // eslint-disable-next-line jest/no-conditional-in-test
         if (calls === 1) {
           observer.disconnect();
         }
@@ -143,7 +137,6 @@ describe("useMutationObserver", () => {
           <div ref={ref}>status: coding</div>
           <button
             onClick={() => {
-              // eslint-disable-next-line jest/no-conditional-in-test
               if (ref.current) {
                 ref.current.textContent = "status: Gaming";
               }

--- a/packages/rooks/src/__tests__/useMutilSelectableList.spec.ts
+++ b/packages/rooks/src/__tests__/useMutilSelectableList.spec.ts
@@ -12,6 +12,7 @@ describe("useMultiSelectableList", () => {
 
   describe("matchSelection", () => {
     it("console.warn", () => {
+      expect.hasAssertions();
       act(() => {
         result.current[1].matchSelection({ index: 1, value: 2 });
       });
@@ -29,6 +30,7 @@ describe("useMultiSelectableList", () => {
     });
 
     it("match index", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useMultiSelectableList([1, 2, 3], [0, 1], true)
       );
@@ -39,6 +41,7 @@ describe("useMultiSelectableList", () => {
     });
 
     it("match value", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useMultiSelectableList([1, 2, 3], [0, 1], true)
       );
@@ -51,6 +54,7 @@ describe("useMultiSelectableList", () => {
 
   describe("updateSelections", () => {
     it("set by index", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useMultiSelectableList([1, 2, 3], [0], true)
       );
@@ -63,6 +67,7 @@ describe("useMultiSelectableList", () => {
       expect(currentValues).toEqual([2, 3]);
     });
     it("set by value", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useMultiSelectableList([1, 2, 3], [0], true)
       );
@@ -76,6 +81,7 @@ describe("useMultiSelectableList", () => {
     });
 
     it("set by value fail", () => {
+      expect.hasAssertions();
       const [beforeIndices, beforeValue] = result.current[0];
       act(() => {
         result.current[1].updateSelections({ values: [22] })();
@@ -93,6 +99,7 @@ describe("useMultiSelectableList", () => {
     });
 
     it("console.warn", () => {
+      expect.hasAssertions();
       act(() => {
         result.current[1].updateSelections({ indices: [1], values: [2] })();
       });
@@ -112,6 +119,7 @@ describe("useMultiSelectableList", () => {
 
   describe("toggleSelection", () => {
     it("should toggle selected index", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useMultiSelectableList([1, 2, 3], [0], true)
       );
@@ -124,6 +132,7 @@ describe("useMultiSelectableList", () => {
     });
 
     it("shouldn't toggle selected index when allowUnselected = false", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useMultiSelectableList([1, 2, 3], [0], false)
       );
@@ -143,6 +152,7 @@ describe("useMultiSelectableList", () => {
       (console.warn as jest.Mock).mockReset();
     });
     it("should toggle selected value", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useMultiSelectableList([1, 2, 3], [0], true)
       );
@@ -157,6 +167,7 @@ describe("useMultiSelectableList", () => {
     });
 
     it("console.warn", () => {
+      expect.hasAssertions();
       act(() => {
         result.current[1].toggleSelection({ index: 1, value: 2 })();
       });

--- a/packages/rooks/src/__tests__/useNavigatorLanguage.spec.tsx
+++ b/packages/rooks/src/__tests__/useNavigatorLanguage.spec.tsx
@@ -12,10 +12,12 @@ describe("useNavigatorLanguage", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useNavigatorLanguage).toBeDefined();
   });
 
   it("should get the navigator language", () => {
+    expect.hasAssertions();
     languageGetter.mockReturnValue("de");
     const { result } = renderHook(() => useNavigatorLanguage());
     expect(result.current).toBe("de");

--- a/packages/rooks/src/__tests__/useOnWindowResize.spec.ts
+++ b/packages/rooks/src/__tests__/useOnWindowResize.spec.ts
@@ -4,12 +4,14 @@ import { useOnWindowResize } from "../hooks/useOnWindowResize";
 
 describe("useOnWindowResize", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useOnWindowResize).toBeDefined();
   });
 
   describe("basic", () => {
     const mockCallback = jest.fn(() => {});
     it("should call callback after resize", () => {
+      expect.hasAssertions();
       renderHook(() => useOnWindowResize(mockCallback));
       fireEvent(window, new Event("resize"));
       expect(mockCallback.mock.calls).toHaveLength(1);

--- a/packages/rooks/src/__tests__/useOnWindowScroll.spec.ts
+++ b/packages/rooks/src/__tests__/useOnWindowScroll.spec.ts
@@ -4,12 +4,14 @@ import { useOnWindowScroll } from "../hooks/useOnWindowScroll";
 
 describe("useOnWindowScroll", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useOnWindowScroll).toBeDefined();
   });
 
   describe("basic", () => {
     const mockCallback = jest.fn(() => {});
     it("should call callback after resize", () => {
+      expect.hasAssertions();
       renderHook(() => useOnWindowScroll(mockCallback));
       fireEvent(window, new Event("scroll"));
       expect(mockCallback.mock.calls).toHaveLength(1);

--- a/packages/rooks/src/__tests__/useOnline.spec.tsx
+++ b/packages/rooks/src/__tests__/useOnline.spec.tsx
@@ -5,7 +5,6 @@ import { renderHook } from "@testing-library/react-hooks";
 import { useOnline } from "../hooks/useOnline";
 
 describe("useOnline", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let onlineGetter = jest.spyOn(window.navigator, "onLine", "get");
 
   beforeEach(() => {

--- a/packages/rooks/src/__tests__/useOnline.spec.tsx
+++ b/packages/rooks/src/__tests__/useOnline.spec.tsx
@@ -12,16 +12,19 @@ describe("useOnline", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useOnline).toBeDefined();
   });
 
   it("should get the online status", () => {
+    expect.hasAssertions();
     onlineGetter.mockReturnValue(true);
     const { result } = renderHook(() => useOnline());
     expect(result.current).toBe(true);
   });
 
   it("should get the offline status", () => {
+    expect.hasAssertions();
     onlineGetter.mockReturnValue(false);
     const { result } = renderHook(() => useOnline());
     expect(result.current).toBe(false);

--- a/packages/rooks/src/__tests__/useOutsideClick.spec.tsx
+++ b/packages/rooks/src/__tests__/useOutsideClick.spec.tsx
@@ -113,10 +113,12 @@ describe("useOutsideClick", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useOutsideClick).toBeDefined();
   });
 
   it("should trigger the calback when click on outide", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const app = getByTestId(container as HTMLElement, "app");
     const message = getByTestId(container as HTMLElement, "message");
@@ -127,6 +129,7 @@ describe("useOutsideClick", () => {
   });
 
   it("should not trigger the calback when click the volumn button (inside)", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const button = getByTestId(container as HTMLElement, "button");
     const message = getByTestId(container as HTMLElement, "message");

--- a/packages/rooks/src/__tests__/useOutsideClickRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useOutsideClickRef.spec.tsx
@@ -112,10 +112,12 @@ describe("useOutsideClickRef", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useOutsideClickRef).toBeDefined();
   });
 
   it("should trigger the calback when click on outide", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const app = getByTestId(container as HTMLElement, "app");
     const message = getByTestId(container as HTMLElement, "message");
@@ -126,6 +128,7 @@ describe("useOutsideClickRef", () => {
   });
 
   it("should not trigger the calback when click the volume button (inside)", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const button = getByTestId(container as HTMLElement, "button");
     const message = getByTestId(container as HTMLElement, "message");

--- a/packages/rooks/src/__tests__/usePreviousDifferent.spec.ts
+++ b/packages/rooks/src/__tests__/usePreviousDifferent.spec.ts
@@ -9,7 +9,6 @@ describe("usePreviousDifferent", () => {
     previousValue: number | null;
     value: number;
     value2: number;
-    // eslint-disable-next-line unicorn/consistent-function-scoping
   } => {
     return {
       increment: () => {},

--- a/packages/rooks/src/__tests__/usePreviousImmediate.spec.ts
+++ b/packages/rooks/src/__tests__/usePreviousImmediate.spec.ts
@@ -3,12 +3,10 @@ import { useState } from "react";
 import { usePreviousImmediate } from "../hooks/usePreviousImmediate";
 
 describe("usePreviousImmediate", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let useHook = (): {
     increment: () => void;
     previousValue: number | null;
     value: number;
-    // eslint-disable-next-line unicorn/consistent-function-scoping
   } => {
     return {
       increment: () => {},

--- a/packages/rooks/src/__tests__/useQueueState.spec.ts
+++ b/packages/rooks/src/__tests__/useQueueState.spec.ts
@@ -6,18 +6,22 @@ const { act } = TestRenderer;
 
 describe("useQueueState", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useQueueState).toBeDefined();
   });
   it("should initialize correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useQueueState([1, 2, 3]));
     expect(result.current[0]).toEqual([1, 2, 3]);
   });
   it("should return length correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useQueueState([1, 2, 3]));
     const [, controls] = result.current;
     expect(controls).toHaveLength(3);
   });
   it("should enqueue correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useQueueState([1, 2, 3]));
     // test memo
     const enqueueBeforeRerender = result.current[1].enqueue;
@@ -39,6 +43,7 @@ describe("useQueueState", () => {
     expect(list2).toEqual([1, 2, 3, 7, 8]);
   });
   it("should peek and dequeue correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useQueueState([1, 2, 3]));
     // memo
     const enqueueBeforeRerender = result.current[1].enqueue;
@@ -69,6 +74,7 @@ describe("useQueueState", () => {
     expect(result.current[1]).toHaveLength(3);
   });
   it("handles empty arrays", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useQueueState<number>([]));
     void act(() => {
       result.current[1].dequeue();

--- a/packages/rooks/src/__tests__/useRaf.spec.tsx
+++ b/packages/rooks/src/__tests__/useRaf.spec.tsx
@@ -47,10 +47,12 @@ describe("useRaf", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useRaf).toBeDefined();
   });
 
   it("should render", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     expect(container).toBeDefined();
   });

--- a/packages/rooks/src/__tests__/useSelctableList.spec.ts
+++ b/packages/rooks/src/__tests__/useSelctableList.spec.ts
@@ -11,6 +11,7 @@ describe("useSelctableList", () => {
 
   describe("matchSelection", () => {
     it("console.warn", () => {
+      expect.hasAssertions();
       act(() => {
         result.current[1].matchSelection({ index: 1, value: 2 });
       });
@@ -28,6 +29,7 @@ describe("useSelctableList", () => {
     });
 
     it("match index", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, true)
       );
@@ -38,6 +40,7 @@ describe("useSelctableList", () => {
     });
 
     it("match value", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, true)
       );
@@ -50,6 +53,7 @@ describe("useSelctableList", () => {
 
   describe("updateSelection", () => {
     it("set by index", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, true)
       );
@@ -62,6 +66,7 @@ describe("useSelctableList", () => {
       expect(currentValue).toBe(2);
     });
     it("set by value", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, true)
       );
@@ -75,6 +80,7 @@ describe("useSelctableList", () => {
     });
 
     it("set by value fail", () => {
+      expect.hasAssertions();
       const [beforeIndex, beforeValue] = result.current[0];
       act(() => {
         result.current[1].updateSelection({ value: 22 })();
@@ -92,6 +98,7 @@ describe("useSelctableList", () => {
     });
 
     it("console.warn", () => {
+      expect.hasAssertions();
       act(() => {
         result.current[1].updateSelection({ index: 1, value: 2 })();
       });
@@ -111,6 +118,7 @@ describe("useSelctableList", () => {
 
   describe("toggleSelection", () => {
     it("should toggle selected index", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, true)
       );
@@ -123,6 +131,7 @@ describe("useSelctableList", () => {
     });
 
     it("shouldn't toggle selected index when allowUnselected = false", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, false)
       );
@@ -142,6 +151,7 @@ describe("useSelctableList", () => {
       (console.warn as jest.Mock).mockReset();
     });
     it("should toggle selected value", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, true)
       );
@@ -156,6 +166,7 @@ describe("useSelctableList", () => {
     });
 
     it("shouldn't toggle selected value when allowUnselected", () => {
+      expect.hasAssertions();
       const { result: internalResult } = renderHook(() =>
         useSelectableList([1, 2, 3], 0, false)
       );
@@ -176,6 +187,7 @@ describe("useSelctableList", () => {
     });
 
     it("console.warn", () => {
+      expect.hasAssertions();
       act(() => {
         result.current[1].toggleSelection({ index: 1, value: 2 })();
       });

--- a/packages/rooks/src/__tests__/useSelect.spec.ts
+++ b/packages/rooks/src/__tests__/useSelect.spec.ts
@@ -3,6 +3,7 @@ import { useSelect } from "../hooks/useSelect";
 
 describe("useSelect", () => {
   it("should return correct value at index", () => {
+    expect.hasAssertions();
     let array = [1, 2];
     const { result, rerender } = renderHook(() => useSelect(array, 0));
 

--- a/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
@@ -14,6 +14,7 @@ import { useSessionstorageState } from "../hooks/useSessionstorageState";
 
 describe("useSessionstorageState defined", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useSessionstorageState).toBeDefined();
   });
 });
@@ -52,12 +53,14 @@ describe("useSessionstorageState basic", () => {
   afterEach(cleanup);
 
   it("initializes correctly", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(valueElement.innerHTML).toBe("hello");
   });
 
   it("setting the new value", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const setToNewValueButton = getByTestId(
       container as HTMLElement,

--- a/packages/rooks/src/__tests__/useStackState.spec.ts
+++ b/packages/rooks/src/__tests__/useStackState.spec.ts
@@ -6,18 +6,22 @@ const { act } = TestRenderer;
 
 describe("useStackState", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useStackState).toBeDefined();
   });
   it("should initialize correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useStackState([1, 2, 3]));
     expect(result.current[0]).toEqual([1, 2, 3]);
   });
   it("should return length correctly", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useStackState([1, 2, 3]));
     const [, controls] = result.current;
     expect(controls).toHaveLength(3);
   });
   it("should push correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useStackState([1, 2, 3]));
 
     // memo
@@ -44,6 +48,7 @@ describe("useStackState", () => {
     expect(list2).toEqual([1, 2, 3, 7, 7]);
   });
   it("should peek and pop correctly", () => {
+    expect.hasAssertions();
     const { result, rerender } = renderHook(() => useStackState([1, 2, 3]));
 
     // memo
@@ -76,6 +81,7 @@ describe("useStackState", () => {
     expect(result.current[1]).toHaveLength(3);
   });
   it("handles empty arrays", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useStackState<number>([]));
 
     void act(() => {
@@ -109,6 +115,7 @@ describe("useStackState", () => {
   });
 
   it("should clear the stack", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useStackState([1, 2, 3]));
     expect(result.current[1]).toHaveLength(3);
     void act(() => {

--- a/packages/rooks/src/__tests__/useTimeoutWhen.spec.ts
+++ b/packages/rooks/src/__tests__/useTimeoutWhen.spec.ts
@@ -4,12 +4,12 @@ import { useTimeoutWhen } from "../hooks/useTimeoutWhen";
 
 describe("useTimeoutWhen", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useTimeoutWhen).toBeDefined();
   });
 });
 
 describe("base", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let useHook = () => ({ value: 5 });
   beforeEach(() => {
     useHook = function () {

--- a/packages/rooks/src/__tests__/useToggle.spec.tsx
+++ b/packages/rooks/src/__tests__/useToggle.spec.tsx
@@ -97,7 +97,6 @@ describe("useToggle with custom toggle function false by default", () => {
 
 describe("useToggle with reducer", () => {
   let App = () => <div />;
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let toggleReducer = (
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _state: number,
@@ -105,7 +104,6 @@ describe("useToggle with reducer", () => {
     _action: {
       type: string;
     }
-    // eslint-disable-next-line unicorn/consistent-function-scoping
   ) => 5;
   beforeEach(() => {
     toggleReducer = function (

--- a/packages/rooks/src/__tests__/useToggle.spec.tsx
+++ b/packages/rooks/src/__tests__/useToggle.spec.tsx
@@ -21,16 +21,19 @@ describe("useToggle basic behavior", () => {
   });
   afterEach(cleanup);
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useToggle).toBeDefined();
   });
 
   it("sets initial value correctly", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const toggleElement = getByTestId("toggle-element");
     expect(toggleElement.innerHTML).toBe("true");
   });
 
   it("updates value", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const toggleElement = getByTestId("toggle-element");
     fireEvent.click(toggleElement);
@@ -57,16 +60,19 @@ describe("useToggle with custom toggle function and with strings", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useToggle).toBeDefined();
   });
 
   it("sets initial value correctly", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const toggleElement = getByTestId("toggle-element");
     expect(toggleElement.innerHTML).toBe("regina");
   });
 
   it("updates value", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const toggleElement = getByTestId("toggle-element");
     fireEvent.click(toggleElement);
@@ -89,6 +95,7 @@ describe("useToggle with custom toggle function false by default", () => {
   });
   afterEach(cleanup);
   it("should be false by default", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const toggleElement = getByTestId("toggle-element");
     expect(toggleElement.innerHTML).toBe("false");
@@ -151,11 +158,13 @@ describe("useToggle with reducer", () => {
   });
   afterEach(cleanup);
   it("should be 1 by default", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const toggleElement = getByTestId("toggle-element");
     expect(toggleElement.innerHTML).toBe("1");
   });
   it("should update with dispatched actions", () => {
+    expect.hasAssertions();
     const { getByTestId } = render(<App />);
     const toggleElement = getByTestId("toggle-element");
     const nopeButton = getByTestId("nope-button");

--- a/packages/rooks/src/__tests__/useUndoState.spec.tsx
+++ b/packages/rooks/src/__tests__/useUndoState.spec.tsx
@@ -32,15 +32,18 @@ describe("useUndoState", () => {
   });
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useUndoState).toBeDefined();
   });
 
   it("should honor default value", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useHook(42));
     expect(result.current.value).toBe(42);
   });
 
   it("should show latest value", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useHook(42));
 
     void act(() => {
@@ -52,6 +55,7 @@ describe("useUndoState", () => {
 
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("should show previous value after undo", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useHook(42));
 
     void act(() => {
@@ -64,6 +68,7 @@ describe("useUndoState", () => {
   });
 
   it("should show initial value after multiple undo", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useHook(42));
 
     void act(() => {
@@ -81,6 +86,7 @@ describe("useUndoState", () => {
 
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("should respect maxSize option", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() => useHook(42, { maxSize: 2 }));
 
     void act(() => {

--- a/packages/rooks/src/__tests__/useUndoState.spec.tsx
+++ b/packages/rooks/src/__tests__/useUndoState.spec.tsx
@@ -11,7 +11,6 @@ const { act } = TestRenderer;
 
 describe("useUndoState", () => {
   afterEach(cleanup);
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let useHook = function (defaultValue: number, options?: UseUndoStateOptions) {
     const [value, setValue, undo] = useUndoState<number>(defaultValue, options);
     function increment() {

--- a/packages/rooks/src/__tests__/useWarningOnMountInDevelopment.spec.ts
+++ b/packages/rooks/src/__tests__/useWarningOnMountInDevelopment.spec.ts
@@ -3,9 +3,11 @@ import { useWarningOnMountInDevelopment } from "../hooks/useWarningOnMountInDeve
 
 describe("useWarningOnMountInDevelopment", () => {
   it("is defined", () => {
+    expect.hasAssertions();
     expect(useWarningOnMountInDevelopment).toBeDefined();
   });
   it("logs error in dev env", () => {
+    expect.hasAssertions();
     const spy = jest.spyOn(global.console, "error");
     renderHook(() => useWarningOnMountInDevelopment("message"));
     // eslint-disable-next-line jest/prefer-called-with

--- a/packages/rooks/src/__tests__/useWillUnmount.spec.tsx
+++ b/packages/rooks/src/__tests__/useWillUnmount.spec.tsx
@@ -17,7 +17,6 @@ describe("useWillUnmount", () => {
   const mockCallback = jest.fn(() => null);
   // let firstCallback
   beforeEach(() => {
-    // eslint-disable-next-line unicorn/consistent-function-scoping
     const Child = () => {
       useWillUnmount(mockCallback);
 

--- a/packages/rooks/src/__tests__/useWillUnmount.spec.tsx
+++ b/packages/rooks/src/__tests__/useWillUnmount.spec.tsx
@@ -53,10 +53,12 @@ describe("useWillUnmount", () => {
   afterEach(cleanup);
 
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useWillUnmount).toBeDefined();
   });
 
   it("should only call the unmount function only when unmount", () => {
+    expect.hasAssertions();
     const { container } = render(<App />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const toggleChildElement = getByTestId(

--- a/packages/rooks/src/__tests__/useWindowEventListener.spec.tsx
+++ b/packages/rooks/src/__tests__/useWindowEventListener.spec.tsx
@@ -10,9 +10,11 @@ const { act } = TestRenderer;
 
 describe("useWindowEventListener", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useWindowEventListener).toBeDefined();
   });
   it("should return a undefined", () => {
+    expect.hasAssertions();
     const { result } = renderHook(() =>
       useWindowEventListener("click", () => {
         console.log("clicked");
@@ -36,11 +38,13 @@ describe("useWindowEventListener jsx", () => {
   });
 
   it("should not call callback by default", () => {
+    expect.hasAssertions();
     render(<TestJSX />);
     expect(mockCallback).toHaveBeenCalledTimes(0);
   });
 
   it("should not call callback when event fires", () => {
+    expect.hasAssertions();
     render(<TestJSX />);
     act(() => {
       fireEvent.click(window);
@@ -67,12 +71,14 @@ describe("useWindowEventListener state variables", () => {
   });
 
   it("should not call callback by default", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(Number.parseInt(valueElement.innerHTML)).toBe(0);
   });
 
   it("should not call callback when event fires", () => {
+    expect.hasAssertions();
     const { container } = render(<TestJSX />);
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(Number.parseInt(valueElement.innerHTML)).toBe(0);

--- a/packages/rooks/src/__tests__/useWindowEventListener.spec.tsx
+++ b/packages/rooks/src/__tests__/useWindowEventListener.spec.tsx
@@ -24,9 +24,7 @@ describe("useWindowEventListener", () => {
 });
 
 describe("useWindowEventListener jsx", () => {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let mockCallback = () => {};
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   let TestJSX = () => null;
   beforeEach(() => {
     mockCallback = jest.fn(() => {});

--- a/packages/rooks/src/__tests__/useWindowScrollPosition.spec.ts
+++ b/packages/rooks/src/__tests__/useWindowScrollPosition.spec.ts
@@ -4,11 +4,13 @@ import { useWindowScrollPosition } from "../hooks/useWindowScrollPosition";
 
 describe("useWindowScrollPosition", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useWindowScrollPosition).toBeDefined();
   });
 
   describe("basic", () => {
     it("should call callback after resize", () => {
+      expect.hasAssertions();
       const { result } = renderHook(() => useWindowScrollPosition());
       expect(result.current.scrollX).toBe(0);
       expect(result.current.scrollY).toBe(0);

--- a/packages/rooks/src/__tests__/useWindowSize.spec.tsx
+++ b/packages/rooks/src/__tests__/useWindowSize.spec.tsx
@@ -6,11 +6,13 @@ import { useWindowSize } from "../hooks/useWindowSize";
 
 describe("useWindowSize", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(useWindowSize).toBeDefined();
   });
 
   describe("basic", () => {
     it("should have an initial value on first render", () => {
+      expect.hasAssertions();
       const { result } = renderHook(() => useWindowSize());
       expect(result.current.innerHeight).not.toBeNull();
     });

--- a/packages/rooks/src/hooks/useDebounce.ts
+++ b/packages/rooks/src/hooks/useDebounce.ts
@@ -1,3 +1,4 @@
+import { UnknownFunction } from "@/types/utils";
 import type { DebouncedFunc, DebounceSettings } from "lodash";
 import debounce from "lodash.debounce";
 import { useRef, useEffect, useCallback } from "react";
@@ -15,7 +16,7 @@ import { useRef, useEffect, useCallback } from "react";
  * @returns Returns the new debounced function.
  * @see https://react-hooks.org/docs/useDebounce
  */
-function useDebounce<T extends (...args: any[]) => unknown>(
+function useDebounce<T extends UnknownFunction>(
   callback: T,
   wait?: number,
   options?: DebounceSettings

--- a/packages/rooks/src/hooks/useFullscreen.ts
+++ b/packages/rooks/src/hooks/useFullscreen.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { UnknownFunction } from "@/types/utils";
 import { useState, useCallback, useRef } from "react";
@@ -69,9 +70,7 @@ const getFullscreenControls = (): NormalizedFullscreenApi => {
   const returnValue = {} as NormalizedFullscreenApi;
 
   for (const functionSet of functionMap) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (functionSet && functionSet[1] in document) {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       for (const [index, _function] of functionSet.entries()) {
         returnValue[functionMap[0][index]] = functionSet[index];
       }
@@ -176,12 +175,10 @@ function useFullscreen(options: FullScreenOptions = {}): FullscreenApi {
   );
 
   const request = useCallback(
-    // eslint-disable-next-line consistent-return
     async (internalElement?: HTMLElement) => {
       try {
         const finalElement = internalElement ?? document.documentElement;
 
-        // eslint-disable-next-line @typescript-eslint/return-await
         return await finalElement[fullscreenControls.requestFullscreen](
           requestFullscreenOptions
         );
@@ -192,11 +189,9 @@ function useFullscreen(options: FullScreenOptions = {}): FullscreenApi {
     [fullscreenControls.requestFullscreen, requestFullscreenOptions]
   );
 
-  // eslint-disable-next-line consistent-return
   const exit = useCallback(async () => {
     if (element) {
       try {
-        // eslint-disable-next-line @typescript-eslint/return-await
         return await document[fullscreenControls.exitFullscreen]();
       } catch (error) {
         console.warn(error);
@@ -205,9 +200,9 @@ function useFullscreen(options: FullScreenOptions = {}): FullscreenApi {
   }, [element, fullscreenControls.exitFullscreen]);
 
   const toggle = useCallback(
-    // eslint-disable-next-line no-confusing-arrow
-    (newElement?: HTMLElement) =>
-      element ? exit() : newElement ? request(newElement) : null,
+    (newElement?: HTMLElement) => {
+      return element ? exit() : newElement ? request(newElement) : null;
+    },
     [element, exit, request]
   );
 

--- a/packages/rooks/src/hooks/useFullscreen.ts
+++ b/packages/rooks/src/hooks/useFullscreen.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { UnknownFunction } from "@/types/utils";
 import { useState, useCallback, useRef } from "react";
 import { useDocumentEventListener } from "./useDocumentEventListener";
 import { warning } from "./warning";
@@ -210,8 +211,8 @@ function useFullscreen(options: FullScreenOptions = {}): FullscreenApi {
     [element, exit, request]
   );
 
-  const onChangeDeprecatedHandlerRef = useRef<Function>(noop);
-  const onErrorDeprecatedHandlerRef = useRef<Function>(noop);
+  const onChangeDeprecatedHandlerRef = useRef<UnknownFunction>(noop);
+  const onErrorDeprecatedHandlerRef = useRef<UnknownFunction>(noop);
 
   // Hack to not break it for everyone
   // Honestly these two functions are tragedy and must be removed in v5

--- a/packages/rooks/src/hooks/useGeolocation.ts
+++ b/packages/rooks/src/hooks/useGeolocation.ts
@@ -51,11 +51,11 @@ const defaultGeoLocationOptions: UseGeoLocationOptions = {
  * Gets the geolocation data as a hook
  *
  * @param {UseGeoLocationOptions} geoLocationOptions Geolocation options
- * @see {https://react-hooks.org/docs/useGeolocation}
+ * @see {@link https://react-hooks.org/docs/useGeolocation}
  */
-function useGeolocation(
+const useGeolocation = (
   geoLocationOptions: UseGeoLocationOptions = defaultGeoLocationOptions
-): UseGeolocationReturnType | null {
+): UseGeolocationReturnType | null => {
   const [geoObject, setGeoObject] = useState<UseGeolocationReturnType | null>(
     null
   );
@@ -85,6 +85,6 @@ function useGeolocation(
   }, [when, enableHighAccuracy, timeout, maximumAge, getIsMounted]);
 
   return geoObject;
-}
+};
 
 export { useGeolocation };

--- a/packages/rooks/src/hooks/useMergeRefs.ts
+++ b/packages/rooks/src/hooks/useMergeRefs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/prevent-abbreviations */
 import type { MutableRefObject, RefCallback } from "react";
 import { useMemo } from "react";
 import type { PossibleRef } from "../utils/utils";

--- a/packages/rooks/src/hooks/useMultiSelectableList.ts
+++ b/packages/rooks/src/hooks/useMultiSelectableList.ts
@@ -70,7 +70,6 @@ function useMultiSelectableList<T>(
 
         setCurrentIndices(indices);
       } else if (typeof values !== "undefined") {
-        // eslint-disable-next-line unicorn/no-array-reduce
         const valueIndices = list.reduce((accumulator, current, index) => {
           if (values.includes(current)) {
             const array = [...accumulator, index];

--- a/packages/rooks/src/types/utils.ts
+++ b/packages/rooks/src/types/utils.ts
@@ -11,4 +11,5 @@ export type ListenerOptions =
       signal?: AbortSignal;
     };
 
-export type ExcludeFunction<T> = Exclude<T, Function>;
+export type UnknownFunction = (...args: unknown[]) => unknown;
+export type ExcludeFunction<T> = Exclude<T, UnknownFunction>;

--- a/template/index.spec.template
+++ b/template/index.spec.template
@@ -1,9 +1,10 @@
-import React from 'react'
-import { %name% } from '../hooks/%name%';
+import React from "react";
+import { %name% } from "../hooks/%name%";
 
 
 describe("%name%", () => {
   it("should be defined", () => {
+    expect.hasAssertions();
     expect(%name%).toBeDefined();
   });
 });


### PR DESCRIPTION
Resolved all eslint errors.

## Note

Could not solve useFullscreen document-related error, so I left `@ts-nocheck` as is.
I see the method is similar to `fscreen` (https://www.npmjs.com/package/fscreen), but I doubt is webkit- etc prefix is still needed.