### PR TITLE
Fix: return type `ReadonlyMap` in useNativeMapState

### DIFF
--- a/packages/rooks/src/hooks/useNativeMapState.ts
+++ b/packages/rooks/src/hooks/useNativeMapState.ts
@@ -20,7 +20,7 @@ type MapControls<K, V> = {
 
 function useNativeMapState<K, V>(
   initialMapState?: Map<K, V>
-): [Map<K, V>, MapControls<K, V>] {
+): [ReadonlyMap<K, V>, MapControls<K, V>] {
   const [map, setMap] = useState<Map<K, V>>(initialMapState || new Map<K, V>());
 
   const set = useCallback((key: K, value: V) => {


### PR DESCRIPTION
This will prevent bugs where people try to directly modify the map. By making it a `ReadonlyMap`, they will have TypeScript errors which will remind them to modify mapControls instead of map.