### PR TITLE
feat: add `useCallOnce` hook

### DIFF
--- a/data/docs/useCallOnce.md
+++ b/data/docs/useCallOnce.md
@@ -1,0 +1,32 @@
+---
+id: useCallOnce
+title: useCallOnce
+sidebar_label: useCallOnce
+---
+
+## About
+
+Call the passed function once in the component lifecycle,
+
+unlike `useMemo` that even when you pass empty deps it might
+
+call your callback again (check last sentence in {@link https://legacy.reactjs.org/docs/hooks-reference.html#usememo react docs}),
+
+that's why some libraries use `useState` to call function once in the component lifecycle
+
+## Examples
+
+```tsx
+import { useCallOnce } from "rooks";
+
+export default function App() {
+  // `socket-io.client`
+  const socket = useCallOnce(() => io("https://my-server.com/"));
+
+  // `@tanstack/react-query`
+  const queryClient = useCallOnce(() => new QueryClient());
+
+  // initialize stuff for once in the App lifecycle
+  useCallOnce(() => init());
+}
+```

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -26,6 +26,11 @@
       "category": "ui"
     },
     {
+      "name": "useCallOnce",
+      "description": "Call the passed function once",
+      "category": "effects"
+    },
+    {
       "name": "useCountdown",
       "description": "Count down to a target timestamp and call callbacks every second (or provided peried)",
       "category": "state"

--- a/packages/rooks/src/__tests__/useCallOnce.spec.ts
+++ b/packages/rooks/src/__tests__/useCallOnce.spec.ts
@@ -1,0 +1,44 @@
+import React from "react";
+import { useCallOnce } from "@/hooks/useCallOnce";
+import { renderHook } from "@testing-library/react";
+
+describe("useCallOnce", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useCallOnce).toBeDefined();
+  });
+
+  it("should call the callback once", () => {
+    expect.hasAssertions();
+
+    const cb = jest.fn();
+
+    renderHook(() => useCallOnce(cb));
+
+    expect(cb).toBeCalledTimes(1);
+  });
+
+  it("should call the callback once even during rerenders", () => {
+    expect.hasAssertions();
+
+    const cb = jest.fn();
+
+    const { rerender, unmount } = renderHook(() => useCallOnce(cb));
+
+    rerender();
+    rerender();
+    unmount();
+
+    expect(cb).toBeCalledTimes(1);
+  });
+
+  it("should return value", () => {
+    expect.hasAssertions();
+
+    const cb = jest.fn(() => "value");
+
+    const { result } = renderHook(() => useCallOnce(cb));
+
+    expect(result.current).toBe("value");
+  });
+});

--- a/packages/rooks/src/hooks/useCallOnce.ts
+++ b/packages/rooks/src/hooks/useCallOnce.ts
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+/**
+ * Call the passed function once in the component lifecycle,
+ * 
+ * unlike `useMemo` that even when you pass empty deps it might
+ * 
+ * call your callback again (check last sentence in {@link https://legacy.reactjs.org/docs/hooks-reference.html#usememo react docs}),
+ * 
+ * that's why some libraries use `useState` to call function once in the component lifecycle
+ * 
+ * @param {() => T} cb Callback that's going to be called once in the component lifecycle
+ * @returns {T} The result from your callback
+ * @see {@link https://rooks.vercel.app/docs/useCallOnce}
+ * @example
+ * ```tsx
+ * import { useCallOnce } from "rooks";
+ * 
+ * export default function App() {
+ *   // `socket-io.client`
+ *   const socket = useCallOnce(() => io("https://my-server.com/"));
+ * 
+ *   // `@tanstack/react-query`
+ *   const queryClient = useCallOnce(() => new QueryClient());
+ * 
+ *   // initialize stuff for once in the App lifecycle
+ *   useCallOnce(() => init());
+ * }
+ * ```
+*/
+function useCallOnce<T>(cb: () => T): T {
+  return useState(cb)[0];
+}
+
+export { useCallOnce };


### PR DESCRIPTION
Adding `useCallOnce` hook

Call the passed function once in the component lifecycle,

unlike `useMemo` that even when you pass empty deps it might call your callback again (check last sentence in [react docs](https://legacy.reactjs.org/docs/hooks-reference.html#usememo)),

that's why some libraries use `useState` to call function once in the component lifecycle