### PR TITLE
Disable size limit check for pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,13 +22,13 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           directory: packages/rooks/src/coverage
-  size-limit:
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ci-setup
-      - uses: andresz1/size-limit-action@v1.7.0
-        with:
-          directory: "packages/rooks"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  # size-limit:
+  #   timeout-minutes: 20
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: ./.github/actions/ci-setup
+  #     - uses: andresz1/size-limit-action@v1.7.0
+  #       with:
+  #         directory: "packages/rooks"
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Disable the size limit GitHub Actions check for pull requests by commenting out the job in `pr.yml` for easy re-enablement.