### PR TITLE
use Element type instead of HTMLElement

### DIFF
--- a/packages/rooks/src/hooks/useBoundingclientrect.ts
+++ b/packages/rooks/src/hooks/useBoundingclientrect.ts
@@ -1,3 +1,4 @@
+import { ElementOrNull } from "@/utils/utils";
 import type { MutableRefObject } from "react";
 import { useState, useCallback } from "react";
 import { useDidMount } from "./useDidMount";
@@ -7,7 +8,7 @@ import { useMutationObserver } from "./useMutationObserver";
  * @param element HTML element whose boundingclientrect is needed
  * @returns DOMRect
  */
-function getBoundingClientRect(element: HTMLElement): DOMRect | null {
+function getBoundingClientRect(element: Element): DOMRect | null {
   return element.getBoundingClientRect();
 }
 
@@ -19,7 +20,7 @@ function getBoundingClientRect(element: HTMLElement): DOMRect | null {
  * @see https://react-hooks.org/docs/useBoundingclientRect
  */
 function useBoundingclientrect(
-  ref: MutableRefObject<HTMLElement | null>
+  ref: MutableRefObject<ElementOrNull>
 ): DOMRect | null {
   const [domRect, setDomRect] = useState<DOMRect | null>(null);
 

--- a/packages/rooks/src/hooks/useBoundingclientrectRef.ts
+++ b/packages/rooks/src/hooks/useBoundingclientrectRef.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import type { CallbackRef, HTMLElementOrNull } from "../utils/utils";
+import type { CallbackRef } from "../utils/utils";
 import { useForkRef } from "./useForkRef";
 import { useMutationObserverRef } from "./useMutationObserverRef";
 
@@ -7,7 +7,7 @@ import { useMutationObserverRef } from "./useMutationObserverRef";
  * @param element HTML element whose boundingclientrect is needed
  * @returns DOMRect
  */
-function getBoundingClientRect(element: HTMLElement): DOMRect {
+function getBoundingClientRect(element: Element): DOMRect {
   return element.getBoundingClientRect();
 }
 
@@ -24,7 +24,7 @@ function useBoundingclientrectRef(): [
   () => void
 ] {
   const [domRect, setDomRect] = useState<DOMRect | null>(null);
-  const [node, setNode] = useState<HTMLElementOrNull>(null);
+  const [node, setNode] = useState<Element | null>(null);
 
   const update = useCallback(() => {
     setDomRect(node ? getBoundingClientRect(node) : null);
@@ -34,7 +34,7 @@ function useBoundingclientrectRef(): [
     update();
   }, [update]);
 
-  const ref = useCallback((nodeElement: HTMLElement | null) => {
+  const ref = useCallback((nodeElement: Element | null) => {
     setNode(nodeElement);
   }, []);
 

--- a/packages/rooks/src/hooks/useDimensionsRef.ts
+++ b/packages/rooks/src/hooks/useDimensionsRef.ts
@@ -7,6 +7,7 @@ import { useState, useCallback, useLayoutEffect } from "react";
 import type { LegacyRef } from "react";
 import { useOnWindowResize } from "./useOnWindowResize";
 import { useOnWindowScroll } from "./useOnWindowScroll";
+import { ElementOrNull } from "@/utils/utils";
 
 type UseDimensionsRefReturn = {
   bottom: number;
@@ -22,14 +23,14 @@ type UseDimensionsRefReturn = {
 type UseDimensionsHook = [
   LegacyRef<HTMLDivElement> | undefined,
   UseDimensionsRefReturn,
-  HTMLElement | null
+  ElementOrNull
 ];
 
 type UseDimensionsRefArgs = {
   updateOnResize?: boolean;
   updateOnScroll?: boolean;
 };
-const getDimensionObject = (node: HTMLElement): UseDimensionsRefReturn => {
+const getDimensionObject = (node: Element): UseDimensionsRefReturn => {
   const rect = node.getBoundingClientRect();
 
   return {
@@ -50,7 +51,7 @@ const noWindowReturnValue: UseDimensionsHook = [undefined, null, null];
  * useDimensionsRef
  * @param updateOnScroll Whether to update on scroll
  * @param updateOnResize Whether to update on resize
- * @returns [React.Ref<HTMLDivElement>, UseDimensionsRefReturn, HTMLElement | null]
+ * @returns [React.Ref<HTMLDivElement>, UseDimensionsRefReturn, ElementOrNull]
  * @see https://react-hooks.org/docs/useDimensionsRef
  */
 export const useDimensionsRef = ({
@@ -58,9 +59,9 @@ export const useDimensionsRef = ({
   updateOnResize = true,
 }: UseDimensionsRefArgs = {}): UseDimensionsHook => {
   const [dimensions, setDimensions] = useState<UseDimensionsRefReturn>(null);
-  const [node, setNode] = useState<HTMLElement | null>(null);
+  const [node, setNode] = useState<ElementOrNull>(null);
 
-  const ref = useCallback((nodeFromCallback: HTMLElement | null) => {
+  const ref = useCallback((nodeFromCallback: ElementOrNull) => {
     setNode(nodeFromCallback);
   }, []);
 

--- a/packages/rooks/src/hooks/useEventListenerRef.ts
+++ b/packages/rooks/src/hooks/useEventListenerRef.ts
@@ -26,8 +26,8 @@ function useEventListenerRef(
     | EventListenerOptions
     | boolean = {},
   isLayoutEffect = false
-): (refElement: RefElementOrNull<HTMLElement>) => void {
-  const [ref, element] = useRefElement<HTMLElement>();
+): (refElement: RefElementOrNull<Element>) => void {
+  const [ref, element] = useRefElement<Element>();
   const freshCallback = useFreshTick(callback);
   const useEffectToRun = isLayoutEffect ? useIsomorphicEffect : useEffect;
 

--- a/packages/rooks/src/hooks/useFocus.ts
+++ b/packages/rooks/src/hooks/useFocus.ts
@@ -13,7 +13,7 @@ interface FocusResult<T> {
  * @description Handles focus events for the immediate target element.
  * @see {@link https://react-hooks.org/docs/useFocus}
  */
-const useFocus = <T extends HTMLElement>(props: FocusProps): FocusResult<T> => {
+const useFocus = <T extends Element>(props: FocusProps): FocusResult<T> => {
   const {
     onBlur: propsOnBlur,
     onFocus: propsOnFocus,

--- a/packages/rooks/src/hooks/useFocusWithin.ts
+++ b/packages/rooks/src/hooks/useFocusWithin.ts
@@ -20,7 +20,7 @@ interface FocusWithinResult<T> {
  * @description Handles focus events for the target component.
  * @see {@link https://react-hooks.org/docs/useFocusWithin}
  */
-const useFocusWithin = <T extends HTMLElement>(
+const useFocusWithin = <T extends Element>(
   props: FocusWithinProps
 ): FocusWithinResult<T> => {
   const { onBlurWithin, onFocusWithin, onFocusWithinChange } = props;

--- a/packages/rooks/src/hooks/useInViewRef.ts
+++ b/packages/rooks/src/hooks/useInViewRef.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from "react";
-import type { HTMLElementOrNull, CallbackRef } from "../utils/utils";
+import type { ElementOrNull, CallbackRef } from "../utils/utils";
 import { noop } from "@/utils/noop";
 
 const config: IntersectionObserverInit = {
@@ -24,7 +24,7 @@ function useInViewRef(
 ): [CallbackRef, boolean] {
   const { root = null, rootMargin, threshold } = options;
 
-  const [node, setNode] = useState<HTMLElementOrNull>(null);
+  const [node, setNode] = useState<ElementOrNull>(null);
   const [inView, setInView] = useState<boolean>(false);
 
   useEffect(() => {
@@ -46,7 +46,7 @@ function useInViewRef(
     return noop;
   }, [node, callback, root, rootMargin, threshold, options]);
 
-  const ref = useCallback((nodeElement: HTMLElementOrNull) => {
+  const ref = useCallback((nodeElement: ElementOrNull) => {
     setNode(nodeElement);
   }, []);
 

--- a/packages/rooks/src/hooks/useIntersectionObserverRef.ts
+++ b/packages/rooks/src/hooks/useIntersectionObserverRef.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from "react";
-import type { HTMLElementOrNull, CallbackRef } from "../utils/utils";
+import type { ElementOrNull, CallbackRef } from "../utils/utils";
 import { noop } from "@/utils/noop";
 
 const config: IntersectionObserverInit = {
@@ -24,7 +24,7 @@ function useIntersectionObserverRef(
 ): [CallbackRef] {
   const { root = null, rootMargin, threshold } = options;
 
-  const [node, setNode] = useState<HTMLElementOrNull>(null);
+  const [node, setNode] = useState<ElementOrNull>(null);
 
   useEffect(() => {
     // Create an observer instance linked to the callback function
@@ -42,7 +42,7 @@ function useIntersectionObserverRef(
     return noop;
   }, [node, callback, root, rootMargin, threshold, options]);
 
-  const ref = useCallback((nodeElement: HTMLElementOrNull) => {
+  const ref = useCallback((nodeElement: ElementOrNull) => {
     setNode(nodeElement);
   }, []);
 

--- a/packages/rooks/src/hooks/useKey.ts
+++ b/packages/rooks/src/hooks/useKey.ts
@@ -15,7 +15,7 @@ type Options = {
    * Please use useKeyRef instead if you want to use with callback refs.
    * If no target is specified, events are listened to on the window. Defaults to window.
    */
-  target?: RefObject<HTMLElement>;
+  target?: RefObject<Element>;
   /**
    * Condition which if true, will enable the event listeners
    */

--- a/packages/rooks/src/hooks/useKeyBindings.ts
+++ b/packages/rooks/src/hooks/useKeyBindings.ts
@@ -14,7 +14,7 @@ type Options = {
    * events are listened to on the window. Only works with object refs. If you want to use with callback refs,
    * please use useKeyRef instead.
    */
-  target?: RefObject<HTMLElement>;
+  target?: RefObject<Element>;
   /**
    * Condition which if true, will enable the event listeners
    */

--- a/packages/rooks/src/hooks/useKeyRef.ts
+++ b/packages/rooks/src/hooks/useKeyRef.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { doesIdentifierMatchKeyboardEvent } from "../utils/doesIdentifierMatchKeyboardEvent";
-import type { CallbackRef, HTMLElementOrNull } from "../utils/utils";
+import type { CallbackRef, ElementOrNull } from "../utils/utils";
 import { noop } from "@/utils/noop";
 
 type TrackedKeyEvents = "keydown" | "keypress" | "keyup";
@@ -38,9 +38,9 @@ function useKeyRef(
   callback: Callback,
   options?: Options
 ): CallbackRef {
-  const [targetNode, setTargetNode] = useState<HTMLElementOrNull>(null);
+  const [targetNode, setTargetNode] = useState<ElementOrNull>(null);
 
-  const ref = useCallback((node: HTMLElement | null) => {
+  const ref = useCallback((node: ElementOrNull) => {
     setTargetNode(node);
   }, []);
 

--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from "react";
 import { useEffect, useRef, useCallback } from "react";
 import { doesIdentifierMatchKeyboardEvent } from "../utils/doesIdentifierMatchKeyboardEvent";
 import { noop } from "@/utils/noop";
+import { ElementOrNull } from "@/utils/utils";
 
 type TPressedKeyMapping = {
   [key: string]: boolean | undefined;
@@ -16,7 +17,9 @@ type Options = {
    * target ref on which the events should be listened. If no target is specified,
    * events are listened to on the document
    */
-  target?: MutableRefObject<Document> | MutableRefObject<HTMLElement | null | undefined>;
+  target?:
+    | MutableRefObject<Document>
+    | MutableRefObject<ElementOrNull | undefined>;
   /**
    * when boolean to enable and disable events, when passed false
    * remove the eventlistener if any

--- a/packages/rooks/src/hooks/useMutationObserver.ts
+++ b/packages/rooks/src/hooks/useMutationObserver.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject } from "react";
 import { useEffect } from "react";
 import { noop } from "@/utils/noop";
+import { ElementOrNull } from "@/utils/utils";
 
 const config: MutationObserverInit = {
   attributes: true,
@@ -15,13 +16,13 @@ const config: MutationObserverInit = {
  *
  * Returns a mutation observer for a React Ref and fires a callback
  *
- * @param {MutableRefObject<HTMLElement | null>} ref React ref on which mutations are to be observed
+ * @param {MutableRefObject<ElementOrNull>} ref React ref on which mutations are to be observed
  * @param {MutationCallback} callback Function that needs to be fired on mutation
  * @param {MutationObserverInit} options
  * @see https://react-hooks.org/docs/useMutationObserver
  */
 function useMutationObserver(
-  ref: MutableRefObject<HTMLElement | null>,
+  ref: MutableRefObject<ElementOrNull>,
   callback: MutationCallback,
   options: MutationObserverInit = config
 ): void {

--- a/packages/rooks/src/hooks/useMutationObserverRef.ts
+++ b/packages/rooks/src/hooks/useMutationObserverRef.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from "react";
-import type { CallbackRef, HTMLElementOrNull } from "../utils/utils";
+import type { CallbackRef, ElementOrNull } from "../utils/utils";
 import { noop } from "@/utils/noop";
 
 const config: MutationObserverInit = {
@@ -23,7 +23,7 @@ function useMutationObserverRef(
   callback: MutationCallback,
   options: MutationObserverInit = config
 ): [CallbackRef] {
-  const [node, setNode] = useState<HTMLElementOrNull>(null);
+  const [node, setNode] = useState<ElementOrNull>(null);
 
   useEffect(() => {
     // Create an observer instance linked to the callback function
@@ -41,7 +41,7 @@ function useMutationObserverRef(
     return noop;
   }, [node, callback, options]);
 
-  const ref: CallbackRef = useCallback((nodeElement: HTMLElementOrNull) => {
+  const ref: CallbackRef = useCallback((nodeElement: ElementOrNull) => {
     setNode(nodeElement);
   }, []);
 

--- a/packages/rooks/src/hooks/useOutsideClick.ts
+++ b/packages/rooks/src/hooks/useOutsideClick.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject } from "react";
 import { useEffect, useRef, useCallback } from "react";
 import { noop } from "@/utils/noop";
+import { ElementOrNull } from "@/utils/utils";
 
 /**
  * useOutsideClick hook
@@ -33,7 +34,7 @@ import { noop } from "@/utils/noop";
  * ```
  */
 function useOutsideClick(
-  ref: MutableRefObject<HTMLElement | null>,
+  ref: MutableRefObject<ElementOrNull>,
   handler: (event: MouseEvent) => void,
   when = true
 ): void {

--- a/packages/rooks/src/hooks/useOutsideClickRef.ts
+++ b/packages/rooks/src/hooks/useOutsideClickRef.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from "react";
-import type { HTMLElementOrNull, CallbackRef } from "../utils/utils";
+import type { ElementOrNull, CallbackRef } from "../utils/utils";
 import { noop } from "@/utils/noop";
 
 /**
@@ -17,7 +17,7 @@ function useOutsideClickRef(
 ): [CallbackRef] {
   const savedHandler = useRef(handler);
 
-  const [node, setNode] = useState<HTMLElementOrNull>(null);
+  const [node, setNode] = useState<ElementOrNull>(null);
 
   const memoizedCallback = useCallback(
     (event: MouseEvent) => {
@@ -32,7 +32,7 @@ function useOutsideClickRef(
     savedHandler.current = handler;
   });
 
-  const ref = useCallback((nodeElement: HTMLElementOrNull) => {
+  const ref = useCallback((nodeElement: ElementOrNull) => {
     setNode(nodeElement);
   }, []);
 

--- a/packages/rooks/src/hooks/useRefElement.ts
+++ b/packages/rooks/src/hooks/useRefElement.ts
@@ -5,7 +5,7 @@ import type { RefElementOrNull } from "../utils/utils";
  * useRefElement hook for React
  * Helps bridge gap between callback ref and state
  * Manages the element called with callback ref api using state variable
- * @returns {[RefElementOrNull, (element: HTMLElementOrNull) => void]}
+ * @returns {[RefElementOrNull, (element: ElementOrNull) => void]}
  * @see https://react-hooks.org/docs/useRefElement
  */
 function useRefElement<T>(): [

--- a/packages/rooks/src/hooks/useResizeObserverRef.ts
+++ b/packages/rooks/src/hooks/useResizeObserverRef.ts
@@ -1,6 +1,6 @@
 import { noop } from "@/utils/noop";
 import { useCallback, useEffect, useState } from "react";
-import type { CallbackRef, HTMLElementOrNull } from "../utils/utils";
+import type { CallbackRef, ElementOrNull } from "../utils/utils";
 import { useFreshTick } from "./useFreshTick";
 
 const config: ResizeObserverOptions = {
@@ -23,7 +23,7 @@ function useResizeObserverRef(
   callback: ResizeObserverCallback,
   options: ResizeObserverOptions = config
 ): [CallbackRef] {
-  const [node, setNode] = useState<HTMLElementOrNull>(null);
+  const [node, setNode] = useState<ElementOrNull>(null);
   const freshCallback = useFreshTick(callback);
 
   useEffect(() => {
@@ -41,7 +41,7 @@ function useResizeObserverRef(
     return noop;
   }, [node, freshCallback, options]);
 
-  const ref: CallbackRef = useCallback((node: HTMLElementOrNull) => {
+  const ref: CallbackRef = useCallback((node: ElementOrNull) => {
     setNode(node);
   }, []);
 

--- a/packages/rooks/src/utils/utils.ts
+++ b/packages/rooks/src/utils/utils.ts
@@ -1,13 +1,14 @@
 import type { MutableRefObject, Ref } from "react";
 
 export type HTMLElementOrNull = HTMLElement | null;
+export type ElementOrNull = Element | null;
 export type RefElementOrNull<T> = T | null;
 
-export type CallbackRef<T extends HTMLElement | null = HTMLElementOrNull> = (
+export type CallbackRef<T extends ElementOrNull = ElementOrNull> = (
   node: T
 ) => void;
 
-export type AnyRef<T extends HTMLElement | null = HTMLElementOrNull> =
+export type AnyRef<T extends ElementOrNull = ElementOrNull> =
   | CallbackRef<T>
   | MutableRefObject<T>;
 


### PR DESCRIPTION
resolves #1557 
_Hopefully_ these changes are non-breaking.
Since both `HTMLElement` and `SVGElement` extend `Element`, and (at least according to TypeScript) all previous `HTMLElement` references are supported by `Element`.

Although I guess I'm not quite sure what users are doing with those refs, etc.