### PR TITLE
Prevent excessive call of resize observer callback

### DIFF
--- a/packages/rooks/src/hooks/useResizeObserverRef.ts
+++ b/packages/rooks/src/hooks/useResizeObserverRef.ts
@@ -1,7 +1,6 @@
 import { noop } from "@/utils/noop";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CallbackRef, HTMLElementOrNull } from "../utils/utils";
-import { useFreshTick } from "./useFreshTick";
 
 const config: ResizeObserverOptions = {
   box: "content-box",
@@ -14,7 +13,7 @@ const config: ResizeObserverOptions = {
  * Returns a resize observer for a React Ref and fires a callback
  * https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
  *
- * @param {ResizeObserverCallback} callback Function that needs to be fired on resize
+ * @param {ResizeObserverCallback} callback Function that needs to be fired on resize: ;
  * @param {ResizeObserverOptions} options An options object allowing you to set options for the observation
  * @returns {[CallbackRef]} callbackref
  * @see https://rooks.vercel.app/docs/useResizeObserverRef
@@ -23,23 +22,32 @@ function useResizeObserverRef(
   callback: ResizeObserverCallback,
   options: ResizeObserverOptions = config
 ): [CallbackRef] {
+  const { box } = options;
   const [node, setNode] = useState<HTMLElementOrNull>(null);
-  const freshCallback = useFreshTick(callback);
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const handleResizeObserver = useCallback<ResizeObserverCallback>(
+    (...args) => {
+      callbackRef.current(...args);
+    },
+    []
+  );
 
   useEffect(() => {
     if (node) {
       // Create an observer instance linked to the callback function
-      const observer = new ResizeObserver(freshCallback);
+      const observer = new ResizeObserver(handleResizeObserver);
 
       // Start observing the target node for resizes
-      observer.observe(node, options);
+      observer.observe(node, { box });
 
       return () => {
         observer.disconnect();
       };
     }
     return noop;
-  }, [node, freshCallback, options]);
+  }, [node, handleResizeObserver, box]);
 
   const ref: CallbackRef = useCallback((node: HTMLElementOrNull) => {
     setNode(node);

--- a/packages/rooks/src/hooks/useResizeObserverRef.ts
+++ b/packages/rooks/src/hooks/useResizeObserverRef.ts
@@ -25,7 +25,10 @@ function useResizeObserverRef(
   const { box } = options;
   const [node, setNode] = useState<HTMLElementOrNull>(null);
   const callbackRef = useRef(callback);
-  callbackRef.current = callback;
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
 
   const handleResizeObserver = useCallback<ResizeObserverCallback>(
     (...args) => {

--- a/packages/rooks/src/hooks/useResizeObserverRef.ts
+++ b/packages/rooks/src/hooks/useResizeObserverRef.ts
@@ -38,7 +38,7 @@ function useResizeObserverRef(
   );
 
   useEffect(() => {
-    if (node && callbackRef.current) {
+    if (node) {
       // Create an observer instance linked to the callback function
       const observer = new ResizeObserver(handleResizeObserver);
 

--- a/packages/rooks/src/hooks/useResizeObserverRef.ts
+++ b/packages/rooks/src/hooks/useResizeObserverRef.ts
@@ -19,7 +19,7 @@ const config: ResizeObserverOptions = {
  * @see https://rooks.vercel.app/docs/useResizeObserverRef
  */
 function useResizeObserverRef(
-  callback: ResizeObserverCallback,
+  callback: ResizeObserverCallback | undefined,
   options: ResizeObserverOptions = config
 ): [CallbackRef] {
   const { box } = options;
@@ -29,13 +29,13 @@ function useResizeObserverRef(
 
   const handleResizeObserver = useCallback<ResizeObserverCallback>(
     (...args) => {
-      callbackRef.current(...args);
+      callbackRef.current?.(...args);
     },
     []
   );
 
   useEffect(() => {
-    if (node) {
+    if (node && callbackRef.current) {
       // Create an observer instance linked to the callback function
       const observer = new ResizeObserver(handleResizeObserver);
 


### PR DESCRIPTION
The same problem with #1568 also existed with `useMutationObserver` and we fixed it.
This issue can also be seen in examples in the [official documentation](https://rooks.vercel.app/docs/useResizeObserverRef).

![useResizeObserverRef](https://user-images.githubusercontent.com/77329061/210852669-6cfdc684-d6a7-4a8b-a498-470e755aa8b8.gif)

Since a new callback is created and passed every render, then the callback is called because new `ResizeObserver` is created, and since the callback is changing the state of `resizeCount`, so it re-renders infinitely.

Additionally, it would be nice to be able to cancel observing using a nullish callback like `useIntersectionObserver`, so I modified it the same way.(ref: #897)