### PR TITLE
Reduce the frequency of `useIntersectionObserver` callback execution

### DIFF
--- a/.changeset/healthy-berries-compare.md
+++ b/.changeset/healthy-berries-compare.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+Reduce the frequency of `useIntersectionObserver` callback execution

--- a/packages/rooks/src/hooks/useIntersectionObserverRef.ts
+++ b/packages/rooks/src/hooks/useIntersectionObserverRef.ts
@@ -40,7 +40,7 @@ function useIntersectionObserverRef(
 
   useEffect(() => {
     // Create an observer instance linked to the callback function
-    if (node && callbackRef.current) {
+    if (node) {
       const observer = new IntersectionObserver(handleIntersectionObserver, {
         root,
         rootMargin,

--- a/packages/rooks/src/hooks/useIntersectionObserverRef.ts
+++ b/packages/rooks/src/hooks/useIntersectionObserverRef.ts
@@ -27,7 +27,9 @@ function useIntersectionObserverRef(
   const [node, setNode] = useState<HTMLElementOrNull>(null);
 
   const callbackRef = useRef(callback);
-  callbackRef.current = callback;
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
 
   const handleIntersectionObserver = useCallback<IntersectionObserverCallback>(
     (...args) => {

--- a/packages/rooks/src/hooks/useIntersectionObserverRef.ts
+++ b/packages/rooks/src/hooks/useIntersectionObserverRef.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import type { HTMLElementOrNull, CallbackRef } from "../utils/utils";
 import { noop } from "@/utils/noop";
 
@@ -26,10 +26,24 @@ function useIntersectionObserverRef(
 
   const [node, setNode] = useState<HTMLElementOrNull>(null);
 
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const handleIntersectionObserver = useCallback<IntersectionObserverCallback>(
+    (...args) => {
+      return callbackRef.current?.(...args);
+    },
+    []
+  );
+
   useEffect(() => {
     // Create an observer instance linked to the callback function
-    if (node && callback) {
-      const observer = new IntersectionObserver(callback, options);
+    if (node && callbackRef.current) {
+      const observer = new IntersectionObserver(handleIntersectionObserver, {
+        root,
+        rootMargin,
+        threshold,
+      });
 
       // Start observing the target node for configured mutations
       observer.observe(node);
@@ -40,7 +54,7 @@ function useIntersectionObserverRef(
     }
 
     return noop;
-  }, [node, callback, root, rootMargin, threshold, options]);
+  }, [node, handleIntersectionObserver, root, rootMargin, threshold]);
 
   const ref = useCallback((nodeElement: HTMLElementOrNull) => {
     setNode(nodeElement);


### PR DESCRIPTION
Fixed an issue where the `IntersectionObserver` object was recreated and the callback was called excessively whenever the `options` or `callback` argument changed, even if the intersection state did not change.

#### AS-IS
```ts
const doSomethingWithEntry = useCallback(([entry]) => {
    // do something with entry
}, [ ...deps ]);

const callbackRef = useRef(doSomethingWithEntry);
callbackRef.current = doSomethingWithEntry;

const callback = useCallback((...args) => {
    return callbackRef.current?.(...args);
}, []);

const ref = useIntersectionObserverRef(
    callback,
    useMemo({ threshold: 0.5 }, [])
);
```

#### TO-BE
````ts
const callback = useCallback(([entry]) => {
    // do something with entry
}, [ ...deps ]);

const ref = useIntersectionObserverRef(callback, { threshold: 0.5 });
```
