### PR TITLE
Fix pnpm build errors

### DIFF
--- a/apps/website/content/docs/hooks/useDebounceFn.mdx
+++ b/apps/website/content/docs/hooks/useDebounceFn.mdx
@@ -187,7 +187,7 @@ export default function App() {
 | -------- | -------- | ---------------------------------------------- | ------------------------------------ |
 | func     | Function | The function to debounce                       | -                                    |
 | delay    | Number   | The delay in milliseconds                      | -                                    |
-| options  | Object   | Configuration options (see options table)     | { leading: false, trailing: true }   |
+| options  | Object   | Configuration options (see options table)     | `{ leading: false, trailing: true }` |
 
 ### Options
 

--- a/apps/website/content/docs/hooks/useSafeSetState.mdx
+++ b/apps/website/content/docs/hooks/useSafeSetState.mdx
@@ -135,7 +135,7 @@ Returns an array with two elements:
 | Return value  | Type                              | Description                                                           | Default   |
 | ------------- | --------------------------------- | --------------------------------------------------------------------- | --------- |
 | state         | T                                 | The current state value                                               | undefined |
-| safeSetState  | Dispatch<SetStateAction<T>>       | Function to update state, but only if component is still mounted     | undefined |
+| safeSetState  | `Dispatch<SetStateAction<T>>`     | Function to update state, but only if component is still mounted     | undefined |
 
 ### Behavior
 

--- a/apps/website/content/docs/hooks/useSessionstorageState.mdx
+++ b/apps/website/content/docs/hooks/useSessionstorageState.mdx
@@ -170,7 +170,7 @@ Returns an array with three elements:
 | Return value | Type                        | Description                                           |
 | ------------ | --------------------------- | ----------------------------------------------------- |
 | value        | S                           | Current state value, synchronized with sessionStorage |
-| setValue     | Dispatch<SetStateAction<S>> | Function to update the state (similar to useState)    |
+| setValue     | `Dispatch<SetStateAction<S>>` | Function to update the state (similar to useState)    |
 | remove       | () => void                  | Function to remove the item from sessionStorage       |
 
 ### Features


### PR DESCRIPTION
Escape TypeScript generic and JavaScript object syntax in MDX files to fix build errors.

The MDX parser was failing to correctly interpret TypeScript generic syntax (e.g., `<T>`) and certain JavaScript object literal syntax when used directly in the MDX content, leading to build failures. Escaping these expressions allows the parser to process the files correctly.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-240fb066-ae43-4048-b26c-ffcd534b7575) · [Cursor](https://cursor.com/background-agent?bcId=bc-240fb066-ae43-4048-b26c-ffcd534b7575)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)