### PR TITLE
Make useKey target option support undefined

### DIFF
--- a/.changeset/forty-seals-confess.md
+++ b/.changeset/forty-seals-confess.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+Make useKey target option support undefined

--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -16,7 +16,7 @@ type Options = {
    * target ref on which the events should be listened. If no target is specified,
    * events are listened to on the document
    */
-  target?: MutableRefObject<Document> | MutableRefObject<HTMLElement | null>;
+  target?: MutableRefObject<Document> | MutableRefObject<HTMLElement | null | undefined>;
   /**
    * when boolean to enable and disable events, when passed false
    * remove the eventlistener if any


### PR DESCRIPTION
It should be possible to use the ref without having to declare it as null