### PR TITLE
Fix readme image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br/>
 <br/>
 <p align="center">
-  <img src="https://cdn.discordapp.com/attachments/761126463457460234/775262278026788885/Final_Copy_8.png" height="auto" width="100%" />
+  <img src=".github/assets/Final_Copy_8.png" height="auto" width="100%" />
 </p>
 <br/>
 


### PR DESCRIPTION
Update README image source to local path to fix 404 rendering issue.

The README was referencing an image from an external Discord CDN URL which was returning a 404. This PR updates the source to the correct local path within the repository.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f7c811f2-c8de-40ea-bb57-3f81046700b4) · [Cursor](https://cursor.com/background-agent?bcId=bc-f7c811f2-c8de-40ea-bb57-3f81046700b4)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)