### PR TITLE
add: useKeys changeset

### DIFF
--- a/.changeset/hot-panthers-wink.md
+++ b/.changeset/hot-panthers-wink.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+Add an opt-in option to prevent useKeys from losing track of keyup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@ From the root of the project:
 
 ### Adding Changeset information
 
-* Changeset information is a **must** when you are making a change to `rooks`(your change can be a new feature or a bug fix).
-* To add a changeset -> run `yarn add changeset`
-* It let's you to select *which packages needs to be bumped into which version*.
-* After answering the questions in the cli, you can see your changeset information in the `.changeset` folder in the root of our project folder.
-* Create a commit after adding the changeset information.
-* It's that simple.
+- Changeset information is a **must** when you are making a change to `rooks`(your change can be a new feature or a bug fix).
+- To add a changeset -> run `yarn changeset` in the project root.
+- It lets you to select _which packages needs to be bumped into which version_.
+- After answering the questions in the cli, you can see your changeset information in the `.changeset` folder in the root of our project folder.
+- Create a commit after adding the changeset information.
+- It's that simple.
 
 ## Contributing Guidelines
 

--- a/data/docs/useKeys.md
+++ b/data/docs/useKeys.md
@@ -26,16 +26,17 @@ export default function App() {
     ["ControlLeft", "KeyS"],
     () => {
       alert("you presses ctrlLeft + s");
-      setFirstCallbackCallCount((curr) => curr + 1);
+      setFirstCallbackCallCount(curr => curr + 1);
     },
     {
       target: containerRef,
       when: isEventActive,
+      preventLostKeyup: true,
     }
   );
   useKeys(
     ["m", "r"],
-    (event) => {
+    event => {
       // event.stopPropagation();
       console.log("here you go m and r");
     },
@@ -75,11 +76,12 @@ export default function App() {
 | callback       | Function | Callback function to be called when event is triggered | undefined |
 | options        | Object   | See table below                                        | undefined |
 
-| Options value | Type                      | Description                                                                      | Defualt     |
-| ------------- | ------------------------- | -------------------------------------------------------------------------------- | ----------- |
-| when          | Boolean                   | Condition which if true, will enable the event listeners                         | true        |
-| eventTypes    | Array of number or string | Keyboardevent types to listen for. Valid options are keyDown, keyPress and keyUp | ['keydown'] |
-| target        | HTMLElement ref           | target ref on which the events should be listened.                               | window      |
+| Options value    | Type                      | Description                                                                      | Defualt     |
+| ---------------- | ------------------------- | -------------------------------------------------------------------------------- | ----------- |
+| when             | Boolean                   | Condition which if true, will enable the event listeners                         | true        |
+| eventTypes       | Array of number or string | Keyboardevent types to listen for. Valid options are keyDown, keyPress and keyUp | ['keydown'] |
+| target           | HTMLElement ref           | target ref on which the events should be listened.                               | window      |
+| preventLostKeyup | Boolean                   | Prevent keyup events get lost tracking when alert is triggered.                  | false       |
 
 ### Returns
 


### PR DESCRIPTION
- added changeset for useKeys, which I forgot to include in https://github.com/imbhargav5/rooks/pull/1210
- updated the docs for useKeys

## Note

I can't find a workflow to use the updated rooks in the docs.
When I `yarn build` and `yarn dev` locally, it still seems to use the outdated rooks in the localhosted website.