### PR TITLE
Fix readme asset visibility on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br/>
 <br/>
 <p align="center">
-  <img src=".github/assets/Final_Copy_8.png" height="auto" width="100%" />
+  <img src="https://raw.githubusercontent.com/imbhargav5/rooks/main/.github/assets/Final_Copy_8.png" height="auto" width="100%" />
 </p>
 <br/>
 


### PR DESCRIPTION
Update README image path to use GitHub raw URL for npm visibility.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f0344689-9b4a-48e8-88ae-d29a7ededee3) · [Cursor](https://cursor.com/background-agent?bcId=bc-f0344689-9b4a-48e8-88ae-d29a7ededee3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)