### PR TITLE
useMediaMatch handles case where window is not defined

### DIFF
--- a/.changeset/early-fireants-march.md
+++ b/.changeset/early-fireants-march.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+useMatchMedia will not throw an exception if window is not defined

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ From the root of the project:
 
 ### Adding Changeset information
 
-- Changeset information is a **must** when you are making a change to `rooks`(your change can be a new feature or a bug fix).
+- Changeset information is a **must** when you are making a change to `rooks` (your change can be a new feature or a bug fix).
 - To add a changeset -> run `yarn changeset` in the project root.
 - It lets you to select _which packages needs to be bumped into which version_.
 - After answering the questions in the cli, you can see your changeset information in the `.changeset` folder in the root of our project folder.

--- a/packages/rooks/src/__tests__/useMediaMatch.spec.tsx
+++ b/packages/rooks/src/__tests__/useMediaMatch.spec.tsx
@@ -78,6 +78,38 @@ describe("useMediaMatch", () => {
   });
 });
 
+it("should not throw an exception when window is undefined", async () => {
+  expect.hasAssertions();
+  const matchMedia = jest.fn<MediaQueryList, [string]>();
+  const addEventListener = jest.fn<
+    void,
+    [string, (event_: MediaQueryListEventMap["change"]) => void]
+  >();
+  const removeEventListener = jest.fn<void, [string, () => void]>();
+
+  matchMedia.mockReturnValue({
+    addEventListener,
+    matches: true,
+    removeEventListener,
+  } as any);
+
+  const windowSpy = jest.spyOn(window, "window", "get");
+
+  windowSpy.mockImplementation(() => undefined as any);
+
+  const { result, unmount } = renderHook(({ query }) => useMediaMatch(query), {
+    initialProps: { query: "print" },
+  });
+
+  expect(matchMedia).not.toHaveBeenCalled();
+  expect(addEventListener).not.toHaveBeenCalled();
+  expect(result.current).toBe(false);
+
+  // Unmount, ensuring we unbind the listener
+  unmount();
+  windowSpy.mockRestore();
+});
+
 function expectDefined<T>(t: T | undefined): T {
   expect(t).toBeDefined();
 

--- a/packages/rooks/src/hooks/useMediaMatch.ts
+++ b/packages/rooks/src/hooks/useMediaMatch.ts
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useState } from "react";
  * @see https://rooks.vercel.app/docs/useMediaMatch
  */
 function useMediaMatch(query: string): boolean {
-  const isWindowDefined = typeof window !== "undefined";
+  const isWindowDefined = typeof window !== "undefined" && window.matchMedia;
   const matchMedia = useMemo<MediaQueryList | undefined>(
     () => (isWindowDefined ? window.matchMedia(query) : undefined),
     [query, isWindowDefined]
@@ -21,7 +21,7 @@ function useMediaMatch(query: string): boolean {
   );
 
   useEffect(() => {
-    if (!matchMedia) {
+    if (!isWindowDefined || !matchMedia) {
       return;
     }
 
@@ -36,9 +36,9 @@ function useMediaMatch(query: string): boolean {
       matchMedia.addListener(listener);
       return () => matchMedia.removeListener(listener);
     }
-  }, [matchMedia]);
+  }, [isWindowDefined, matchMedia]);
 
-  if (typeof window === "undefined") {
+  if (isWindowDefined) {
     console.warn("useMediaMatch cannot function as window is undefined.");
 
     return false;

--- a/packages/rooks/src/hooks/useMediaMatch.ts
+++ b/packages/rooks/src/hooks/useMediaMatch.ts
@@ -11,13 +11,20 @@ import { useEffect, useMemo, useState } from "react";
  * @see https://rooks.vercel.app/docs/useMediaMatch
  */
 function useMediaMatch(query: string): boolean {
-  const matchMedia = useMemo<MediaQueryList>(
-    () => window.matchMedia(query),
-    [query]
+  const isWindowDefined = typeof window !== "undefined";
+  const matchMedia = useMemo<MediaQueryList | undefined>(
+    () => (isWindowDefined ? window.matchMedia(query) : undefined),
+    [query, isWindowDefined]
   );
-  const [matches, setMatches] = useState<boolean>(() => matchMedia.matches);
+  const [matches, setMatches] = useState<boolean>(() =>
+    (isWindowDefined && matchMedia ? matchMedia.matches : false)
+  );
 
   useEffect(() => {
+    if (!matchMedia) {
+      return;
+    }
+
     setMatches(matchMedia.matches);
     const listener = (event: MediaQueryListEventMap["change"]) =>
       setMatches(event.matches);


### PR DESCRIPTION
In some contexts (e.g. while running the Next.js dev server), `window` will not be defined, which causes this hook to throw an exception. This pull request protects against this situation; the hook returns `false` in that case (as in, the media query is not a match).

[Here's a Codesandbox](https://codesandbox.io/p/sandbox/cold-shadow-dpcsv6?file=%2Fpages%2Findex.tsx&selection=%5B%7B%22endColumn%22%3A55%2C%22endLineNumber%22%3A6%2C%22startColumn%22%3A55%2C%22startLineNumber%22%3A6%7D%5D) with the current (unpatched) hook running within Next.