### PR TITLE
fix(useMediaMatch): safari 13.1 addListener fix

### DIFF
--- a/.changeset/shaggy-jars-happen.md
+++ b/.changeset/shaggy-jars-happen.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+fix(useMediaMatch): safari 13.1 addListener fix

--- a/packages/rooks/src/hooks/useMediaMatch.ts
+++ b/packages/rooks/src/hooks/useMediaMatch.ts
@@ -21,8 +21,14 @@ function useMediaMatch(query: string): boolean {
     setMatches(matchMedia.matches);
     const listener = (event: MediaQueryListEventMap["change"]) =>
       setMatches(event.matches);
-    matchMedia.addEventListener("change", listener);
-    return () => matchMedia.removeEventListener("change", listener);
+
+    if (matchMedia.addEventListener) {
+      matchMedia.addEventListener("change", listener);
+      return () => matchMedia.removeEventListener("change", listener);
+    } else {
+      matchMedia.addListener(listener);
+      return () => matchMedia.removeListener(listener);
+    }
   }, [matchMedia]);
 
   if (typeof window === "undefined") {


### PR DESCRIPTION
This PR fixes a regression causing crashes in old Safari versions