### PR TITLE
Fix : useDocumentTitle markdown SyntaxError

### DIFF
--- a/data/docs/useDocumentTitle.md
+++ b/data/docs/useDocumentTitle.md
@@ -14,26 +14,6 @@ Sets the document title and optionally resets the title on unmount
 
 ### Basic example
 
-````jsx
-import { useDocumentTitle } from "rooks";
-
-function App() {
-  useDocumentTitle("New document title");
-
-  return (
-    <div>
-      <h1>Document title is now "New document title"</h1>
-    </div>
-  );
-}
-
-export default App;
-
-
-## Examples
-
-### Basic example
-
 ```jsx
 import { useDocumentTitle } from "rooks";
 
@@ -48,8 +28,7 @@ function App() {
 }
 
 export default App;
-
-````
+```
 
 ### Example with reset
 


### PR DESCRIPTION
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/1ffac4eb-afb7-447f-bcc7-c37711e75d6a">

There was an error in docs, so I fixed it
https://rooks.vercel.app/docs/useDocumentTitle