### PR TITLE
Fix pnpm build failure

### DIFF
--- a/apps/website/content/docs/hooks/useSetState.mdx
+++ b/apps/website/content/docs/hooks/useSetState.mdx
@@ -105,7 +105,7 @@ export default function App() {
 
 | Argument value   | Type   | Description                      | Default |
 | ---------------- | ------ | -------------------------------- | ------- |
-| initialSetValue  | Set<T> | The initial value of the set to manage | Required |
+| initialSetValue  | `Set<T>` | The initial value of the set to manage | Required |
 
 ### Returns
 
@@ -113,8 +113,8 @@ Returns an array with two elements:
 
 | Return value | Type                    | Description                                    | Default   |
 | ------------ | ----------------------- | ---------------------------------------------- | --------- |
-| set          | Set<T>                  | The current state of the Set                   | new Set() |
-| controls     | UseSetStateControls<T>  | An object containing set manipulation methods   | {}        |
+| set          | `Set<T>`                  | The current state of the Set                   | new Set() |
+| controls     | `UseSetStateControls<T>`  | An object containing set manipulation methods   | {}        |
 
 ### Control Methods
 


### PR DESCRIPTION
Wrap TypeScript generics in backticks in MDX documentation to fix build failures caused by MDX parsing errors.

The build was failing because MDX was misinterpreting TypeScript generic types like `Set<T>` within markdown tables as unclosed JSX tags (`<T>`), leading to parsing errors. Wrapping these types in backticks ensures they are treated as inline code.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-214d566f-572a-4991-918a-c4128e1ec206) · [Cursor](https://cursor.com/background-agent?bcId=bc-214d566f-572a-4991-918a-c4128e1ec206)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)