### PR TITLE
useLocalstorageState: Ensure the identity of set/remove don't change when used

### DIFF
--- a/.changeset/stale-poets-walk.md
+++ b/.changeset/stale-poets-walk.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+useLocalstorageState: ensure stable identity for set/remove functions

--- a/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
@@ -68,6 +68,20 @@ describe("useLocalstorageState basic", () => {
     const removeAfterRerender = result.current[2];
     expect(setBeforeRerender).toBe(setAfterRerender);
     expect(removeBeforeRerender).toBe(removeAfterRerender);
+    act(() => {
+      setBeforeRerender("next value");
+    });
+    const setAfterSet = result.current[1];
+    const removeAfterSet = result.current[2];
+    expect(setBeforeRerender).toBe(setAfterSet);
+    expect(removeBeforeRerender).toBe(removeAfterSet);
+    act(() => {
+      removeBeforeRerender();
+    });
+    const setAfterRemove = result.current[1];
+    const removeAfterRemove = result.current[2];
+    expect(setBeforeRerender).toBe(setAfterRemove);
+    expect(removeBeforeRerender).toBe(removeAfterRemove);
   });
 
   it("initializes correctly", () => {

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -1,3 +1,4 @@
+import { useFreshRef } from "@/hooks/useFreshRef";
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 
@@ -174,18 +175,20 @@ function useLocalstorageState<S>(
     [customEventTypeName]
   );
 
+  const currentValue = useFreshRef(value, true);
+
   const set = useCallback(
     (newValue: SetStateAction<S>) => {
       const resolvedNewValue =
         typeof newValue === "function"
-          ? (newValue as (prevState: S) => S)(value)
+          ? (newValue as (prevState: S) => S)(currentValue.current)
           : newValue;
       isUpdateFromCrossDocumentListener.current = false;
       isUpdateFromWithinDocumentListener.current = false;
       setValue(resolvedNewValue);
       broadcastValueWithinDocument(resolvedNewValue);
     },
-    [broadcastValueWithinDocument, value]
+    [broadcastValueWithinDocument, currentValue]
   );
 
   const remove = useCallback(() => {

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -1,6 +1,6 @@
-import { useFreshRef } from "@/hooks/useFreshRef";
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
+import { useFreshRef } from "./useFreshRef";
 
 // Gets value from localstorage
 function getValueFromLocalStorage(key: string) {


### PR DESCRIPTION
In https://github.com/imbhargav5/rooks/commit/adaaad1725977d539f5bda8c1fc8ee8358bd6a49#diff-b0add5bafe9b472c2eb73a766b1fde5062317a10e944f82725c1d782ccc7d6bf the possibility of using a function to generate the next state for `useLocalstorageState` was added. Unfortunately, this was done by adding the current value as a dependency of set, which meant its identity changed every time it is used. This is not the behaviour of `useState` and is not ideal – and most importantly its not necessary. We can just read the value from a ref instead.

This PR does that, and adds extra tests to ensure the identity of set (and remove) doesn't change when used. 