### PR TITLE
fix(useDebouncedValue): types of useDebouncedValue will only add null to the union if initializeWithNull was passed

### DIFF
--- a/packages/rooks/src/__tests__/useDebouncedValue.spec.ts
+++ b/packages/rooks/src/__tests__/useDebouncedValue.spec.ts
@@ -2,6 +2,16 @@ import type { RenderResult } from "@testing-library/react-hooks";
 import { act, renderHook } from "@testing-library/react-hooks";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+  ? 1
+  : 2
+  ? true
+  : false;
+
+type Expect<T extends true> = T;
+
+const doNotExecute = (_func: () => void) => true;
+
 describe("useDebouncedValue", () => {
   beforeEach(() => {
     jest.useFakeTimers("modern");
@@ -99,5 +109,43 @@ describe("useDebouncedValue", () => {
       jest.runAllTimers();
     });
     expect(result.current[0]).toBe(mockValue);
+  });
+
+  describe("types", () => {
+    it("should return a union with null when initializeWithNull is true", () => {
+      doNotExecute(() => {
+        const hookResult = renderHook(() =>
+          useDebouncedValue("mock_value", 200, { initializeWithNull: true })
+        );
+        const result: Expect<
+          Equal<string | null, typeof hookResult.result.current[0]>
+        > = true;
+        return result;
+      });
+    });
+
+    it("should not return a union with null per default", () => {
+      doNotExecute(() => {
+        const hookResult = renderHook(() =>
+          useDebouncedValue("mock_value", 200)
+        );
+        const result: Expect<
+          Equal<string, typeof hookResult.result.current[0]>
+        > = true;
+        return result;
+      });
+    });
+
+    it("should not return a union with null when initializeWithNull is false", () => {
+      doNotExecute(() => {
+        const hookResult = renderHook(() =>
+          useDebouncedValue("mock_value", 200, { initializeWithNull: false })
+        );
+        const result: Expect<
+          Equal<string, typeof hookResult.result.current[0]>
+        > = true;
+        return result;
+      });
+    });
   });
 });

--- a/packages/rooks/src/hooks/useDebouncedValue.ts
+++ b/packages/rooks/src/hooks/useDebouncedValue.ts
@@ -4,17 +4,23 @@ import { useDebounce } from "./useDebounce";
 import { useDidMount } from "./useDidMount";
 import { useDidUpdate } from "./useDidUpdate";
 
-type UseDebouncedValueOptions = Partial<{
-  initializeWithNull: boolean;
-}>;
+type UseDebouncedValueOptions<TInitializeWithNull extends boolean = false> =
+  Partial<{
+    initializeWithNull: TInitializeWithNull;
+  }>;
 
 const defaultUseDebounceValueOptions = {
   initializeWithNull: false,
 };
 
-type UseDebouncedValueReturnType<T> = [
-  debouncedValue: T | null,
-  immediatelyUpdateDebouncedValue: Dispatch<SetStateAction<T | null>>
+type UseDebouncedValueReturnType<
+  TValue = unknown,
+  TInitializeWithNull extends boolean = false
+> = [
+  debouncedValue: TInitializeWithNull extends true ? TValue | null : TValue,
+  immediatelyUpdateDebouncedValue: Dispatch<
+    SetStateAction<TInitializeWithNull extends true ? TValue | null : TValue>
+  >
 ];
 
 /**
@@ -24,18 +30,21 @@ type UseDebouncedValueReturnType<T> = [
  * @param options The options object.
  * @see https://rooks.vercel.app/docs/useDebouncedValue
  */
-export const useDebouncedValue = <T = unknown>(
-  value: T,
+export const useDebouncedValue = <
+  TValue = unknown,
+  TInitializeWithNull extends boolean = false
+>(
+  value: TValue,
   timeout: number,
-  options: UseDebouncedValueOptions = {}
-): UseDebouncedValueReturnType<T> => {
+  options: UseDebouncedValueOptions<TInitializeWithNull> = {}
+): UseDebouncedValueReturnType<TValue, TInitializeWithNull> => {
   // eslint-disable-next-line prefer-object-spread
   const { initializeWithNull } = Object.assign(
     {},
     defaultUseDebounceValueOptions,
     options
   );
-  const [updatedValue, setUpdatedValue] = useState<T | null>(
+  const [updatedValue, setUpdatedValue] = useState<TValue | null>(
     initializeWithNull ? null : value
   );
   const debouncedSetUpdatedValue = useDebounce(setUpdatedValue, timeout);
@@ -50,5 +59,8 @@ export const useDebouncedValue = <T = unknown>(
 
   // No need to add `debouncedSetUpdatedValue ` to dependencies as it is a ref.current.
   // returning both updatedValue and setUpdatedValue (not the debounced version) to instantly update this if  needed.
-  return [updatedValue, setUpdatedValue];
+  return [updatedValue, setUpdatedValue] as UseDebouncedValueReturnType<
+    TValue,
+    TInitializeWithNull
+  >;
 };


### PR DESCRIPTION
fixes #1573 