### PR TITLE
Fix readme documentation link generation

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -224,7 +224,7 @@ type CounterHandler = {
  * @property {Function} incrementBy Increment counter by incrAmount
  * @property {Function} decrementBy Decrement counter by decrAmount
  * @property {Function} reset Reset counter to initialValue
- * @see {@link https://rooks.vercel.app/docs/useCounter}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useCounter}
  */
 
 /**
@@ -232,7 +232,7 @@ type CounterHandler = {
  *
  * @param {number} initialValue The initial value of the counter
  * @returns {handler} A handler to interact with the counter
- * @see https://rooks.vercel.app/docs/useCounter
+ * @see https://rooks.vercel.app/docs/hooks/useCounter
  */
 function useCounter(initialValue: number): CounterHandler {
   const [counter, setCounter] = useState(initialValue);

--- a/README.md
+++ b/README.md
@@ -33,144 +33,144 @@
 
 <h3 align="center">🎬 Animation & Timing - 5 hooks</h3>
 
-* [useIntervalWhen](https://rooks.vercel.app/docs/useIntervalWhen) - Sets an interval immediately when a condition is true
-* [useLockBodyScroll](https://rooks.vercel.app/docs/useLockBodyScroll) - This hook locks the scroll of the body element when `isLocked` is set to `true`.
-* [useRaf](https://rooks.vercel.app/docs/useRaf) - A continuously running requestAnimationFrame hook for React
-* [useResizeObserverRef](https://rooks.vercel.app/docs/useResizeObserverRef) - Resize Observer hook for React.
-* [useTimeoutWhen](https://rooks.vercel.app/docs/useTimeoutWhen) - Takes a callback and fires it when a condition is true
+* [useIntervalWhen](https://rooks.vercel.app/docs/hooks/useIntervalWhen) - Sets an interval immediately when a condition is true
+* [useLockBodyScroll](https://rooks.vercel.app/docs/hooks/useLockBodyScroll) - This hook locks the scroll of the body element when `isLocked` is set to `true`.
+* [useRaf](https://rooks.vercel.app/docs/hooks/useRaf) - A continuously running requestAnimationFrame hook for React
+* [useResizeObserverRef](https://rooks.vercel.app/docs/hooks/useResizeObserverRef) - Resize Observer hook for React.
+* [useTimeoutWhen](https://rooks.vercel.app/docs/hooks/useTimeoutWhen) - Takes a callback and fires it when a condition is true
 
 <h3 align="center">🌐 Browser APIs - 9 hooks</h3>
 
-* [useGeolocation](https://rooks.vercel.app/docs/useGeolocation) - A hook to provide the geolocation info on client side.
-* [useIdleDetectionApi](https://rooks.vercel.app/docs/useIdleDetectionApi) - Hook to detect when user is idle using Idle Detection API with polyfill
-* [useNavigatorLanguage](https://rooks.vercel.app/docs/useNavigatorLanguage) - Navigator Language hook for React.
-* [useOnline](https://rooks.vercel.app/docs/useOnline) - Online status hook for React.
-* [useOrientation](https://rooks.vercel.app/docs/useOrientation) - orientation hook for react
-* [useScreenDetailsApi](https://rooks.vercel.app/docs/useScreenDetailsApi) - Hook for multi-screen information and management using Screen Details API
-* [useSpeech](https://rooks.vercel.app/docs/useSpeech) - Speech synthesis hook for React
-* [useVibrate](https://rooks.vercel.app/docs/useVibrate) - Vibration API hook for React
-* [useWebLocksApi](https://rooks.vercel.app/docs/useWebLocksApi) - Hook for coordinating operations across tabs/workers with Web Locks API
+* [useGeolocation](https://rooks.vercel.app/docs/hooks/useGeolocation) - A hook to provide the geolocation info on client side.
+* [useIdleDetectionApi](https://rooks.vercel.app/docs/hooks/useIdleDetectionApi) - Hook to detect when user is idle using Idle Detection API with polyfill
+* [useNavigatorLanguage](https://rooks.vercel.app/docs/hooks/useNavigatorLanguage) - Navigator Language hook for React.
+* [useOnline](https://rooks.vercel.app/docs/hooks/useOnline) - Online status hook for React.
+* [useOrientation](https://rooks.vercel.app/docs/hooks/useOrientation) - orientation hook for react
+* [useScreenDetailsApi](https://rooks.vercel.app/docs/hooks/useScreenDetailsApi) - Hook for multi-screen information and management using Screen Details API
+* [useSpeech](https://rooks.vercel.app/docs/hooks/useSpeech) - Speech synthesis hook for React
+* [useVibrate](https://rooks.vercel.app/docs/hooks/useVibrate) - Vibration API hook for React
+* [useWebLocksApi](https://rooks.vercel.app/docs/hooks/useWebLocksApi) - Hook for coordinating operations across tabs/workers with Web Locks API
 
 <h3 align="center">🛠️ Development & Debugging - 2 hooks</h3>
 
-* [useRenderCount](https://rooks.vercel.app/docs/useRenderCount) - Get the render count of a component
-* [useWhyDidYouUpdate](https://rooks.vercel.app/docs/useWhyDidYouUpdate) - A hook that can track which value change caused a rerender
+* [useRenderCount](https://rooks.vercel.app/docs/hooks/useRenderCount) - Get the render count of a component
+* [useWhyDidYouUpdate](https://rooks.vercel.app/docs/hooks/useWhyDidYouUpdate) - A hook that can track which value change caused a rerender
 
 <h3 align="center">🚀 Events - 14 hooks</h3>
 
-* [useDocumentEventListener](https://rooks.vercel.app/docs/useDocumentEventListener) - A react hook to an event listener to the document object
-* [useDocumentVisibilityState](https://rooks.vercel.app/docs/useDocumentVisibilityState) - Returns the visibility state of the document.
-* [useFocus](https://rooks.vercel.app/docs/useFocus) - Handles focus events for the immediate target element.
-* [useFocusWithin](https://rooks.vercel.app/docs/useFocusWithin) - Handles focus events for the target component.
-* [useIsDroppingFiles](https://rooks.vercel.app/docs/useIsDroppingFiles) - Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
-* [useOnClickRef](https://rooks.vercel.app/docs/useOnClickRef) - Callback on click/tap events
-* [useOnHoverRef](https://rooks.vercel.app/docs/useOnHoverRef) - On hover callback hook
-* [useOnLongHover](https://rooks.vercel.app/docs/useOnLongHover) - Fires a callback when an element is hovered for a while
-* [useOnLongPress](https://rooks.vercel.app/docs/useOnLongPress) - Fire a callback on long press
-* [useOnWindowResize](https://rooks.vercel.app/docs/useOnWindowResize) - A React hook for adding an event listener for window resize
-* [useOnWindowScroll](https://rooks.vercel.app/docs/useOnWindowScroll) - A React hook for adding an event listener for window scroll
-* [useOutsideClick](https://rooks.vercel.app/docs/useOutsideClick) - Outside click(for a ref) event as hook for React.
-* [useOutsideClickRef](https://rooks.vercel.app/docs/useOutsideClickRef) - A hook that can track a click event outside a ref. Returns a callbackRef.
-* [useWindowEventListener](https://rooks.vercel.app/docs/useWindowEventListener) - Adds an event listener to window
+* [useDocumentEventListener](https://rooks.vercel.app/docs/hooks/useDocumentEventListener) - A react hook to an event listener to the document object
+* [useDocumentVisibilityState](https://rooks.vercel.app/docs/hooks/useDocumentVisibilityState) - Returns the visibility state of the document.
+* [useFocus](https://rooks.vercel.app/docs/hooks/useFocus) - Handles focus events for the immediate target element.
+* [useFocusWithin](https://rooks.vercel.app/docs/hooks/useFocusWithin) - Handles focus events for the target component.
+* [useIsDroppingFiles](https://rooks.vercel.app/docs/hooks/useIsDroppingFiles) - Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
+* [useOnClickRef](https://rooks.vercel.app/docs/hooks/useOnClickRef) - Callback on click/tap events
+* [useOnHoverRef](https://rooks.vercel.app/docs/hooks/useOnHoverRef) - On hover callback hook
+* [useOnLongHover](https://rooks.vercel.app/docs/hooks/useOnLongHover) - Fires a callback when an element is hovered for a while
+* [useOnLongPress](https://rooks.vercel.app/docs/hooks/useOnLongPress) - Fire a callback on long press
+* [useOnWindowResize](https://rooks.vercel.app/docs/hooks/useOnWindowResize) - A React hook for adding an event listener for window resize
+* [useOnWindowScroll](https://rooks.vercel.app/docs/hooks/useOnWindowScroll) - A React hook for adding an event listener for window scroll
+* [useOutsideClick](https://rooks.vercel.app/docs/hooks/useOutsideClick) - Outside click(for a ref) event as hook for React.
+* [useOutsideClickRef](https://rooks.vercel.app/docs/hooks/useOutsideClickRef) - A hook that can track a click event outside a ref. Returns a callbackRef.
+* [useWindowEventListener](https://rooks.vercel.app/docs/hooks/useWindowEventListener) - Adds an event listener to window
 
 <h3 align="center">📝 Form & File Handling - 1 hook</h3>
 
-* [useFileDropRef](https://rooks.vercel.app/docs/useFileDropRef) - Drop files easily
+* [useFileDropRef](https://rooks.vercel.app/docs/hooks/useFileDropRef) - Drop files easily
 
 <h3 align="center">⌨️ Keyboard & Input - 5 hooks</h3>
 
-* [useInput](https://rooks.vercel.app/docs/useInput) - Input hook for React.
-* [useKey](https://rooks.vercel.app/docs/useKey) - keypress, keyup and keydown event handlers as hooks for react.
-* [useKeyBindings](https://rooks.vercel.app/docs/useKeyBindings) - useKeyBindings can bind multiple keys to multiple callbacks and fire the callbacks on key press.
-* [useKeyRef](https://rooks.vercel.app/docs/useKeyRef) - Very similar useKey but it returns a ref
-* [useKeys](https://rooks.vercel.app/docs/useKeys) - A hook which allows to setup callbacks when a combination of keys are pressed at the same time.
+* [useInput](https://rooks.vercel.app/docs/hooks/useInput) - Input hook for React.
+* [useKey](https://rooks.vercel.app/docs/hooks/useKey) - keypress, keyup and keydown event handlers as hooks for react.
+* [useKeyBindings](https://rooks.vercel.app/docs/hooks/useKeyBindings) - useKeyBindings can bind multiple keys to multiple callbacks and fire the callbacks on key press.
+* [useKeyRef](https://rooks.vercel.app/docs/hooks/useKeyRef) - Very similar useKey but it returns a ref
+* [useKeys](https://rooks.vercel.app/docs/hooks/useKeys) - A hook which allows to setup callbacks when a combination of keys are pressed at the same time.
 
 <h3 align="center">🔥 Lifecycle & Effects - 9 hooks</h3>
 
-* [useAsyncEffect](https://rooks.vercel.app/docs/useAsyncEffect) - A version of useEffect that accepts an async function
-* [useDeepCompareEffect](https://rooks.vercel.app/docs/useDeepCompareEffect) - Deep compare dependencies instead of shallow for useEffect
-* [useDidMount](https://rooks.vercel.app/docs/useDidMount) - componentDidMount hook for React
-* [useDidUpdate](https://rooks.vercel.app/docs/useDidUpdate) - componentDidUpdate hook for react
-* [useDocumentTitle](https://rooks.vercel.app/docs/useDocumentTitle) - A hook to easily update document title with React
-* [useEffectOnceWhen](https://rooks.vercel.app/docs/useEffectOnceWhen) - Runs a callback effect atmost one time when a condition becomes true
-* [useIsomorphicEffect](https://rooks.vercel.app/docs/useIsomorphicEffect) - A hook that resolves to useEffect on the server and useLayoutEffect on the client.
-* [useLifecycleLogger](https://rooks.vercel.app/docs/useLifecycleLogger) - A react hook that console logs parameters as component transitions through lifecycles.
-* [useWillUnmount](https://rooks.vercel.app/docs/useWillUnmount) - componentWillUnmount lifecycle as hook for React.
+* [useAsyncEffect](https://rooks.vercel.app/docs/hooks/useAsyncEffect) - A version of useEffect that accepts an async function
+* [useDeepCompareEffect](https://rooks.vercel.app/docs/hooks/useDeepCompareEffect) - Deep compare dependencies instead of shallow for useEffect
+* [useDidMount](https://rooks.vercel.app/docs/hooks/useDidMount) - componentDidMount hook for React
+* [useDidUpdate](https://rooks.vercel.app/docs/hooks/useDidUpdate) - componentDidUpdate hook for react
+* [useDocumentTitle](https://rooks.vercel.app/docs/hooks/useDocumentTitle) - A hook to easily update document title with React
+* [useEffectOnceWhen](https://rooks.vercel.app/docs/hooks/useEffectOnceWhen) - Runs a callback effect atmost one time when a condition becomes true
+* [useIsomorphicEffect](https://rooks.vercel.app/docs/hooks/useIsomorphicEffect) - A hook that resolves to useEffect on the server and useLayoutEffect on the client.
+* [useLifecycleLogger](https://rooks.vercel.app/docs/hooks/useLifecycleLogger) - A react hook that console logs parameters as component transitions through lifecycles.
+* [useWillUnmount](https://rooks.vercel.app/docs/hooks/useWillUnmount) - componentWillUnmount lifecycle as hook for React.
 
 <h3 align="center">🖱️ Mouse & Touch - 3 hooks</h3>
 
-* [useMouse](https://rooks.vercel.app/docs/useMouse) - Mouse position hook for React.
-* [useMouseMoveDelta](https://rooks.vercel.app/docs/useMouseMoveDelta) - Tracks delta of mouse move
-* [useMouseWheelDelta](https://rooks.vercel.app/docs/useMouseWheelDelta) - Tracks delta of mouse move
+* [useMouse](https://rooks.vercel.app/docs/hooks/useMouse) - Mouse position hook for React.
+* [useMouseMoveDelta](https://rooks.vercel.app/docs/hooks/useMouseMoveDelta) - Tracks delta of mouse move
+* [useMouseWheelDelta](https://rooks.vercel.app/docs/hooks/useMouseWheelDelta) - Tracks delta of mouse move
 
 <h3 align="center">⚡ Performance & Optimization - 4 hooks</h3>
 
-* [useDebounce](https://rooks.vercel.app/docs/useDebounce) - Debounce hook for react
-* [useDebouncedValue](https://rooks.vercel.app/docs/useDebouncedValue) - Tracks another value and gets updated in a debounced way.
-* [useDebounceFn](https://rooks.vercel.app/docs/useDebounceFn) - Powerful debounce function hook for React
-* [useThrottle](https://rooks.vercel.app/docs/useThrottle) - Throttle custom hook for React
+* [useDebounce](https://rooks.vercel.app/docs/hooks/useDebounce) - Debounce hook for react
+* [useDebouncedValue](https://rooks.vercel.app/docs/hooks/useDebouncedValue) - Tracks another value and gets updated in a debounced way.
+* [useDebounceFn](https://rooks.vercel.app/docs/hooks/useDebounceFn) - Powerful debounce function hook for React
+* [useThrottle](https://rooks.vercel.app/docs/hooks/useThrottle) - Throttle custom hook for React
 
 <h3 align="center">❇️ State - 18 hooks</h3>
 
-* [useArrayState](https://rooks.vercel.app/docs/useArrayState) - Array state manager hook for React
-* [useCountdown](https://rooks.vercel.app/docs/useCountdown) - Count down to a target timestamp and call callbacks every second (or provided peried)
-* [useCounter](https://rooks.vercel.app/docs/useCounter) - Counter hook for React.
-* [useGetIsMounted](https://rooks.vercel.app/docs/useGetIsMounted) - Checks if a component is mounted or not at the time. Useful for async effects
-* [useLocalstorageState](https://rooks.vercel.app/docs/useLocalstorageState) - UseState but auto updates values to localStorage
-* [useMapState](https://rooks.vercel.app/docs/useMapState) - A react hook to manage state in a key value pair map.
-* [useMultiSelectableList](https://rooks.vercel.app/docs/useMultiSelectableList) - A custom hook to easily select multiple values from a list
-* [useNativeMapState](https://rooks.vercel.app/docs/useNativeMapState) - Manage Map() object state in React
-* [usePreviousDifferent](https://rooks.vercel.app/docs/usePreviousDifferent) - usePreviousDifferent returns the last different value of a variable
-* [usePreviousImmediate](https://rooks.vercel.app/docs/usePreviousImmediate) - usePreviousImmediate returns the previous value of a variable even if it was the same or different
-* [usePromise](https://rooks.vercel.app/docs/usePromise) - Promise management hook for react
-* [useQueueState](https://rooks.vercel.app/docs/useQueueState) - A React hook that manages state in the form of a queue
-* [useSafeSetState](https://rooks.vercel.app/docs/useSafeSetState) - set state but ignores if component has already unmounted
-* [useSelect](https://rooks.vercel.app/docs/useSelect) - Select values from a list easily. List selection hook for react.
-* [useSelectableList](https://rooks.vercel.app/docs/useSelectableList) - Easily select a single value from a list of values. very useful for radio buttons, select inputs  etc.
-* [useSessionstorageState](https://rooks.vercel.app/docs/useSessionstorageState) - useState but syncs with sessionstorage
-* [useSetState](https://rooks.vercel.app/docs/useSetState) - Manage the state of a Set in React.
-* [useStackState](https://rooks.vercel.app/docs/useStackState) - A React hook that manages state in the form of a stack
+* [useArrayState](https://rooks.vercel.app/docs/hooks/useArrayState) - Array state manager hook for React
+* [useCountdown](https://rooks.vercel.app/docs/hooks/useCountdown) - Count down to a target timestamp and call callbacks every second (or provided peried)
+* [useCounter](https://rooks.vercel.app/docs/hooks/useCounter) - Counter hook for React.
+* [useGetIsMounted](https://rooks.vercel.app/docs/hooks/useGetIsMounted) - Checks if a component is mounted or not at the time. Useful for async effects
+* [useLocalstorageState](https://rooks.vercel.app/docs/hooks/useLocalstorageState) - UseState but auto updates values to localStorage
+* [useMapState](https://rooks.vercel.app/docs/hooks/useMapState) - A react hook to manage state in a key value pair map.
+* [useMultiSelectableList](https://rooks.vercel.app/docs/hooks/useMultiSelectableList) - A custom hook to easily select multiple values from a list
+* [useNativeMapState](https://rooks.vercel.app/docs/hooks/useNativeMapState) - Manage Map() object state in React
+* [usePreviousDifferent](https://rooks.vercel.app/docs/hooks/usePreviousDifferent) - usePreviousDifferent returns the last different value of a variable
+* [usePreviousImmediate](https://rooks.vercel.app/docs/hooks/usePreviousImmediate) - usePreviousImmediate returns the previous value of a variable even if it was the same or different
+* [usePromise](https://rooks.vercel.app/docs/hooks/usePromise) - Promise management hook for react
+* [useQueueState](https://rooks.vercel.app/docs/hooks/useQueueState) - A React hook that manages state in the form of a queue
+* [useSafeSetState](https://rooks.vercel.app/docs/hooks/useSafeSetState) - set state but ignores if component has already unmounted
+* [useSelect](https://rooks.vercel.app/docs/hooks/useSelect) - Select values from a list easily. List selection hook for react.
+* [useSelectableList](https://rooks.vercel.app/docs/hooks/useSelectableList) - Easily select a single value from a list of values. very useful for radio buttons, select inputs  etc.
+* [useSessionstorageState](https://rooks.vercel.app/docs/hooks/useSessionstorageState) - useState but syncs with sessionstorage
+* [useSetState](https://rooks.vercel.app/docs/hooks/useSetState) - Manage the state of a Set in React.
+* [useStackState](https://rooks.vercel.app/docs/hooks/useStackState) - A React hook that manages state in the form of a stack
 
 <h3 align="center">🔄 State History & Time Travel - 4 hooks</h3>
 
-* [useTimeTravelState](https://rooks.vercel.app/docs/useTimeTravelState) - A hook that manages state which can undo and redo. A more powerful version of useUndoState hook.
-* [useToggle](https://rooks.vercel.app/docs/useToggle) - Toggle (between booleans or custom data)hook for React.
-* [useUndoRedoState](https://rooks.vercel.app/docs/useUndoRedoState) - Setstate but can also undo and redo
-* [useUndoState](https://rooks.vercel.app/docs/useUndoState) - Drop in replacement for useState hook but with undo functionality.
+* [useTimeTravelState](https://rooks.vercel.app/docs/hooks/useTimeTravelState) - A hook that manages state which can undo and redo. A more powerful version of useUndoState hook.
+* [useToggle](https://rooks.vercel.app/docs/hooks/useToggle) - Toggle (between booleans or custom data)hook for React.
+* [useUndoRedoState](https://rooks.vercel.app/docs/hooks/useUndoRedoState) - Setstate but can also undo and redo
+* [useUndoState](https://rooks.vercel.app/docs/hooks/useUndoState) - Drop in replacement for useState hook but with undo functionality.
 
 <h3 align="center">⚛️ UI - 12 hooks</h3>
 
-* [useAudio](https://rooks.vercel.app/docs/useAudio) - Audio hook
-* [useBoundingclientrect](https://rooks.vercel.app/docs/useBoundingclientrect) - getBoundingClientRect hook for React.
-* [useBoundingclientrectRef](https://rooks.vercel.app/docs/useBoundingclientrectRef) - A hook that tracks the boundingclientrect of an element. It returns a callbackRef so that the element node if changed is easily tracked.
-* [useDimensionsRef](https://rooks.vercel.app/docs/useDimensionsRef) - Easily grab dimensions of an element with a ref using this hook
-* [useFullscreen](https://rooks.vercel.app/docs/useFullscreen) - Use full screen api for making beautiful and emersive experinces.
-* [useIntersectionObserverRef](https://rooks.vercel.app/docs/useIntersectionObserverRef) - A hook to register an intersection observer listener.
-* [useInViewRef](https://rooks.vercel.app/docs/useInViewRef) - Simple hook that monitors element enters or leave the viewport that's using Intersection Observer API.
-* [useMediaMatch](https://rooks.vercel.app/docs/useMediaMatch) - Signal whether or not a media query is currently matched.
-* [useMutationObserver](https://rooks.vercel.app/docs/useMutationObserver) - Mutation Observer hook for React.
-* [useMutationObserverRef](https://rooks.vercel.app/docs/useMutationObserverRef) - A hook that tracks mutations of an element. It returns a callbackRef.
-* [usePictureInPictureApi](https://rooks.vercel.app/docs/usePictureInPictureApi) - Hook for managing Picture-in-Picture video functionality
-* [useVideo](https://rooks.vercel.app/docs/useVideo) - Video hook for react
+* [useAudio](https://rooks.vercel.app/docs/hooks/useAudio) - Audio hook
+* [useBoundingclientrect](https://rooks.vercel.app/docs/hooks/useBoundingclientrect) - getBoundingClientRect hook for React.
+* [useBoundingclientrectRef](https://rooks.vercel.app/docs/hooks/useBoundingclientrectRef) - A hook that tracks the boundingclientrect of an element. It returns a callbackRef so that the element node if changed is easily tracked.
+* [useDimensionsRef](https://rooks.vercel.app/docs/hooks/useDimensionsRef) - Easily grab dimensions of an element with a ref using this hook
+* [useFullscreen](https://rooks.vercel.app/docs/hooks/useFullscreen) - Use full screen api for making beautiful and emersive experinces.
+* [useIntersectionObserverRef](https://rooks.vercel.app/docs/hooks/useIntersectionObserverRef) - A hook to register an intersection observer listener.
+* [useInViewRef](https://rooks.vercel.app/docs/hooks/useInViewRef) - Simple hook that monitors element enters or leave the viewport that's using Intersection Observer API.
+* [useMediaMatch](https://rooks.vercel.app/docs/hooks/useMediaMatch) - Signal whether or not a media query is currently matched.
+* [useMutationObserver](https://rooks.vercel.app/docs/hooks/useMutationObserver) - Mutation Observer hook for React.
+* [useMutationObserverRef](https://rooks.vercel.app/docs/hooks/useMutationObserverRef) - A hook that tracks mutations of an element. It returns a callbackRef.
+* [usePictureInPictureApi](https://rooks.vercel.app/docs/hooks/usePictureInPictureApi) - Hook for managing Picture-in-Picture video functionality
+* [useVideo](https://rooks.vercel.app/docs/hooks/useVideo) - Video hook for react
 
 <h3 align="center">🔧 Utilities & Refs - 7 hooks</h3>
 
-* [useEventListenerRef](https://rooks.vercel.app/docs/useEventListenerRef) - A react hook to add an event listener to a ref
-* [useForkRef](https://rooks.vercel.app/docs/useForkRef) - A hook that can combine two refs(mutable or callbackRefs) into a single callbackRef
-* [useFreshCallback](https://rooks.vercel.app/docs/useFreshCallback) - Avoid stale closures and keep your callback fresh
-* [useFreshRef](https://rooks.vercel.app/docs/useFreshRef) - Avoid stale state in callbacks with this hook. Auto updates values using a ref.
-* [useFreshTick](https://rooks.vercel.app/docs/useFreshTick) - Like use-fresh-ref but specifically for functions
-* [useMergeRefs](https://rooks.vercel.app/docs/useMergeRefs) - Merges any number of refs into a single ref
-* [useRefElement](https://rooks.vercel.app/docs/useRefElement) - Helps bridge gap between callback ref and state
+* [useEventListenerRef](https://rooks.vercel.app/docs/hooks/useEventListenerRef) - A react hook to add an event listener to a ref
+* [useForkRef](https://rooks.vercel.app/docs/hooks/useForkRef) - A hook that can combine two refs(mutable or callbackRefs) into a single callbackRef
+* [useFreshCallback](https://rooks.vercel.app/docs/hooks/useFreshCallback) - Avoid stale closures and keep your callback fresh
+* [useFreshRef](https://rooks.vercel.app/docs/hooks/useFreshRef) - Avoid stale state in callbacks with this hook. Auto updates values using a ref.
+* [useFreshTick](https://rooks.vercel.app/docs/hooks/useFreshTick) - Like use-fresh-ref but specifically for functions
+* [useMergeRefs](https://rooks.vercel.app/docs/hooks/useMergeRefs) - Merges any number of refs into a single ref
+* [useRefElement](https://rooks.vercel.app/docs/hooks/useRefElement) - Helps bridge gap between callback ref and state
 
 <h3 align="center">📱 Window & Viewport - 2 hooks</h3>
 
-* [useWindowScrollPosition](https://rooks.vercel.app/docs/useWindowScrollPosition) - A React hook to get the scroll position of the window
-* [useWindowSize](https://rooks.vercel.app/docs/useWindowSize) - Window size hook for React.
+* [useWindowScrollPosition](https://rooks.vercel.app/docs/hooks/useWindowScrollPosition) - A React hook to get the scroll position of the window
+* [useWindowSize](https://rooks.vercel.app/docs/hooks/useWindowSize) - Window size hook for React.
 
 <h3 align="center">🧪 Experimental Hooks - 1 hook</h3>
 
-* [useSuspenseNavigatorUserAgentData](https://rooks.vercel.app/docs/useSuspenseNavigatorUserAgentData) - Suspense-enabled hook for getting high entropy values from Navigator User Agent Data API
+* [useSuspenseNavigatorUserAgentData](https://rooks.vercel.app/docs/hooks/useSuspenseNavigatorUserAgentData) - Suspense-enabled hook for getting high entropy values from Navigator User Agent Data API
 
 <p align="center"><em>⚠️ Experimental hooks may be removed or significantly changed in any release without notice. Use with caution in production.</em></p>
 

--- a/apps/website/src/pages/list-of-hooks.md
+++ b/apps/website/src/pages/list-of-hooks.md
@@ -8,144 +8,144 @@ sidebar_label: Hooks List
 
 <h3 align="center">🎬 Animation & Timing - 5 hooks</h3>
 
-* [useIntervalWhen](https://rooks.vercel.app/docs/useIntervalWhen) - Sets an interval immediately when a condition is true
-* [useLockBodyScroll](https://rooks.vercel.app/docs/useLockBodyScroll) - This hook locks the scroll of the body element when `isLocked` is set to `true`.
-* [useRaf](https://rooks.vercel.app/docs/useRaf) - A continuously running requestAnimationFrame hook for React
-* [useResizeObserverRef](https://rooks.vercel.app/docs/useResizeObserverRef) - Resize Observer hook for React.
-* [useTimeoutWhen](https://rooks.vercel.app/docs/useTimeoutWhen) - Takes a callback and fires it when a condition is true
+* [useIntervalWhen](https://rooks.vercel.app/docs/hooks/useIntervalWhen) - Sets an interval immediately when a condition is true
+* [useLockBodyScroll](https://rooks.vercel.app/docs/hooks/useLockBodyScroll) - This hook locks the scroll of the body element when `isLocked` is set to `true`.
+* [useRaf](https://rooks.vercel.app/docs/hooks/useRaf) - A continuously running requestAnimationFrame hook for React
+* [useResizeObserverRef](https://rooks.vercel.app/docs/hooks/useResizeObserverRef) - Resize Observer hook for React.
+* [useTimeoutWhen](https://rooks.vercel.app/docs/hooks/useTimeoutWhen) - Takes a callback and fires it when a condition is true
 
 <h3 align="center">🌐 Browser APIs - 9 hooks</h3>
 
-* [useGeolocation](https://rooks.vercel.app/docs/useGeolocation) - A hook to provide the geolocation info on client side.
-* [useIdleDetectionApi](https://rooks.vercel.app/docs/useIdleDetectionApi) - Hook to detect when user is idle using Idle Detection API with polyfill
-* [useNavigatorLanguage](https://rooks.vercel.app/docs/useNavigatorLanguage) - Navigator Language hook for React.
-* [useOnline](https://rooks.vercel.app/docs/useOnline) - Online status hook for React.
-* [useOrientation](https://rooks.vercel.app/docs/useOrientation) - orientation hook for react
-* [useScreenDetailsApi](https://rooks.vercel.app/docs/useScreenDetailsApi) - Hook for multi-screen information and management using Screen Details API
-* [useSpeech](https://rooks.vercel.app/docs/useSpeech) - Speech synthesis hook for React
-* [useVibrate](https://rooks.vercel.app/docs/useVibrate) - Vibration API hook for React
-* [useWebLocksApi](https://rooks.vercel.app/docs/useWebLocksApi) - Hook for coordinating operations across tabs/workers with Web Locks API
+* [useGeolocation](https://rooks.vercel.app/docs/hooks/useGeolocation) - A hook to provide the geolocation info on client side.
+* [useIdleDetectionApi](https://rooks.vercel.app/docs/hooks/useIdleDetectionApi) - Hook to detect when user is idle using Idle Detection API with polyfill
+* [useNavigatorLanguage](https://rooks.vercel.app/docs/hooks/useNavigatorLanguage) - Navigator Language hook for React.
+* [useOnline](https://rooks.vercel.app/docs/hooks/useOnline) - Online status hook for React.
+* [useOrientation](https://rooks.vercel.app/docs/hooks/useOrientation) - orientation hook for react
+* [useScreenDetailsApi](https://rooks.vercel.app/docs/hooks/useScreenDetailsApi) - Hook for multi-screen information and management using Screen Details API
+* [useSpeech](https://rooks.vercel.app/docs/hooks/useSpeech) - Speech synthesis hook for React
+* [useVibrate](https://rooks.vercel.app/docs/hooks/useVibrate) - Vibration API hook for React
+* [useWebLocksApi](https://rooks.vercel.app/docs/hooks/useWebLocksApi) - Hook for coordinating operations across tabs/workers with Web Locks API
 
 <h3 align="center">🛠️ Development & Debugging - 2 hooks</h3>
 
-* [useRenderCount](https://rooks.vercel.app/docs/useRenderCount) - Get the render count of a component
-* [useWhyDidYouUpdate](https://rooks.vercel.app/docs/useWhyDidYouUpdate) - A hook that can track which value change caused a rerender
+* [useRenderCount](https://rooks.vercel.app/docs/hooks/useRenderCount) - Get the render count of a component
+* [useWhyDidYouUpdate](https://rooks.vercel.app/docs/hooks/useWhyDidYouUpdate) - A hook that can track which value change caused a rerender
 
 <h3 align="center">🚀 Events - 14 hooks</h3>
 
-* [useDocumentEventListener](https://rooks.vercel.app/docs/useDocumentEventListener) - A react hook to an event listener to the document object
-* [useDocumentVisibilityState](https://rooks.vercel.app/docs/useDocumentVisibilityState) - Returns the visibility state of the document.
-* [useFocus](https://rooks.vercel.app/docs/useFocus) - Handles focus events for the immediate target element.
-* [useFocusWithin](https://rooks.vercel.app/docs/useFocusWithin) - Handles focus events for the target component.
-* [useIsDroppingFiles](https://rooks.vercel.app/docs/useIsDroppingFiles) - Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
-* [useOnClickRef](https://rooks.vercel.app/docs/useOnClickRef) - Callback on click/tap events
-* [useOnHoverRef](https://rooks.vercel.app/docs/useOnHoverRef) - On hover callback hook
-* [useOnLongHover](https://rooks.vercel.app/docs/useOnLongHover) - Fires a callback when an element is hovered for a while
-* [useOnLongPress](https://rooks.vercel.app/docs/useOnLongPress) - Fire a callback on long press
-* [useOnWindowResize](https://rooks.vercel.app/docs/useOnWindowResize) - A React hook for adding an event listener for window resize
-* [useOnWindowScroll](https://rooks.vercel.app/docs/useOnWindowScroll) - A React hook for adding an event listener for window scroll
-* [useOutsideClick](https://rooks.vercel.app/docs/useOutsideClick) - Outside click(for a ref) event as hook for React.
-* [useOutsideClickRef](https://rooks.vercel.app/docs/useOutsideClickRef) - A hook that can track a click event outside a ref. Returns a callbackRef.
-* [useWindowEventListener](https://rooks.vercel.app/docs/useWindowEventListener) - Adds an event listener to window
+* [useDocumentEventListener](https://rooks.vercel.app/docs/hooks/useDocumentEventListener) - A react hook to an event listener to the document object
+* [useDocumentVisibilityState](https://rooks.vercel.app/docs/hooks/useDocumentVisibilityState) - Returns the visibility state of the document.
+* [useFocus](https://rooks.vercel.app/docs/hooks/useFocus) - Handles focus events for the immediate target element.
+* [useFocusWithin](https://rooks.vercel.app/docs/hooks/useFocusWithin) - Handles focus events for the target component.
+* [useIsDroppingFiles](https://rooks.vercel.app/docs/hooks/useIsDroppingFiles) - Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
+* [useOnClickRef](https://rooks.vercel.app/docs/hooks/useOnClickRef) - Callback on click/tap events
+* [useOnHoverRef](https://rooks.vercel.app/docs/hooks/useOnHoverRef) - On hover callback hook
+* [useOnLongHover](https://rooks.vercel.app/docs/hooks/useOnLongHover) - Fires a callback when an element is hovered for a while
+* [useOnLongPress](https://rooks.vercel.app/docs/hooks/useOnLongPress) - Fire a callback on long press
+* [useOnWindowResize](https://rooks.vercel.app/docs/hooks/useOnWindowResize) - A React hook for adding an event listener for window resize
+* [useOnWindowScroll](https://rooks.vercel.app/docs/hooks/useOnWindowScroll) - A React hook for adding an event listener for window scroll
+* [useOutsideClick](https://rooks.vercel.app/docs/hooks/useOutsideClick) - Outside click(for a ref) event as hook for React.
+* [useOutsideClickRef](https://rooks.vercel.app/docs/hooks/useOutsideClickRef) - A hook that can track a click event outside a ref. Returns a callbackRef.
+* [useWindowEventListener](https://rooks.vercel.app/docs/hooks/useWindowEventListener) - Adds an event listener to window
 
 <h3 align="center">📝 Form & File Handling - 1 hook</h3>
 
-* [useFileDropRef](https://rooks.vercel.app/docs/useFileDropRef) - Drop files easily
+* [useFileDropRef](https://rooks.vercel.app/docs/hooks/useFileDropRef) - Drop files easily
 
 <h3 align="center">⌨️ Keyboard & Input - 5 hooks</h3>
 
-* [useInput](https://rooks.vercel.app/docs/useInput) - Input hook for React.
-* [useKey](https://rooks.vercel.app/docs/useKey) - keypress, keyup and keydown event handlers as hooks for react.
-* [useKeyBindings](https://rooks.vercel.app/docs/useKeyBindings) - useKeyBindings can bind multiple keys to multiple callbacks and fire the callbacks on key press.
-* [useKeyRef](https://rooks.vercel.app/docs/useKeyRef) - Very similar useKey but it returns a ref
-* [useKeys](https://rooks.vercel.app/docs/useKeys) - A hook which allows to setup callbacks when a combination of keys are pressed at the same time.
+* [useInput](https://rooks.vercel.app/docs/hooks/useInput) - Input hook for React.
+* [useKey](https://rooks.vercel.app/docs/hooks/useKey) - keypress, keyup and keydown event handlers as hooks for react.
+* [useKeyBindings](https://rooks.vercel.app/docs/hooks/useKeyBindings) - useKeyBindings can bind multiple keys to multiple callbacks and fire the callbacks on key press.
+* [useKeyRef](https://rooks.vercel.app/docs/hooks/useKeyRef) - Very similar useKey but it returns a ref
+* [useKeys](https://rooks.vercel.app/docs/hooks/useKeys) - A hook which allows to setup callbacks when a combination of keys are pressed at the same time.
 
 <h3 align="center">🔥 Lifecycle & Effects - 9 hooks</h3>
 
-* [useAsyncEffect](https://rooks.vercel.app/docs/useAsyncEffect) - A version of useEffect that accepts an async function
-* [useDeepCompareEffect](https://rooks.vercel.app/docs/useDeepCompareEffect) - Deep compare dependencies instead of shallow for useEffect
-* [useDidMount](https://rooks.vercel.app/docs/useDidMount) - componentDidMount hook for React
-* [useDidUpdate](https://rooks.vercel.app/docs/useDidUpdate) - componentDidUpdate hook for react
-* [useDocumentTitle](https://rooks.vercel.app/docs/useDocumentTitle) - A hook to easily update document title with React
-* [useEffectOnceWhen](https://rooks.vercel.app/docs/useEffectOnceWhen) - Runs a callback effect atmost one time when a condition becomes true
-* [useIsomorphicEffect](https://rooks.vercel.app/docs/useIsomorphicEffect) - A hook that resolves to useEffect on the server and useLayoutEffect on the client.
-* [useLifecycleLogger](https://rooks.vercel.app/docs/useLifecycleLogger) - A react hook that console logs parameters as component transitions through lifecycles.
-* [useWillUnmount](https://rooks.vercel.app/docs/useWillUnmount) - componentWillUnmount lifecycle as hook for React.
+* [useAsyncEffect](https://rooks.vercel.app/docs/hooks/useAsyncEffect) - A version of useEffect that accepts an async function
+* [useDeepCompareEffect](https://rooks.vercel.app/docs/hooks/useDeepCompareEffect) - Deep compare dependencies instead of shallow for useEffect
+* [useDidMount](https://rooks.vercel.app/docs/hooks/useDidMount) - componentDidMount hook for React
+* [useDidUpdate](https://rooks.vercel.app/docs/hooks/useDidUpdate) - componentDidUpdate hook for react
+* [useDocumentTitle](https://rooks.vercel.app/docs/hooks/useDocumentTitle) - A hook to easily update document title with React
+* [useEffectOnceWhen](https://rooks.vercel.app/docs/hooks/useEffectOnceWhen) - Runs a callback effect atmost one time when a condition becomes true
+* [useIsomorphicEffect](https://rooks.vercel.app/docs/hooks/useIsomorphicEffect) - A hook that resolves to useEffect on the server and useLayoutEffect on the client.
+* [useLifecycleLogger](https://rooks.vercel.app/docs/hooks/useLifecycleLogger) - A react hook that console logs parameters as component transitions through lifecycles.
+* [useWillUnmount](https://rooks.vercel.app/docs/hooks/useWillUnmount) - componentWillUnmount lifecycle as hook for React.
 
 <h3 align="center">🖱️ Mouse & Touch - 3 hooks</h3>
 
-* [useMouse](https://rooks.vercel.app/docs/useMouse) - Mouse position hook for React.
-* [useMouseMoveDelta](https://rooks.vercel.app/docs/useMouseMoveDelta) - Tracks delta of mouse move
-* [useMouseWheelDelta](https://rooks.vercel.app/docs/useMouseWheelDelta) - Tracks delta of mouse move
+* [useMouse](https://rooks.vercel.app/docs/hooks/useMouse) - Mouse position hook for React.
+* [useMouseMoveDelta](https://rooks.vercel.app/docs/hooks/useMouseMoveDelta) - Tracks delta of mouse move
+* [useMouseWheelDelta](https://rooks.vercel.app/docs/hooks/useMouseWheelDelta) - Tracks delta of mouse move
 
 <h3 align="center">⚡ Performance & Optimization - 4 hooks</h3>
 
-* [useDebounce](https://rooks.vercel.app/docs/useDebounce) - Debounce hook for react
-* [useDebouncedValue](https://rooks.vercel.app/docs/useDebouncedValue) - Tracks another value and gets updated in a debounced way.
-* [useDebounceFn](https://rooks.vercel.app/docs/useDebounceFn) - Powerful debounce function hook for React
-* [useThrottle](https://rooks.vercel.app/docs/useThrottle) - Throttle custom hook for React
+* [useDebounce](https://rooks.vercel.app/docs/hooks/useDebounce) - Debounce hook for react
+* [useDebouncedValue](https://rooks.vercel.app/docs/hooks/useDebouncedValue) - Tracks another value and gets updated in a debounced way.
+* [useDebounceFn](https://rooks.vercel.app/docs/hooks/useDebounceFn) - Powerful debounce function hook for React
+* [useThrottle](https://rooks.vercel.app/docs/hooks/useThrottle) - Throttle custom hook for React
 
 <h3 align="center">❇️ State - 18 hooks</h3>
 
-* [useArrayState](https://rooks.vercel.app/docs/useArrayState) - Array state manager hook for React
-* [useCountdown](https://rooks.vercel.app/docs/useCountdown) - Count down to a target timestamp and call callbacks every second (or provided peried)
-* [useCounter](https://rooks.vercel.app/docs/useCounter) - Counter hook for React.
-* [useGetIsMounted](https://rooks.vercel.app/docs/useGetIsMounted) - Checks if a component is mounted or not at the time. Useful for async effects
-* [useLocalstorageState](https://rooks.vercel.app/docs/useLocalstorageState) - UseState but auto updates values to localStorage
-* [useMapState](https://rooks.vercel.app/docs/useMapState) - A react hook to manage state in a key value pair map.
-* [useMultiSelectableList](https://rooks.vercel.app/docs/useMultiSelectableList) - A custom hook to easily select multiple values from a list
-* [useNativeMapState](https://rooks.vercel.app/docs/useNativeMapState) - Manage Map() object state in React
-* [usePreviousDifferent](https://rooks.vercel.app/docs/usePreviousDifferent) - usePreviousDifferent returns the last different value of a variable
-* [usePreviousImmediate](https://rooks.vercel.app/docs/usePreviousImmediate) - usePreviousImmediate returns the previous value of a variable even if it was the same or different
-* [usePromise](https://rooks.vercel.app/docs/usePromise) - Promise management hook for react
-* [useQueueState](https://rooks.vercel.app/docs/useQueueState) - A React hook that manages state in the form of a queue
-* [useSafeSetState](https://rooks.vercel.app/docs/useSafeSetState) - set state but ignores if component has already unmounted
-* [useSelect](https://rooks.vercel.app/docs/useSelect) - Select values from a list easily. List selection hook for react.
-* [useSelectableList](https://rooks.vercel.app/docs/useSelectableList) - Easily select a single value from a list of values. very useful for radio buttons, select inputs  etc.
-* [useSessionstorageState](https://rooks.vercel.app/docs/useSessionstorageState) - useState but syncs with sessionstorage
-* [useSetState](https://rooks.vercel.app/docs/useSetState) - Manage the state of a Set in React.
-* [useStackState](https://rooks.vercel.app/docs/useStackState) - A React hook that manages state in the form of a stack
+* [useArrayState](https://rooks.vercel.app/docs/hooks/useArrayState) - Array state manager hook for React
+* [useCountdown](https://rooks.vercel.app/docs/hooks/useCountdown) - Count down to a target timestamp and call callbacks every second (or provided peried)
+* [useCounter](https://rooks.vercel.app/docs/hooks/useCounter) - Counter hook for React.
+* [useGetIsMounted](https://rooks.vercel.app/docs/hooks/useGetIsMounted) - Checks if a component is mounted or not at the time. Useful for async effects
+* [useLocalstorageState](https://rooks.vercel.app/docs/hooks/useLocalstorageState) - UseState but auto updates values to localStorage
+* [useMapState](https://rooks.vercel.app/docs/hooks/useMapState) - A react hook to manage state in a key value pair map.
+* [useMultiSelectableList](https://rooks.vercel.app/docs/hooks/useMultiSelectableList) - A custom hook to easily select multiple values from a list
+* [useNativeMapState](https://rooks.vercel.app/docs/hooks/useNativeMapState) - Manage Map() object state in React
+* [usePreviousDifferent](https://rooks.vercel.app/docs/hooks/usePreviousDifferent) - usePreviousDifferent returns the last different value of a variable
+* [usePreviousImmediate](https://rooks.vercel.app/docs/hooks/usePreviousImmediate) - usePreviousImmediate returns the previous value of a variable even if it was the same or different
+* [usePromise](https://rooks.vercel.app/docs/hooks/usePromise) - Promise management hook for react
+* [useQueueState](https://rooks.vercel.app/docs/hooks/useQueueState) - A React hook that manages state in the form of a queue
+* [useSafeSetState](https://rooks.vercel.app/docs/hooks/useSafeSetState) - set state but ignores if component has already unmounted
+* [useSelect](https://rooks.vercel.app/docs/hooks/useSelect) - Select values from a list easily. List selection hook for react.
+* [useSelectableList](https://rooks.vercel.app/docs/hooks/useSelectableList) - Easily select a single value from a list of values. very useful for radio buttons, select inputs  etc.
+* [useSessionstorageState](https://rooks.vercel.app/docs/hooks/useSessionstorageState) - useState but syncs with sessionstorage
+* [useSetState](https://rooks.vercel.app/docs/hooks/useSetState) - Manage the state of a Set in React.
+* [useStackState](https://rooks.vercel.app/docs/hooks/useStackState) - A React hook that manages state in the form of a stack
 
 <h3 align="center">🔄 State History & Time Travel - 4 hooks</h3>
 
-* [useTimeTravelState](https://rooks.vercel.app/docs/useTimeTravelState) - A hook that manages state which can undo and redo. A more powerful version of useUndoState hook.
-* [useToggle](https://rooks.vercel.app/docs/useToggle) - Toggle (between booleans or custom data)hook for React.
-* [useUndoRedoState](https://rooks.vercel.app/docs/useUndoRedoState) - Setstate but can also undo and redo
-* [useUndoState](https://rooks.vercel.app/docs/useUndoState) - Drop in replacement for useState hook but with undo functionality.
+* [useTimeTravelState](https://rooks.vercel.app/docs/hooks/useTimeTravelState) - A hook that manages state which can undo and redo. A more powerful version of useUndoState hook.
+* [useToggle](https://rooks.vercel.app/docs/hooks/useToggle) - Toggle (between booleans or custom data)hook for React.
+* [useUndoRedoState](https://rooks.vercel.app/docs/hooks/useUndoRedoState) - Setstate but can also undo and redo
+* [useUndoState](https://rooks.vercel.app/docs/hooks/useUndoState) - Drop in replacement for useState hook but with undo functionality.
 
 <h3 align="center">⚛️ UI - 12 hooks</h3>
 
-* [useAudio](https://rooks.vercel.app/docs/useAudio) - Audio hook
-* [useBoundingclientrect](https://rooks.vercel.app/docs/useBoundingclientrect) - getBoundingClientRect hook for React.
-* [useBoundingclientrectRef](https://rooks.vercel.app/docs/useBoundingclientrectRef) - A hook that tracks the boundingclientrect of an element. It returns a callbackRef so that the element node if changed is easily tracked.
-* [useDimensionsRef](https://rooks.vercel.app/docs/useDimensionsRef) - Easily grab dimensions of an element with a ref using this hook
-* [useFullscreen](https://rooks.vercel.app/docs/useFullscreen) - Use full screen api for making beautiful and emersive experinces.
-* [useIntersectionObserverRef](https://rooks.vercel.app/docs/useIntersectionObserverRef) - A hook to register an intersection observer listener.
-* [useInViewRef](https://rooks.vercel.app/docs/useInViewRef) - Simple hook that monitors element enters or leave the viewport that's using Intersection Observer API.
-* [useMediaMatch](https://rooks.vercel.app/docs/useMediaMatch) - Signal whether or not a media query is currently matched.
-* [useMutationObserver](https://rooks.vercel.app/docs/useMutationObserver) - Mutation Observer hook for React.
-* [useMutationObserverRef](https://rooks.vercel.app/docs/useMutationObserverRef) - A hook that tracks mutations of an element. It returns a callbackRef.
-* [usePictureInPictureApi](https://rooks.vercel.app/docs/usePictureInPictureApi) - Hook for managing Picture-in-Picture video functionality
-* [useVideo](https://rooks.vercel.app/docs/useVideo) - Video hook for react
+* [useAudio](https://rooks.vercel.app/docs/hooks/useAudio) - Audio hook
+* [useBoundingclientrect](https://rooks.vercel.app/docs/hooks/useBoundingclientrect) - getBoundingClientRect hook for React.
+* [useBoundingclientrectRef](https://rooks.vercel.app/docs/hooks/useBoundingclientrectRef) - A hook that tracks the boundingclientrect of an element. It returns a callbackRef so that the element node if changed is easily tracked.
+* [useDimensionsRef](https://rooks.vercel.app/docs/hooks/useDimensionsRef) - Easily grab dimensions of an element with a ref using this hook
+* [useFullscreen](https://rooks.vercel.app/docs/hooks/useFullscreen) - Use full screen api for making beautiful and emersive experinces.
+* [useIntersectionObserverRef](https://rooks.vercel.app/docs/hooks/useIntersectionObserverRef) - A hook to register an intersection observer listener.
+* [useInViewRef](https://rooks.vercel.app/docs/hooks/useInViewRef) - Simple hook that monitors element enters or leave the viewport that's using Intersection Observer API.
+* [useMediaMatch](https://rooks.vercel.app/docs/hooks/useMediaMatch) - Signal whether or not a media query is currently matched.
+* [useMutationObserver](https://rooks.vercel.app/docs/hooks/useMutationObserver) - Mutation Observer hook for React.
+* [useMutationObserverRef](https://rooks.vercel.app/docs/hooks/useMutationObserverRef) - A hook that tracks mutations of an element. It returns a callbackRef.
+* [usePictureInPictureApi](https://rooks.vercel.app/docs/hooks/usePictureInPictureApi) - Hook for managing Picture-in-Picture video functionality
+* [useVideo](https://rooks.vercel.app/docs/hooks/useVideo) - Video hook for react
 
 <h3 align="center">🔧 Utilities & Refs - 7 hooks</h3>
 
-* [useEventListenerRef](https://rooks.vercel.app/docs/useEventListenerRef) - A react hook to add an event listener to a ref
-* [useForkRef](https://rooks.vercel.app/docs/useForkRef) - A hook that can combine two refs(mutable or callbackRefs) into a single callbackRef
-* [useFreshCallback](https://rooks.vercel.app/docs/useFreshCallback) - Avoid stale closures and keep your callback fresh
-* [useFreshRef](https://rooks.vercel.app/docs/useFreshRef) - Avoid stale state in callbacks with this hook. Auto updates values using a ref.
-* [useFreshTick](https://rooks.vercel.app/docs/useFreshTick) - Like use-fresh-ref but specifically for functions
-* [useMergeRefs](https://rooks.vercel.app/docs/useMergeRefs) - Merges any number of refs into a single ref
-* [useRefElement](https://rooks.vercel.app/docs/useRefElement) - Helps bridge gap between callback ref and state
+* [useEventListenerRef](https://rooks.vercel.app/docs/hooks/useEventListenerRef) - A react hook to add an event listener to a ref
+* [useForkRef](https://rooks.vercel.app/docs/hooks/useForkRef) - A hook that can combine two refs(mutable or callbackRefs) into a single callbackRef
+* [useFreshCallback](https://rooks.vercel.app/docs/hooks/useFreshCallback) - Avoid stale closures and keep your callback fresh
+* [useFreshRef](https://rooks.vercel.app/docs/hooks/useFreshRef) - Avoid stale state in callbacks with this hook. Auto updates values using a ref.
+* [useFreshTick](https://rooks.vercel.app/docs/hooks/useFreshTick) - Like use-fresh-ref but specifically for functions
+* [useMergeRefs](https://rooks.vercel.app/docs/hooks/useMergeRefs) - Merges any number of refs into a single ref
+* [useRefElement](https://rooks.vercel.app/docs/hooks/useRefElement) - Helps bridge gap between callback ref and state
 
 <h3 align="center">📱 Window & Viewport - 2 hooks</h3>
 
-* [useWindowScrollPosition](https://rooks.vercel.app/docs/useWindowScrollPosition) - A React hook to get the scroll position of the window
-* [useWindowSize](https://rooks.vercel.app/docs/useWindowSize) - Window size hook for React.
+* [useWindowScrollPosition](https://rooks.vercel.app/docs/hooks/useWindowScrollPosition) - A React hook to get the scroll position of the window
+* [useWindowSize](https://rooks.vercel.app/docs/hooks/useWindowSize) - Window size hook for React.
 
 <h3 align="center">🧪 Experimental Hooks - 1 hook</h3>
 
-* [useSuspenseNavigatorUserAgentData](https://rooks.vercel.app/docs/useSuspenseNavigatorUserAgentData) - Suspense-enabled hook for getting high entropy values from Navigator User Agent Data API
+* [useSuspenseNavigatorUserAgentData](https://rooks.vercel.app/docs/hooks/useSuspenseNavigatorUserAgentData) - Suspense-enabled hook for getting high entropy values from Navigator User Agent Data API
 
 <p align="center"><em>⚠️ Experimental hooks may be removed or significantly changed in any release without notice. Use with caution in production.</em></p>
 

--- a/code-style-guide.md
+++ b/code-style-guide.md
@@ -128,7 +128,7 @@ type CounterHandler = {
  *
  * @param {number} initialValue The initial value of the counter
  * @returns {handler} A handler to interact with the counter
- * @see https://rooks.vercel.app/docs/useCounter
+ * @see https://rooks.vercel.app/docs/hooks/useCounter
  */
 // 3. Hook Function
 function useCounter(initialValue: number): CounterHandler {
@@ -230,7 +230,7 @@ describe("useCounter", () => {
  * @param {TrackedKeyEvents} keys List of keys to listen for. Eg: ["a", "b"]
  * @param {Callback} callback  Callback to fire on keyboard events
  * @param {Options} options Options
- * @see https://rooks.vercel.app/docs/useKey
+ * @see https://rooks.vercel.app/docs/hooks/useKey
  */
 ```
 

--- a/packages/rooks/README.md
+++ b/packages/rooks/README.md
@@ -33,144 +33,144 @@
 
 <h3 align="center">🎬 Animation & Timing - 5 hooks</h3>
 
-* [useIntervalWhen](https://rooks.vercel.app/docs/useIntervalWhen) - Sets an interval immediately when a condition is true
-* [useLockBodyScroll](https://rooks.vercel.app/docs/useLockBodyScroll) - This hook locks the scroll of the body element when `isLocked` is set to `true`.
-* [useRaf](https://rooks.vercel.app/docs/useRaf) - A continuously running requestAnimationFrame hook for React
-* [useResizeObserverRef](https://rooks.vercel.app/docs/useResizeObserverRef) - Resize Observer hook for React.
-* [useTimeoutWhen](https://rooks.vercel.app/docs/useTimeoutWhen) - Takes a callback and fires it when a condition is true
+* [useIntervalWhen](https://rooks.vercel.app/docs/hooks/useIntervalWhen) - Sets an interval immediately when a condition is true
+* [useLockBodyScroll](https://rooks.vercel.app/docs/hooks/useLockBodyScroll) - This hook locks the scroll of the body element when `isLocked` is set to `true`.
+* [useRaf](https://rooks.vercel.app/docs/hooks/useRaf) - A continuously running requestAnimationFrame hook for React
+* [useResizeObserverRef](https://rooks.vercel.app/docs/hooks/useResizeObserverRef) - Resize Observer hook for React.
+* [useTimeoutWhen](https://rooks.vercel.app/docs/hooks/useTimeoutWhen) - Takes a callback and fires it when a condition is true
 
 <h3 align="center">🌐 Browser APIs - 9 hooks</h3>
 
-* [useGeolocation](https://rooks.vercel.app/docs/useGeolocation) - A hook to provide the geolocation info on client side.
-* [useIdleDetectionApi](https://rooks.vercel.app/docs/useIdleDetectionApi) - Hook to detect when user is idle using Idle Detection API with polyfill
-* [useNavigatorLanguage](https://rooks.vercel.app/docs/useNavigatorLanguage) - Navigator Language hook for React.
-* [useOnline](https://rooks.vercel.app/docs/useOnline) - Online status hook for React.
-* [useOrientation](https://rooks.vercel.app/docs/useOrientation) - orientation hook for react
-* [useScreenDetailsApi](https://rooks.vercel.app/docs/useScreenDetailsApi) - Hook for multi-screen information and management using Screen Details API
-* [useSpeech](https://rooks.vercel.app/docs/useSpeech) - Speech synthesis hook for React
-* [useVibrate](https://rooks.vercel.app/docs/useVibrate) - Vibration API hook for React
-* [useWebLocksApi](https://rooks.vercel.app/docs/useWebLocksApi) - Hook for coordinating operations across tabs/workers with Web Locks API
+* [useGeolocation](https://rooks.vercel.app/docs/hooks/useGeolocation) - A hook to provide the geolocation info on client side.
+* [useIdleDetectionApi](https://rooks.vercel.app/docs/hooks/useIdleDetectionApi) - Hook to detect when user is idle using Idle Detection API with polyfill
+* [useNavigatorLanguage](https://rooks.vercel.app/docs/hooks/useNavigatorLanguage) - Navigator Language hook for React.
+* [useOnline](https://rooks.vercel.app/docs/hooks/useOnline) - Online status hook for React.
+* [useOrientation](https://rooks.vercel.app/docs/hooks/useOrientation) - orientation hook for react
+* [useScreenDetailsApi](https://rooks.vercel.app/docs/hooks/useScreenDetailsApi) - Hook for multi-screen information and management using Screen Details API
+* [useSpeech](https://rooks.vercel.app/docs/hooks/useSpeech) - Speech synthesis hook for React
+* [useVibrate](https://rooks.vercel.app/docs/hooks/useVibrate) - Vibration API hook for React
+* [useWebLocksApi](https://rooks.vercel.app/docs/hooks/useWebLocksApi) - Hook for coordinating operations across tabs/workers with Web Locks API
 
 <h3 align="center">🛠️ Development & Debugging - 2 hooks</h3>
 
-* [useRenderCount](https://rooks.vercel.app/docs/useRenderCount) - Get the render count of a component
-* [useWhyDidYouUpdate](https://rooks.vercel.app/docs/useWhyDidYouUpdate) - A hook that can track which value change caused a rerender
+* [useRenderCount](https://rooks.vercel.app/docs/hooks/useRenderCount) - Get the render count of a component
+* [useWhyDidYouUpdate](https://rooks.vercel.app/docs/hooks/useWhyDidYouUpdate) - A hook that can track which value change caused a rerender
 
 <h3 align="center">🚀 Events - 14 hooks</h3>
 
-* [useDocumentEventListener](https://rooks.vercel.app/docs/useDocumentEventListener) - A react hook to an event listener to the document object
-* [useDocumentVisibilityState](https://rooks.vercel.app/docs/useDocumentVisibilityState) - Returns the visibility state of the document.
-* [useFocus](https://rooks.vercel.app/docs/useFocus) - Handles focus events for the immediate target element.
-* [useFocusWithin](https://rooks.vercel.app/docs/useFocusWithin) - Handles focus events for the target component.
-* [useIsDroppingFiles](https://rooks.vercel.app/docs/useIsDroppingFiles) - Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
-* [useOnClickRef](https://rooks.vercel.app/docs/useOnClickRef) - Callback on click/tap events
-* [useOnHoverRef](https://rooks.vercel.app/docs/useOnHoverRef) - On hover callback hook
-* [useOnLongHover](https://rooks.vercel.app/docs/useOnLongHover) - Fires a callback when an element is hovered for a while
-* [useOnLongPress](https://rooks.vercel.app/docs/useOnLongPress) - Fire a callback on long press
-* [useOnWindowResize](https://rooks.vercel.app/docs/useOnWindowResize) - A React hook for adding an event listener for window resize
-* [useOnWindowScroll](https://rooks.vercel.app/docs/useOnWindowScroll) - A React hook for adding an event listener for window scroll
-* [useOutsideClick](https://rooks.vercel.app/docs/useOutsideClick) - Outside click(for a ref) event as hook for React.
-* [useOutsideClickRef](https://rooks.vercel.app/docs/useOutsideClickRef) - A hook that can track a click event outside a ref. Returns a callbackRef.
-* [useWindowEventListener](https://rooks.vercel.app/docs/useWindowEventListener) - Adds an event listener to window
+* [useDocumentEventListener](https://rooks.vercel.app/docs/hooks/useDocumentEventListener) - A react hook to an event listener to the document object
+* [useDocumentVisibilityState](https://rooks.vercel.app/docs/hooks/useDocumentVisibilityState) - Returns the visibility state of the document.
+* [useFocus](https://rooks.vercel.app/docs/hooks/useFocus) - Handles focus events for the immediate target element.
+* [useFocusWithin](https://rooks.vercel.app/docs/hooks/useFocusWithin) - Handles focus events for the target component.
+* [useIsDroppingFiles](https://rooks.vercel.app/docs/hooks/useIsDroppingFiles) - Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
+* [useOnClickRef](https://rooks.vercel.app/docs/hooks/useOnClickRef) - Callback on click/tap events
+* [useOnHoverRef](https://rooks.vercel.app/docs/hooks/useOnHoverRef) - On hover callback hook
+* [useOnLongHover](https://rooks.vercel.app/docs/hooks/useOnLongHover) - Fires a callback when an element is hovered for a while
+* [useOnLongPress](https://rooks.vercel.app/docs/hooks/useOnLongPress) - Fire a callback on long press
+* [useOnWindowResize](https://rooks.vercel.app/docs/hooks/useOnWindowResize) - A React hook for adding an event listener for window resize
+* [useOnWindowScroll](https://rooks.vercel.app/docs/hooks/useOnWindowScroll) - A React hook for adding an event listener for window scroll
+* [useOutsideClick](https://rooks.vercel.app/docs/hooks/useOutsideClick) - Outside click(for a ref) event as hook for React.
+* [useOutsideClickRef](https://rooks.vercel.app/docs/hooks/useOutsideClickRef) - A hook that can track a click event outside a ref. Returns a callbackRef.
+* [useWindowEventListener](https://rooks.vercel.app/docs/hooks/useWindowEventListener) - Adds an event listener to window
 
 <h3 align="center">📝 Form & File Handling - 1 hook</h3>
 
-* [useFileDropRef](https://rooks.vercel.app/docs/useFileDropRef) - Drop files easily
+* [useFileDropRef](https://rooks.vercel.app/docs/hooks/useFileDropRef) - Drop files easily
 
 <h3 align="center">⌨️ Keyboard & Input - 5 hooks</h3>
 
-* [useInput](https://rooks.vercel.app/docs/useInput) - Input hook for React.
-* [useKey](https://rooks.vercel.app/docs/useKey) - keypress, keyup and keydown event handlers as hooks for react.
-* [useKeyBindings](https://rooks.vercel.app/docs/useKeyBindings) - useKeyBindings can bind multiple keys to multiple callbacks and fire the callbacks on key press.
-* [useKeyRef](https://rooks.vercel.app/docs/useKeyRef) - Very similar useKey but it returns a ref
-* [useKeys](https://rooks.vercel.app/docs/useKeys) - A hook which allows to setup callbacks when a combination of keys are pressed at the same time.
+* [useInput](https://rooks.vercel.app/docs/hooks/useInput) - Input hook for React.
+* [useKey](https://rooks.vercel.app/docs/hooks/useKey) - keypress, keyup and keydown event handlers as hooks for react.
+* [useKeyBindings](https://rooks.vercel.app/docs/hooks/useKeyBindings) - useKeyBindings can bind multiple keys to multiple callbacks and fire the callbacks on key press.
+* [useKeyRef](https://rooks.vercel.app/docs/hooks/useKeyRef) - Very similar useKey but it returns a ref
+* [useKeys](https://rooks.vercel.app/docs/hooks/useKeys) - A hook which allows to setup callbacks when a combination of keys are pressed at the same time.
 
 <h3 align="center">🔥 Lifecycle & Effects - 9 hooks</h3>
 
-* [useAsyncEffect](https://rooks.vercel.app/docs/useAsyncEffect) - A version of useEffect that accepts an async function
-* [useDeepCompareEffect](https://rooks.vercel.app/docs/useDeepCompareEffect) - Deep compare dependencies instead of shallow for useEffect
-* [useDidMount](https://rooks.vercel.app/docs/useDidMount) - componentDidMount hook for React
-* [useDidUpdate](https://rooks.vercel.app/docs/useDidUpdate) - componentDidUpdate hook for react
-* [useDocumentTitle](https://rooks.vercel.app/docs/useDocumentTitle) - A hook to easily update document title with React
-* [useEffectOnceWhen](https://rooks.vercel.app/docs/useEffectOnceWhen) - Runs a callback effect atmost one time when a condition becomes true
-* [useIsomorphicEffect](https://rooks.vercel.app/docs/useIsomorphicEffect) - A hook that resolves to useEffect on the server and useLayoutEffect on the client.
-* [useLifecycleLogger](https://rooks.vercel.app/docs/useLifecycleLogger) - A react hook that console logs parameters as component transitions through lifecycles.
-* [useWillUnmount](https://rooks.vercel.app/docs/useWillUnmount) - componentWillUnmount lifecycle as hook for React.
+* [useAsyncEffect](https://rooks.vercel.app/docs/hooks/useAsyncEffect) - A version of useEffect that accepts an async function
+* [useDeepCompareEffect](https://rooks.vercel.app/docs/hooks/useDeepCompareEffect) - Deep compare dependencies instead of shallow for useEffect
+* [useDidMount](https://rooks.vercel.app/docs/hooks/useDidMount) - componentDidMount hook for React
+* [useDidUpdate](https://rooks.vercel.app/docs/hooks/useDidUpdate) - componentDidUpdate hook for react
+* [useDocumentTitle](https://rooks.vercel.app/docs/hooks/useDocumentTitle) - A hook to easily update document title with React
+* [useEffectOnceWhen](https://rooks.vercel.app/docs/hooks/useEffectOnceWhen) - Runs a callback effect atmost one time when a condition becomes true
+* [useIsomorphicEffect](https://rooks.vercel.app/docs/hooks/useIsomorphicEffect) - A hook that resolves to useEffect on the server and useLayoutEffect on the client.
+* [useLifecycleLogger](https://rooks.vercel.app/docs/hooks/useLifecycleLogger) - A react hook that console logs parameters as component transitions through lifecycles.
+* [useWillUnmount](https://rooks.vercel.app/docs/hooks/useWillUnmount) - componentWillUnmount lifecycle as hook for React.
 
 <h3 align="center">🖱️ Mouse & Touch - 3 hooks</h3>
 
-* [useMouse](https://rooks.vercel.app/docs/useMouse) - Mouse position hook for React.
-* [useMouseMoveDelta](https://rooks.vercel.app/docs/useMouseMoveDelta) - Tracks delta of mouse move
-* [useMouseWheelDelta](https://rooks.vercel.app/docs/useMouseWheelDelta) - Tracks delta of mouse move
+* [useMouse](https://rooks.vercel.app/docs/hooks/useMouse) - Mouse position hook for React.
+* [useMouseMoveDelta](https://rooks.vercel.app/docs/hooks/useMouseMoveDelta) - Tracks delta of mouse move
+* [useMouseWheelDelta](https://rooks.vercel.app/docs/hooks/useMouseWheelDelta) - Tracks delta of mouse move
 
 <h3 align="center">⚡ Performance & Optimization - 4 hooks</h3>
 
-* [useDebounce](https://rooks.vercel.app/docs/useDebounce) - Debounce hook for react
-* [useDebouncedValue](https://rooks.vercel.app/docs/useDebouncedValue) - Tracks another value and gets updated in a debounced way.
-* [useDebounceFn](https://rooks.vercel.app/docs/useDebounceFn) - Powerful debounce function hook for React
-* [useThrottle](https://rooks.vercel.app/docs/useThrottle) - Throttle custom hook for React
+* [useDebounce](https://rooks.vercel.app/docs/hooks/useDebounce) - Debounce hook for react
+* [useDebouncedValue](https://rooks.vercel.app/docs/hooks/useDebouncedValue) - Tracks another value and gets updated in a debounced way.
+* [useDebounceFn](https://rooks.vercel.app/docs/hooks/useDebounceFn) - Powerful debounce function hook for React
+* [useThrottle](https://rooks.vercel.app/docs/hooks/useThrottle) - Throttle custom hook for React
 
 <h3 align="center">❇️ State - 18 hooks</h3>
 
-* [useArrayState](https://rooks.vercel.app/docs/useArrayState) - Array state manager hook for React
-* [useCountdown](https://rooks.vercel.app/docs/useCountdown) - Count down to a target timestamp and call callbacks every second (or provided peried)
-* [useCounter](https://rooks.vercel.app/docs/useCounter) - Counter hook for React.
-* [useGetIsMounted](https://rooks.vercel.app/docs/useGetIsMounted) - Checks if a component is mounted or not at the time. Useful for async effects
-* [useLocalstorageState](https://rooks.vercel.app/docs/useLocalstorageState) - UseState but auto updates values to localStorage
-* [useMapState](https://rooks.vercel.app/docs/useMapState) - A react hook to manage state in a key value pair map.
-* [useMultiSelectableList](https://rooks.vercel.app/docs/useMultiSelectableList) - A custom hook to easily select multiple values from a list
-* [useNativeMapState](https://rooks.vercel.app/docs/useNativeMapState) - Manage Map() object state in React
-* [usePreviousDifferent](https://rooks.vercel.app/docs/usePreviousDifferent) - usePreviousDifferent returns the last different value of a variable
-* [usePreviousImmediate](https://rooks.vercel.app/docs/usePreviousImmediate) - usePreviousImmediate returns the previous value of a variable even if it was the same or different
-* [usePromise](https://rooks.vercel.app/docs/usePromise) - Promise management hook for react
-* [useQueueState](https://rooks.vercel.app/docs/useQueueState) - A React hook that manages state in the form of a queue
-* [useSafeSetState](https://rooks.vercel.app/docs/useSafeSetState) - set state but ignores if component has already unmounted
-* [useSelect](https://rooks.vercel.app/docs/useSelect) - Select values from a list easily. List selection hook for react.
-* [useSelectableList](https://rooks.vercel.app/docs/useSelectableList) - Easily select a single value from a list of values. very useful for radio buttons, select inputs  etc.
-* [useSessionstorageState](https://rooks.vercel.app/docs/useSessionstorageState) - useState but syncs with sessionstorage
-* [useSetState](https://rooks.vercel.app/docs/useSetState) - Manage the state of a Set in React.
-* [useStackState](https://rooks.vercel.app/docs/useStackState) - A React hook that manages state in the form of a stack
+* [useArrayState](https://rooks.vercel.app/docs/hooks/useArrayState) - Array state manager hook for React
+* [useCountdown](https://rooks.vercel.app/docs/hooks/useCountdown) - Count down to a target timestamp and call callbacks every second (or provided peried)
+* [useCounter](https://rooks.vercel.app/docs/hooks/useCounter) - Counter hook for React.
+* [useGetIsMounted](https://rooks.vercel.app/docs/hooks/useGetIsMounted) - Checks if a component is mounted or not at the time. Useful for async effects
+* [useLocalstorageState](https://rooks.vercel.app/docs/hooks/useLocalstorageState) - UseState but auto updates values to localStorage
+* [useMapState](https://rooks.vercel.app/docs/hooks/useMapState) - A react hook to manage state in a key value pair map.
+* [useMultiSelectableList](https://rooks.vercel.app/docs/hooks/useMultiSelectableList) - A custom hook to easily select multiple values from a list
+* [useNativeMapState](https://rooks.vercel.app/docs/hooks/useNativeMapState) - Manage Map() object state in React
+* [usePreviousDifferent](https://rooks.vercel.app/docs/hooks/usePreviousDifferent) - usePreviousDifferent returns the last different value of a variable
+* [usePreviousImmediate](https://rooks.vercel.app/docs/hooks/usePreviousImmediate) - usePreviousImmediate returns the previous value of a variable even if it was the same or different
+* [usePromise](https://rooks.vercel.app/docs/hooks/usePromise) - Promise management hook for react
+* [useQueueState](https://rooks.vercel.app/docs/hooks/useQueueState) - A React hook that manages state in the form of a queue
+* [useSafeSetState](https://rooks.vercel.app/docs/hooks/useSafeSetState) - set state but ignores if component has already unmounted
+* [useSelect](https://rooks.vercel.app/docs/hooks/useSelect) - Select values from a list easily. List selection hook for react.
+* [useSelectableList](https://rooks.vercel.app/docs/hooks/useSelectableList) - Easily select a single value from a list of values. very useful for radio buttons, select inputs  etc.
+* [useSessionstorageState](https://rooks.vercel.app/docs/hooks/useSessionstorageState) - useState but syncs with sessionstorage
+* [useSetState](https://rooks.vercel.app/docs/hooks/useSetState) - Manage the state of a Set in React.
+* [useStackState](https://rooks.vercel.app/docs/hooks/useStackState) - A React hook that manages state in the form of a stack
 
 <h3 align="center">🔄 State History & Time Travel - 4 hooks</h3>
 
-* [useTimeTravelState](https://rooks.vercel.app/docs/useTimeTravelState) - A hook that manages state which can undo and redo. A more powerful version of useUndoState hook.
-* [useToggle](https://rooks.vercel.app/docs/useToggle) - Toggle (between booleans or custom data)hook for React.
-* [useUndoRedoState](https://rooks.vercel.app/docs/useUndoRedoState) - Setstate but can also undo and redo
-* [useUndoState](https://rooks.vercel.app/docs/useUndoState) - Drop in replacement for useState hook but with undo functionality.
+* [useTimeTravelState](https://rooks.vercel.app/docs/hooks/useTimeTravelState) - A hook that manages state which can undo and redo. A more powerful version of useUndoState hook.
+* [useToggle](https://rooks.vercel.app/docs/hooks/useToggle) - Toggle (between booleans or custom data)hook for React.
+* [useUndoRedoState](https://rooks.vercel.app/docs/hooks/useUndoRedoState) - Setstate but can also undo and redo
+* [useUndoState](https://rooks.vercel.app/docs/hooks/useUndoState) - Drop in replacement for useState hook but with undo functionality.
 
 <h3 align="center">⚛️ UI - 12 hooks</h3>
 
-* [useAudio](https://rooks.vercel.app/docs/useAudio) - Audio hook
-* [useBoundingclientrect](https://rooks.vercel.app/docs/useBoundingclientrect) - getBoundingClientRect hook for React.
-* [useBoundingclientrectRef](https://rooks.vercel.app/docs/useBoundingclientrectRef) - A hook that tracks the boundingclientrect of an element. It returns a callbackRef so that the element node if changed is easily tracked.
-* [useDimensionsRef](https://rooks.vercel.app/docs/useDimensionsRef) - Easily grab dimensions of an element with a ref using this hook
-* [useFullscreen](https://rooks.vercel.app/docs/useFullscreen) - Use full screen api for making beautiful and emersive experinces.
-* [useIntersectionObserverRef](https://rooks.vercel.app/docs/useIntersectionObserverRef) - A hook to register an intersection observer listener.
-* [useInViewRef](https://rooks.vercel.app/docs/useInViewRef) - Simple hook that monitors element enters or leave the viewport that's using Intersection Observer API.
-* [useMediaMatch](https://rooks.vercel.app/docs/useMediaMatch) - Signal whether or not a media query is currently matched.
-* [useMutationObserver](https://rooks.vercel.app/docs/useMutationObserver) - Mutation Observer hook for React.
-* [useMutationObserverRef](https://rooks.vercel.app/docs/useMutationObserverRef) - A hook that tracks mutations of an element. It returns a callbackRef.
-* [usePictureInPictureApi](https://rooks.vercel.app/docs/usePictureInPictureApi) - Hook for managing Picture-in-Picture video functionality
-* [useVideo](https://rooks.vercel.app/docs/useVideo) - Video hook for react
+* [useAudio](https://rooks.vercel.app/docs/hooks/useAudio) - Audio hook
+* [useBoundingclientrect](https://rooks.vercel.app/docs/hooks/useBoundingclientrect) - getBoundingClientRect hook for React.
+* [useBoundingclientrectRef](https://rooks.vercel.app/docs/hooks/useBoundingclientrectRef) - A hook that tracks the boundingclientrect of an element. It returns a callbackRef so that the element node if changed is easily tracked.
+* [useDimensionsRef](https://rooks.vercel.app/docs/hooks/useDimensionsRef) - Easily grab dimensions of an element with a ref using this hook
+* [useFullscreen](https://rooks.vercel.app/docs/hooks/useFullscreen) - Use full screen api for making beautiful and emersive experinces.
+* [useIntersectionObserverRef](https://rooks.vercel.app/docs/hooks/useIntersectionObserverRef) - A hook to register an intersection observer listener.
+* [useInViewRef](https://rooks.vercel.app/docs/hooks/useInViewRef) - Simple hook that monitors element enters or leave the viewport that's using Intersection Observer API.
+* [useMediaMatch](https://rooks.vercel.app/docs/hooks/useMediaMatch) - Signal whether or not a media query is currently matched.
+* [useMutationObserver](https://rooks.vercel.app/docs/hooks/useMutationObserver) - Mutation Observer hook for React.
+* [useMutationObserverRef](https://rooks.vercel.app/docs/hooks/useMutationObserverRef) - A hook that tracks mutations of an element. It returns a callbackRef.
+* [usePictureInPictureApi](https://rooks.vercel.app/docs/hooks/usePictureInPictureApi) - Hook for managing Picture-in-Picture video functionality
+* [useVideo](https://rooks.vercel.app/docs/hooks/useVideo) - Video hook for react
 
 <h3 align="center">🔧 Utilities & Refs - 7 hooks</h3>
 
-* [useEventListenerRef](https://rooks.vercel.app/docs/useEventListenerRef) - A react hook to add an event listener to a ref
-* [useForkRef](https://rooks.vercel.app/docs/useForkRef) - A hook that can combine two refs(mutable or callbackRefs) into a single callbackRef
-* [useFreshCallback](https://rooks.vercel.app/docs/useFreshCallback) - Avoid stale closures and keep your callback fresh
-* [useFreshRef](https://rooks.vercel.app/docs/useFreshRef) - Avoid stale state in callbacks with this hook. Auto updates values using a ref.
-* [useFreshTick](https://rooks.vercel.app/docs/useFreshTick) - Like use-fresh-ref but specifically for functions
-* [useMergeRefs](https://rooks.vercel.app/docs/useMergeRefs) - Merges any number of refs into a single ref
-* [useRefElement](https://rooks.vercel.app/docs/useRefElement) - Helps bridge gap between callback ref and state
+* [useEventListenerRef](https://rooks.vercel.app/docs/hooks/useEventListenerRef) - A react hook to add an event listener to a ref
+* [useForkRef](https://rooks.vercel.app/docs/hooks/useForkRef) - A hook that can combine two refs(mutable or callbackRefs) into a single callbackRef
+* [useFreshCallback](https://rooks.vercel.app/docs/hooks/useFreshCallback) - Avoid stale closures and keep your callback fresh
+* [useFreshRef](https://rooks.vercel.app/docs/hooks/useFreshRef) - Avoid stale state in callbacks with this hook. Auto updates values using a ref.
+* [useFreshTick](https://rooks.vercel.app/docs/hooks/useFreshTick) - Like use-fresh-ref but specifically for functions
+* [useMergeRefs](https://rooks.vercel.app/docs/hooks/useMergeRefs) - Merges any number of refs into a single ref
+* [useRefElement](https://rooks.vercel.app/docs/hooks/useRefElement) - Helps bridge gap between callback ref and state
 
 <h3 align="center">📱 Window & Viewport - 2 hooks</h3>
 
-* [useWindowScrollPosition](https://rooks.vercel.app/docs/useWindowScrollPosition) - A React hook to get the scroll position of the window
-* [useWindowSize](https://rooks.vercel.app/docs/useWindowSize) - Window size hook for React.
+* [useWindowScrollPosition](https://rooks.vercel.app/docs/hooks/useWindowScrollPosition) - A React hook to get the scroll position of the window
+* [useWindowSize](https://rooks.vercel.app/docs/hooks/useWindowSize) - Window size hook for React.
 
 <h3 align="center">🧪 Experimental Hooks - 1 hook</h3>
 
-* [useSuspenseNavigatorUserAgentData](https://rooks.vercel.app/docs/useSuspenseNavigatorUserAgentData) - Suspense-enabled hook for getting high entropy values from Navigator User Agent Data API
+* [useSuspenseNavigatorUserAgentData](https://rooks.vercel.app/docs/hooks/useSuspenseNavigatorUserAgentData) - Suspense-enabled hook for getting high entropy values from Navigator User Agent Data API
 
 <p align="center"><em>⚠️ Experimental hooks may be removed or significantly changed in any release without notice. Use with caution in production.</em></p>
 

--- a/packages/rooks/src/hooks/useArrayState.ts
+++ b/packages/rooks/src/hooks/useArrayState.ts
@@ -41,7 +41,7 @@ export type UseArrayStateReturnValue<T> = [T[], UseArrayStateControls<T>];
  * @description Array state manager hook for React
  * @param {Array<T>} initialState Initial state of the array
  * @returns {UseArrayStateReturnValue<T>} Array state manager hook for React
- * @see {@link https://rooks.vercel.app/docs/useArrayState}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useArrayState}
  *
  * @example
  *

--- a/packages/rooks/src/hooks/useAsyncEffect.ts
+++ b/packages/rooks/src/hooks/useAsyncEffect.ts
@@ -11,7 +11,7 @@ type CleanupFunction<T> = (result: T | void) => void;
  * @param {Effect<T>} effect Async function that can return a cleanup function and takes in an AbortSignal
  * @param {DependencyList} deps If present, effect will only activate if the values in the list change
  * @param {CleanupFunction} cleanup The destroy/cleanup function. Will be called with previous result if it exists. 
- * @see https://rooks.vercel.app/docs/useAsyncEffect
+ * @see https://rooks.vercel.app/docs/hooks/useAsyncEffect
  * @example 
  * ```jsx
  * useAsyncEffect(

--- a/packages/rooks/src/hooks/useAudio.ts
+++ b/packages/rooks/src/hooks/useAudio.ts
@@ -1,7 +1,7 @@
 /**
  * useAudio
  * @description Enhanced audio hook with comprehensive controls and state management
- * @see {@link https://rooks.vercel.app/docs/useAudio}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useAudio}
  */
 import { useState, useEffect, RefCallback } from "react";
 import { useFreshCallback } from "@/hooks/useFreshCallback";

--- a/packages/rooks/src/hooks/useBoundingclientrect.ts
+++ b/packages/rooks/src/hooks/useBoundingclientrect.ts
@@ -16,7 +16,7 @@ function getBoundingClientRect(element: HTMLElement): DOMRect | null {
  *
  * @param ref The React ref whose ClientRect is needed
  * @returns DOMRect | null
- * @see https://rooks.vercel.app/docs/useBoundingclientRect
+ * @see https://rooks.vercel.app/docs/hooks/useBoundingclientRect
  */
 function useBoundingclientrect(
   ref: MutableRefObject<HTMLElement | null>

--- a/packages/rooks/src/hooks/useBoundingclientrectRef.ts
+++ b/packages/rooks/src/hooks/useBoundingclientrectRef.ts
@@ -16,7 +16,7 @@ function getBoundingClientRect(element: HTMLElement): DOMRect {
  * Tracks the boundingclientrect of a React Ref and fires a callback when the element's size changes.
  *
  * @returns [CallbackRef | null, DOMRect | null, () => void]
- * @see https://rooks.vercel.app/docs/useBoundingclientRectRef
+ * @see https://rooks.vercel.app/docs/hooks/useBoundingclientRectRef
  */
 function useBoundingclientrectRef(): [
   CallbackRef | null,

--- a/packages/rooks/src/hooks/useCountdown.ts
+++ b/packages/rooks/src/hooks/useCountdown.ts
@@ -14,7 +14,7 @@ type CountdownOptions = {
  *
  * @param endTime Time to countdown
  * @param options  Countdown options
- * @see https://rooks.vercel.app/docs/useCountdown
+ * @see https://rooks.vercel.app/docs/hooks/useCountdown
  */
 function useCountdown(endTime: Date, options: CountdownOptions = {}): number {
   const { interval = 1_000, onDown, onEnd } = options;

--- a/packages/rooks/src/hooks/useCounter.ts
+++ b/packages/rooks/src/hooks/useCounter.ts
@@ -19,7 +19,7 @@ type CounterHandler = {
  * @property {Function} incrementBy Increment counter by incrAmount
  * @property {Function} decrementBy Decrement counter by decrAmount
  * @property {Function} reset Reset counter to initialValue
- * @see {@link https://rooks.vercel.app/docs/useCounter}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useCounter}
  */
 
 /**
@@ -27,7 +27,7 @@ type CounterHandler = {
  *
  * @param {number} initialValue The initial value of the counter
  * @returns {handler} A handler to interact with the counter
- * @see https://rooks.vercel.app/docs/useCounter
+ * @see https://rooks.vercel.app/docs/hooks/useCounter
  */
 function useCounter(initialValue: number): CounterHandler {
   const [counter, setCounter] = useState(initialValue);

--- a/packages/rooks/src/hooks/useDebounce.ts
+++ b/packages/rooks/src/hooks/useDebounce.ts
@@ -30,7 +30,7 @@ type CanAlsoReturnVoid<T extends AnyFunction> = T | (() => void);
  * @param options.maxWait The maximum time func is allowed to be delayed before it's invoked.
  * @param options.trailing Specify invoking on the trailing edge of the timeout.
  * @returns Returns the new debounced function.
- * @see https://rooks.vercel.app/docs/useDebounce
+ * @see https://rooks.vercel.app/docs/hooks/useDebounce
  */
 function useDebounce<T extends AnyFunction>(
   callback: T,

--- a/packages/rooks/src/hooks/useDebounceFn.ts
+++ b/packages/rooks/src/hooks/useDebounceFn.ts
@@ -1,7 +1,7 @@
 /**
  * useDebounceFn
  * @description Powerful debounce function hook for React
- * @see {@link https://rooks.vercel.app/docs/useDebounceFn}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useDebounceFn}
  */
 import { useRef, useCallback, useState } from "react";
 import { useFreshCallback } from "./useFreshCallback";

--- a/packages/rooks/src/hooks/useDebouncedValue.ts
+++ b/packages/rooks/src/hooks/useDebouncedValue.ts
@@ -28,7 +28,7 @@ type UseDebouncedValueReturnType<
  * @param value The value to debounce
  * @param timeout The duration to debounce
  * @param options The options object.
- * @see https://rooks.vercel.app/docs/useDebouncedValue
+ * @see https://rooks.vercel.app/docs/hooks/useDebouncedValue
  */
 export const useDebouncedValue = <
   TValue = unknown,

--- a/packages/rooks/src/hooks/useDeepCompareEffect.ts
+++ b/packages/rooks/src/hooks/useDeepCompareEffect.ts
@@ -1,7 +1,7 @@
 /**
  * useDeepCompareEffect
  * @description Deep compare dependencies instead of shallow for useEffect
- * @see {@link https://rooks.vercel.app/docs/useDeepCompareEffect}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useDeepCompareEffect}
  */
 import { useEffect, useRef, DependencyList, EffectCallback } from "react";
 import isEqual from "fast-deep-equal";

--- a/packages/rooks/src/hooks/useDidMount.ts
+++ b/packages/rooks/src/hooks/useDidMount.ts
@@ -6,7 +6,7 @@ import type { CallbackWithNoArguments } from "@/types/types";
  * @description Calls a function on mount
  *
  * @param {Function} callback Callback function to be called on mount
- * @see https://rooks.vercel.app/docs/useDidMount
+ * @see https://rooks.vercel.app/docs/hooks/useDidMount
  */
 function useDidMount(callback: CallbackWithNoArguments): void {
   useEffect(() => {

--- a/packages/rooks/src/hooks/useDidUpdate.ts
+++ b/packages/rooks/src/hooks/useDidUpdate.ts
@@ -11,7 +11,7 @@ import { useWillUnmount } from "./useWillUnmount";
  *
  * @param {Function} callback The callback to be called on update
  * @param {Array} conditions The list of variables which trigger update when they are changed
- * @see https://rooks.vercel.app/docs/useDidUpdate
+ * @see https://rooks.vercel.app/docs/hooks/useDidUpdate
  */
 function useDidUpdate(callback: () => void, conditions?: unknown[]): void {
   const hasMountedRef = useRef<boolean>(false);

--- a/packages/rooks/src/hooks/useDimensionsRef.ts
+++ b/packages/rooks/src/hooks/useDimensionsRef.ts
@@ -51,7 +51,7 @@ const noWindowReturnValue: UseDimensionsHook = [undefined, null, null];
  * @param updateOnScroll Whether to update on scroll
  * @param updateOnResize Whether to update on resize
  * @returns [React.Ref<HTMLDivElement>, UseDimensionsRefReturn, HTMLElement | null]
- * @see https://rooks.vercel.app/docs/useDimensionsRef
+ * @see https://rooks.vercel.app/docs/hooks/useDimensionsRef
  */
 export const useDimensionsRef = ({
   updateOnScroll = true,

--- a/packages/rooks/src/hooks/useDocumentEventListener.ts
+++ b/packages/rooks/src/hooks/useDocumentEventListener.ts
@@ -10,7 +10,7 @@ import type { ListenerOptions } from "@/types/utils";
  * @param {Function} callback The callback to be called on event
  * @param {ListenerOptions} listenerOptions The options to be passed to the event listener
  * @param {boolean} isLayoutEffect Should it use layout effect. Defaults to false
- * @see https://rooks.vercel.app/docs/useDocumentEventListener
+ * @see https://rooks.vercel.app/docs/hooks/useDocumentEventListener
  */
 function useDocumentEventListener(
   eventName: keyof DocumentEventMap,

--- a/packages/rooks/src/hooks/useDocumentTitle.ts
+++ b/packages/rooks/src/hooks/useDocumentTitle.ts
@@ -22,7 +22,7 @@ type UseDocumentTitleOptions = {
  *   useDocumentTitle("My App", { resetOnUnmount: true });
  *   return <div>Hello, world!</div>;
  * }
- * @see {@link https://rooks.vercel.app/docs/useDocumentTitle}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useDocumentTitle}
  */
 function useDocumentTitle(
   title: string,

--- a/packages/rooks/src/hooks/useDocumentVisibilityState.ts
+++ b/packages/rooks/src/hooks/useDocumentVisibilityState.ts
@@ -30,7 +30,7 @@ function getVisibilityStateServerSnapshot(): UseDocumentVisibilityStateReturnTyp
  * useDocumentVisibilityState
  * @description Returns the visibility state of the document. Returns null on the server side.
  * @returns {UseDocumentVisibilityStateReturnType} The visibility state of the document. `null` on the server.
- * @see {@link https://rooks.vercel.app/docs/useDocumentVisibilityState}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useDocumentVisibilityState}
  */
 function useDocumentVisibilityState(): UseDocumentVisibilityStateReturnType {
   return useSyncExternalStore(getVisibilityStateSubscription, getVisibilityStateSnapshot, getVisibilityStateServerSnapshot);

--- a/packages/rooks/src/hooks/useEffectOnceWhen.ts
+++ b/packages/rooks/src/hooks/useEffectOnceWhen.ts
@@ -8,7 +8,7 @@ import { useEffect, useRef } from "react";
  *
  * @param callback The callback to fire
  * @param when The condition which needs to be true
- * @see https://rooks.vercel.app/docs/useEffectOnceWhen
+ * @see https://rooks.vercel.app/docs/hooks/useEffectOnceWhen
  */
 function useEffectOnceWhen(callback: () => void, when = true): void {
   const hasRunOnceRef = useRef(false);

--- a/packages/rooks/src/hooks/useEventListenerRef.ts
+++ b/packages/rooks/src/hooks/useEventListenerRef.ts
@@ -16,7 +16,7 @@ import { noop } from "@/utils/noop";
  * @param {object} listenerOptions The options to be passed to the event listener
  * @param {boolean} isLayoutEffect Should it use layout effect. Defaults to false
  * @returns {Function} A callback ref that can be used as ref prop
- * @see https://rooks.vercel.app/docs/useEventListenerRef
+ * @see https://rooks.vercel.app/docs/hooks/useEventListenerRef
  */
 function useEventListenerRef(
   eventName: string,

--- a/packages/rooks/src/hooks/useFileDropRef.ts
+++ b/packages/rooks/src/hooks/useFileDropRef.ts
@@ -1,7 +1,7 @@
 /**
  * useFileDropRef
  * @description Drop files easily
- * @see {@link https://rooks.vercel.app/docs/useFileDropRef}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useFileDropRef}
  */
 import { noop } from "@/utils/noop";
 import { useCallback, useState, useEffect } from "react";

--- a/packages/rooks/src/hooks/useFocus.ts
+++ b/packages/rooks/src/hooks/useFocus.ts
@@ -25,7 +25,7 @@ interface FocusResult<T> {
 /**
  * useFocus
  * @description Handles focus events for the immediate target element.
- * @see {@link https://rooks.vercel.app/docs/useFocus}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useFocus}
  */
 const useFocus = <T extends HTMLElement>(props: FocusProps): FocusResult<T> => {
   const {

--- a/packages/rooks/src/hooks/useFocusWithin.ts
+++ b/packages/rooks/src/hooks/useFocusWithin.ts
@@ -18,7 +18,7 @@ interface FocusWithinResult<T> {
 /**
  * useFocusWithin
  * @description Handles focus events for the target component.
- * @see {@link https://rooks.vercel.app/docs/useFocusWithin}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useFocusWithin}
  */
 const useFocusWithin = <T extends HTMLElement>(
   props: FocusWithinProps

--- a/packages/rooks/src/hooks/useForkRef.ts
+++ b/packages/rooks/src/hooks/useForkRef.ts
@@ -20,7 +20,7 @@ function setRef<T>(ref: PossibleRef<T> | null, value: T) {
  * @param refA
  * @param refB
  * @returns MutableRefObject
- * @see https://rooks.vercel.app/docs/useForkRef
+ * @see https://rooks.vercel.app/docs/hooks/useForkRef
  */
 function useForkRef<T>(
   refA: PossibleRef<T> | null,

--- a/packages/rooks/src/hooks/useFreshCallback.ts
+++ b/packages/rooks/src/hooks/useFreshCallback.ts
@@ -1,7 +1,7 @@
 /**
  * useFreshCallback
  * @description Avoid stale closures and keep your callback fresh
- * @see {@link https://rooks.vercel.app/docs/useFreshCallback}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useFreshCallback}
  */
 import { useCallback } from "react";
 import { useFreshRef } from "./useFreshRef";
@@ -12,7 +12,7 @@ type CallbackType<T, R> = (...args: T[]) => R;
  * useFreshCallback
  * @param callback Any callback function
  * @returns A fresh callback.
- * @see https://rooks.vercel.app/docs/useFreshCallback
+ * @see https://rooks.vercel.app/docs/hooks/useFreshCallback
  */
 function useFreshCallback<T, R = void>(
   callback: CallbackType<T, R>

--- a/packages/rooks/src/hooks/useFreshRef.ts
+++ b/packages/rooks/src/hooks/useFreshRef.ts
@@ -10,7 +10,7 @@ import { useIsomorphicEffect } from "./useIsomorphicEffect";
  * @param preferLayoutEffect Should the value be updated using a layout effect
  * or a passive effect. Defaults to false.
  * @returns A ref containing the fresh value
- * @see https://rooks.vercel.app/docs/useFreshRef
+ * @see https://rooks.vercel.app/docs/hooks/useFreshRef
  */
 function useFreshRef<T>(
   value: T,

--- a/packages/rooks/src/hooks/useFreshTick.ts
+++ b/packages/rooks/src/hooks/useFreshTick.ts
@@ -5,7 +5,7 @@ type CallbackType<T> = (...args: T[]) => void;
  * useFreshTick
  * @param callback The callback to be called on mount
  * @returns A fresh callback.
- * @see https://rooks.vercel.app/docs/useFreshCallback
+ * @see https://rooks.vercel.app/docs/hooks/useFreshCallback
  */
 function useFreshTick<T>(callback: CallbackType<T>): CallbackType<T> {
   const freshRef = useFreshRef(callback);

--- a/packages/rooks/src/hooks/useGeolocation.ts
+++ b/packages/rooks/src/hooks/useGeolocation.ts
@@ -54,7 +54,7 @@ const defaultGeoLocationOptions: UseGeoLocationOptions = {
  * Gets the geolocation data as a hook
  *
  * @param {UseGeoLocationOptions} geoLocationOptions Geolocation options
- * @see {@link https://rooks.vercel.app/docs/useGeolocation}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useGeolocation}
  */
 const useGeolocation = (
   geoLocationOptions: UseGeoLocationOptions = defaultGeoLocationOptions

--- a/packages/rooks/src/hooks/useGetIsMounted.ts
+++ b/packages/rooks/src/hooks/useGetIsMounted.ts
@@ -7,7 +7,7 @@ type UseGetIsMounted = () => () => boolean;
  * Useful for async effects. Returns a callback that returns a boolean representing if the component
  * is mounted at the time.
  * @returns () => boolean
- * @see https://rooks.vercel.app/docs/useGetIsMounted
+ * @see https://rooks.vercel.app/docs/hooks/useGetIsMounted
  */
 export const useGetIsMounted: UseGetIsMounted = () => {
   const isMountedRef = useRef<boolean>(false);

--- a/packages/rooks/src/hooks/useGlobalObjectEventListener.ts
+++ b/packages/rooks/src/hooks/useGlobalObjectEventListener.ts
@@ -33,7 +33,7 @@ function useGlobalObjectEventListener(
  * @param {ListenerOptions} listenerOptions The options to be passed to the event listener
  * @param {boolean} when Should the event listener be active
  * @param {boolean} isLayoutEffect Should it use layout effect. Defaults to false
- * @see https://rooks.vercel.app/docs/useGlobalObjectEventListener
+ * @see https://rooks.vercel.app/docs/hooks/useGlobalObjectEventListener
  */
 function useGlobalObjectEventListener<GlobalObject extends Window | Document>(
   globalObject: GlobalObject,

--- a/packages/rooks/src/hooks/useInput.ts
+++ b/packages/rooks/src/hooks/useInput.ts
@@ -42,7 +42,7 @@ const defaultOptions = {};
  * @param {unknown} [initialValue] Initial value of the input
  * @param {Options} [options] Options object
  * @returns {InputHandler} Input handler with value and onChange
- * @see https://rooks.vercel.app/docs/useInput
+ * @see https://rooks.vercel.app/docs/hooks/useInput
  */
 function useInput<
   T extends number | string | readonly string[] | undefined = string

--- a/packages/rooks/src/hooks/useIntersectionObserverRef.ts
+++ b/packages/rooks/src/hooks/useIntersectionObserverRef.ts
@@ -16,7 +16,7 @@ const config: IntersectionObserverInit = {
  *
  * @param {IntersectionObserverCallback} callback Function that needs to be fired on mutation
  * @param {IntersectionObserverInit} options
- * @see https://rooks.vercel.app/docs/useIntersectionObserverRef
+ * @see https://rooks.vercel.app/docs/hooks/useIntersectionObserverRef
  */
 function useIntersectionObserverRef(
   callback: IntersectionObserverCallback | undefined,

--- a/packages/rooks/src/hooks/useIntervalWhen.ts
+++ b/packages/rooks/src/hooks/useIntervalWhen.ts
@@ -9,7 +9,7 @@ import { noop } from "@/utils/noop";
  * @param intervalDurationMs Amount of time in ms after which to invoke
  * @param when The condition which when true, sets the interval
  * @param startImmediate If the callback should be invoked immediately
- * @see https://rooks.vercel.app/docs/useIntervalWhen
+ * @see https://rooks.vercel.app/docs/hooks/useIntervalWhen
  */
 function useIntervalWhen(
   callback: () => void,

--- a/packages/rooks/src/hooks/useIsDroppingFiles.ts
+++ b/packages/rooks/src/hooks/useIsDroppingFiles.ts
@@ -1,7 +1,7 @@
 /**
  * useIsDroppingFiles
  * @description Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
- * @see {@link https://rooks.vercel.app/docs/useIsDroppingFiles}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useIsDroppingFiles}
  */
 import { CallbackRef, HTMLElementOrNull } from "@/utils/utils";
 import { useState, useEffect, useCallback } from "react";

--- a/packages/rooks/src/hooks/useIsomorphicEffect.ts
+++ b/packages/rooks/src/hooks/useIsomorphicEffect.ts
@@ -5,7 +5,7 @@ import { useEffect, useLayoutEffect } from "react";
  * Resolves to useEffect when "window" is not in scope and useLayout effect in the browser
  *
  * @param {Function} callback Callback function to be called on mount
- * @see https://rooks.vercel.app/docs/useIsomorphicEffect
+ * @see https://rooks.vercel.app/docs/hooks/useIsomorphicEffect
  */
 const useIsomorphicEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/packages/rooks/src/hooks/useKey.ts
+++ b/packages/rooks/src/hooks/useKey.ts
@@ -37,7 +37,7 @@ const defaultOptions = {
  * @param {TrackedKeyEvents} keys List of keys to listen for. Eg: ["a", "b"]
  * @param {Callback} callback  Callback to fire on keyboard events
  * @param {Options} options Options
- * @see https://rooks.vercel.app/docs/useKey
+ * @see https://rooks.vercel.app/docs/hooks/useKey
  */
 function useKey(
   keys: Array<number | string> | number | string,

--- a/packages/rooks/src/hooks/useKeyBindings.ts
+++ b/packages/rooks/src/hooks/useKeyBindings.ts
@@ -30,7 +30,7 @@ type KeyBindings = { [key: string]: (event: KeyboardEvent) => void };
  *
  * @param { KeyBindings } keyBindings
  * @param {Options} options
- * @see https://rooks.vercel.app/docs/useKeyBindings
+ * @see https://rooks.vercel.app/docs/hooks/useKeyBindings
  */
 const useKeyBindings = (keyBindings: KeyBindings, options?: Options) => {
   for (const key in keyBindings) {

--- a/packages/rooks/src/hooks/useKeyRef.ts
+++ b/packages/rooks/src/hooks/useKeyRef.ts
@@ -31,7 +31,7 @@ const defaultOptions: Required<Options> = {
  * @param {Function} callback Callback to fire on keyboard events
  * @param {Options} options Options
  * @returns {CallbackRef} CallbackRef
- * @see https://rooks.vercel.app/docs/useKeyRef
+ * @see https://rooks.vercel.app/docs/hooks/useKeyRef
  */
 function useKeyRef(
   keys: Array<number | string> | number | string,

--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -43,7 +43,7 @@ const defaultOptions = {
  * @param keysList - list of keys to listen to
  * @param callback  - callback to be called when a key is pressed
  * @param options - options to be passed to the event listener
- * @see https://rooks.vercel.app/docs/useKeys
+ * @see https://rooks.vercel.app/docs/hooks/useKeys
  */
 function useKeys(
   keysList: string[],

--- a/packages/rooks/src/hooks/useLifecycleLogger.ts
+++ b/packages/rooks/src/hooks/useLifecycleLogger.ts
@@ -8,7 +8,7 @@ import { useWillUnmount } from "./useWillUnmount";
  *
  * @param componentName Name of the component
  * @param {...*} otherArgs Other arguments to log
- * @see https://rooks.vercel.app/docs/useLifecycleLogger
+ * @see https://rooks.vercel.app/docs/hooks/useLifecycleLogger
  */
 const useLifecycleLogger = (
   componentName = "Component",

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -58,7 +58,7 @@ type BroadcastCustomEvent<S> = CustomEvent<{ newValue: S }>;
  *
  * @param {string} key - Key of the localStorage object
  * @param {any} initialState - Default initial value
- * @see https://rooks.vercel.app/docs/useLocalstorageState
+ * @see https://rooks.vercel.app/docs/hooks/useLocalstorageState
  */
 function useLocalstorageState<S>(
   key: string,

--- a/packages/rooks/src/hooks/useLockBodyScroll.ts
+++ b/packages/rooks/src/hooks/useLockBodyScroll.ts
@@ -7,7 +7,7 @@ import { useEffect } from "react";
  * This hook locks the scroll of the body element when `isLocked` is set to `true`.
  *
  * @param isLocked Whether or not to lock the body scroll
- * @see https://rooks.vercel.app/docs/useLockBodyScroll
+ * @see https://rooks.vercel.app/docs/hooks/useLockBodyScroll
  */
 function useLockBodyScroll(isLocked: boolean) {
   useEffect(() => {

--- a/packages/rooks/src/hooks/useMapState.ts
+++ b/packages/rooks/src/hooks/useMapState.ts
@@ -5,7 +5,7 @@ import { useCallback, useState } from "react";
  * A hook to manage state in the form of a map or object.
  *
  * @param initialValue Initial value of the map
- * @see https://rooks.vercel.app/docs/useMapState
+ * @see https://rooks.vercel.app/docs/hooks/useMapState
  */
 function useMapState<
   T extends {

--- a/packages/rooks/src/hooks/useMediaMatch.ts
+++ b/packages/rooks/src/hooks/useMediaMatch.ts
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from "react";
  * @param query The media query to signal on. Example, `"print"` will signal
  * `true` when previewing in print mode, and `false` otherwise.
  * @returns Whether or not the media query is currently matched.
- * @see https://rooks.vercel.app/docs/useMediaMatch
+ * @see https://rooks.vercel.app/docs/hooks/useMediaMatch
  */
 function useMediaMatch(query: string): boolean {
   const matchMedia = useMemo<MediaQueryList>(

--- a/packages/rooks/src/hooks/useMergeRefs.ts
+++ b/packages/rooks/src/hooks/useMergeRefs.ts
@@ -17,7 +17,7 @@ function setRef<T>(ref: PossibleRef<T>, value: T) {
  * Refs can be mutable refs or function refs.
  *
  * @param refs
- * @see https://rooks.vercel.app/docs/useMergeRefs
+ * @see https://rooks.vercel.app/docs/hooks/useMergeRefs
  */
 export function useMergeRefs<T>(
   ...refs: Array<PossibleRef<T>>

--- a/packages/rooks/src/hooks/useMouse.ts
+++ b/packages/rooks/src/hooks/useMouse.ts
@@ -65,7 +65,7 @@ function getMousePositionFromEvent(event: MouseEvent): MouseData {
  *
  * Retrieves current mouse position and information about the position like
  * screenX, pageX, clientX, movementX, offsetX
- * @see https://rooks.vercel.app/docs/useMouse
+ * @see https://rooks.vercel.app/docs/hooks/useMouse
  */
 export function useMouse(): MouseData {
   const [mousePosition, setMousePosition] =

--- a/packages/rooks/src/hooks/useMouseMoveDelta.ts
+++ b/packages/rooks/src/hooks/useMouseMoveDelta.ts
@@ -1,7 +1,7 @@
 /**
  * useMouseMoveDelta
  * @description Tracks delta of mouse move
- * @see {@link https://rooks.vercel.app/docs/useMouseMoveDelta}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useMouseMoveDelta}
  */
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useFreshCallback } from "./useFreshCallback";

--- a/packages/rooks/src/hooks/useMouseWheelDelta.ts
+++ b/packages/rooks/src/hooks/useMouseWheelDelta.ts
@@ -1,7 +1,7 @@
 /**
  * useMouseWheelDelta
  * @description Tracks delta of mouse wheel
- * @see {@link https://rooks.vercel.app/docs/useMouseWheelDelta}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useMouseWheelDelta}
  */
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useFreshCallback } from "./useFreshCallback";

--- a/packages/rooks/src/hooks/useMultiSelectableList.ts
+++ b/packages/rooks/src/hooks/useMultiSelectableList.ts
@@ -42,7 +42,7 @@ type UseMultiSelectableListReturnType<T> = [
  * @param list - The list of values to select from
  * @param initialSelectIndices - The indices of the initial selections
  * @param allowUnselected - Whether or not to allow unselected values
- * @see https://rooks.vercel.app/docs/useMultiSelectableList
+ * @see https://rooks.vercel.app/docs/hooks/useMultiSelectableList
  */
 function useMultiSelectableList<T>(
   list: T[] = [],

--- a/packages/rooks/src/hooks/useMutationObserver.ts
+++ b/packages/rooks/src/hooks/useMutationObserver.ts
@@ -18,7 +18,7 @@ const config: MutationObserverInit = {
  * @param {MutableRefObject<HTMLElement | null>} ref React ref on which mutations are to be observed
  * @param {MutationCallback} callback Function that needs to be fired on mutation
  * @param {MutationObserverInit} options
- * @see https://rooks.vercel.app/docs/useMutationObserver
+ * @see https://rooks.vercel.app/docs/hooks/useMutationObserver
  */
 function useMutationObserver(
   ref: MutableRefObject<HTMLElement | null>,

--- a/packages/rooks/src/hooks/useMutationObserverRef.ts
+++ b/packages/rooks/src/hooks/useMutationObserverRef.ts
@@ -17,7 +17,7 @@ const config: MutationObserverInit = {
  *
  * @param {MutationCallback} callback Function that needs to be fired on mutation
  * @param {MutationObserverInit} options
- * @see https://rooks.vercel.app/docs/useMutationObserverRef
+ * @see https://rooks.vercel.app/docs/hooks/useMutationObserverRef
  */
 function useMutationObserverRef(
   callback: MutationCallback,

--- a/packages/rooks/src/hooks/useNativeMapState.ts
+++ b/packages/rooks/src/hooks/useNativeMapState.ts
@@ -1,7 +1,7 @@
 /**
  * useNativeMapState
  * @description Manage Map() object state in React
- * @see {@link https://rooks.vercel.app/docs/useNativeMapState}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useNativeMapState}
  */
 import { useState, useCallback } from "react";
 

--- a/packages/rooks/src/hooks/useNavigatorLanguage.ts
+++ b/packages/rooks/src/hooks/useNavigatorLanguage.ts
@@ -33,7 +33,7 @@ function getLanguageServerSnapshot(): Language {
  * Returns the language of the navigator
  *
  * @returns {Language}
- * @see https://rooks.vercel.app/docs/useNavigatorLanguage
+ * @see https://rooks.vercel.app/docs/hooks/useNavigatorLanguage
  */
 export function useNavigatorLanguage(): Language {
   return useSyncExternalStore(getLanguageSubscription, getLanguageSnapshot, getLanguageServerSnapshot);

--- a/packages/rooks/src/hooks/useOnLongHover.ts
+++ b/packages/rooks/src/hooks/useOnLongHover.ts
@@ -1,7 +1,7 @@
 /**
  * useOnLongHover
  * @description Fires a callback when an element is hovered for a while
- * @see {@link https://rooks.vercel.app/docs/useOnLongHover}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useOnLongHover}
  */
 import { HTMLElementOrNull } from "@/utils/utils";
 import { useCallback, useEffect, useState } from "react";

--- a/packages/rooks/src/hooks/useOnLongPress.ts
+++ b/packages/rooks/src/hooks/useOnLongPress.ts
@@ -1,7 +1,7 @@
 /**
  * useOnLongPress
  * @description Fire a callback on long press
- * @see {@link https://rooks.vercel.app/docs/useOnLongPress}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useOnLongPress}
  */
 import { HTMLElementOrNull } from "@/utils/utils";
 import { useCallback, useEffect, useState } from "react";

--- a/packages/rooks/src/hooks/useOnWindowResize.ts
+++ b/packages/rooks/src/hooks/useOnWindowResize.ts
@@ -9,7 +9,7 @@ import { useGlobalObjectEventListener } from "./useGlobalObjectEventListener";
  * @param {Function} callback Callback to be called before unmount
  * @param {boolean} when When the handler should be applied
  * @param {boolean} isLayoutEffect Should it use layout effect. Defaults to false
- * @see https://rooks.vercel.app/docs/useOnWindowResize
+ * @see https://rooks.vercel.app/docs/hooks/useOnWindowResize
  */
 function useOnWindowResize(
   callback: EventListener,

--- a/packages/rooks/src/hooks/useOnWindowScroll.ts
+++ b/packages/rooks/src/hooks/useOnWindowScroll.ts
@@ -8,7 +8,7 @@ import { useGlobalObjectEventListener } from "./useGlobalObjectEventListener";
  * @param {Function} callback Callback to be called before unmount
  * @param {boolean} when When the handler should be applied
  * @param {boolean} isLayoutEffect Should it use layout effect. Defaults to false
- * @see https://rooks.vercel.app/docs/useOnWindowScroll
+ * @see https://rooks.vercel.app/docs/hooks/useOnWindowScroll
  *
  */
 function useOnWindowScroll(

--- a/packages/rooks/src/hooks/useOnline.ts
+++ b/packages/rooks/src/hooks/useOnline.ts
@@ -33,7 +33,7 @@ function subscribe(onStoreChange: () => void): () => void {
  * Returns true if navigator is online, false if not.
  *
  * @returns {boolean} The value of navigator.onLine
- * @see https://rooks.vercel.app/docs/useOnline
+ * @see https://rooks.vercel.app/docs/hooks/useOnline
  */
 function useOnline(): boolean | null {
   const isOnline = useSyncExternalStore<boolean | null>(subscribe, getSnapshot);

--- a/packages/rooks/src/hooks/useOrientation.ts
+++ b/packages/rooks/src/hooks/useOrientation.ts
@@ -1,7 +1,7 @@
 /**
  * useOrientation
  * @description orientation hook for react
- * @see {@link https://rooks.vercel.app/docs/useOrientation}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useOrientation}
  */
 import { useState, useEffect } from "react";
 

--- a/packages/rooks/src/hooks/useOutsideClick.ts
+++ b/packages/rooks/src/hooks/useOutsideClick.ts
@@ -9,7 +9,7 @@ import { noop } from "@/utils/noop";
  * @param ref Ref whose outside click needs to be listened to
  * @param handler Callback to fire on outside click
  * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
- * @see https://rooks.vercel.app/docs/useOutsideClick
+ * @see https://rooks.vercel.app/docs/hooks/useOutsideClick
  * @example
  * ```tsx
  * import { useOutsideClick } from "@/hooks/useOutsideClick";

--- a/packages/rooks/src/hooks/useOutsideClickRef.ts
+++ b/packages/rooks/src/hooks/useOutsideClickRef.ts
@@ -9,7 +9,7 @@ import { noop } from "@/utils/noop";
  * @param handler Callback to fire on outside click
  * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
  * @returns An array with first item being ref
- * @see https://rooks.vercel.app/docs/useOutsideClick
+ * @see https://rooks.vercel.app/docs/hooks/useOutsideClick
  */
 function useOutsideClickRef(
   handler: (event: MouseEvent | TouchEvent) => void,

--- a/packages/rooks/src/hooks/usePictureInPictureApi.ts
+++ b/packages/rooks/src/hooks/usePictureInPictureApi.ts
@@ -15,7 +15,7 @@ type PictureInPictureApi = {
  *
  * @param videoRef - Reference to the video element
  * @returns Object containing PiP state and control functions
- * @see https://rooks.vercel.app/docs/usePictureInPictureApi
+ * @see https://rooks.vercel.app/docs/hooks/usePictureInPictureApi
  */
 function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureInPictureApi {
   const [isPiPActive, setIsPiPActive] = useState(false);

--- a/packages/rooks/src/hooks/usePreviousDifferent.ts
+++ b/packages/rooks/src/hooks/usePreviousDifferent.ts
@@ -6,7 +6,7 @@ import { useRef, useEffect } from "react";
  *
  * @param currentValue The value whose previously different value is to be tracked
  * @returns The previous value
- * @see https://rooks.vercel.app/docs/usePreviousDifferent
+ * @see https://rooks.vercel.app/docs/hooks/usePreviousDifferent
  */
 function usePreviousDifferent<T>(currentValue: T): T | null {
   const previousRef = useRef<T | null>(null);

--- a/packages/rooks/src/hooks/usePreviousImmediate.ts
+++ b/packages/rooks/src/hooks/usePreviousImmediate.ts
@@ -5,7 +5,7 @@ import { useRef, useEffect } from "react";
  *
  * @param currentValue The value whose previous value is to be tracked
  * @returns The previous value
- * @see https://rooks.vercel.app/docs/usePreviousImmediate
+ * @see https://rooks.vercel.app/docs/hooks/usePreviousImmediate
  */
 function usePreviousImmediate<T>(currentValue: T): T | null {
   const previousRef = useRef<T | null>(null);

--- a/packages/rooks/src/hooks/usePromise.ts
+++ b/packages/rooks/src/hooks/usePromise.ts
@@ -1,7 +1,7 @@
 /**
  * usePromise
  * @description Promise management hook for react
- * @see {@link https://rooks.vercel.app/docs/usePromise}
+ * @see {@link https://rooks.vercel.app/docs/hooks/usePromise}
  */
 import { useState, useEffect, DependencyList } from "react";
 import { useFreshCallback } from "./useFreshCallback";

--- a/packages/rooks/src/hooks/useQueueState.ts
+++ b/packages/rooks/src/hooks/useQueueState.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
  * Manages a queue with react hooks.
  * @param initialList Initial value of the list
  * @returns The list and controls to modify the queue
- * @see https://rooks.vercel.app/docs/useQueueState
+ * @see https://rooks.vercel.app/docs/hooks/useQueueState
  */
 function useQueueState<T>(initialList: T[]): [
   T[],

--- a/packages/rooks/src/hooks/useRaf.ts
+++ b/packages/rooks/src/hooks/useRaf.ts
@@ -9,7 +9,7 @@ import { noop } from "@/utils/noop";
  *
  * @param {Function} callback The callback function to be executed
  * @param {boolean} [isActive] The value which while true, keeps the raf running infinitely
- * @see https://rooks.vercel.app/docs/useRaf
+ * @see https://rooks.vercel.app/docs/hooks/useRaf
  */
 export function useRaf(
   callback: (timeElapsed: number) => void,

--- a/packages/rooks/src/hooks/useRefElement.ts
+++ b/packages/rooks/src/hooks/useRefElement.ts
@@ -6,7 +6,7 @@ import type { RefElementOrNull } from "../utils/utils";
  * Helps bridge gap between callback ref and state
  * Manages the element called with callback ref api using state variable
  * @returns {[RefElementOrNull, (element: HTMLElementOrNull) => void]}
- * @see https://rooks.vercel.app/docs/useRefElement
+ * @see https://rooks.vercel.app/docs/hooks/useRefElement
  */
 function useRefElement<T>(): [
   (refElement: RefElementOrNull<T>) => void,

--- a/packages/rooks/src/hooks/useRenderCount.ts
+++ b/packages/rooks/src/hooks/useRenderCount.ts
@@ -3,7 +3,7 @@ import { useRef } from "react";
 /**
  * useRenderCount
  * @description Get the render count of a component
- * @see {@link https://rooks.vercel.app/docs/useRenderCount}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useRenderCount}
  */
 function useRenderCount(): number {
   return ++useRef<number>(0).current;

--- a/packages/rooks/src/hooks/useResizeObserverRef.ts
+++ b/packages/rooks/src/hooks/useResizeObserverRef.ts
@@ -16,7 +16,7 @@ const config: ResizeObserverOptions = {
  * @param {ResizeObserverCallback} callback Function that needs to be fired on resize
  * @param {ResizeObserverOptions} options An options object allowing you to set options for the observation
  * @returns {[CallbackRef]} callbackref
- * @see https://rooks.vercel.app/docs/useResizeObserverRef
+ * @see https://rooks.vercel.app/docs/hooks/useResizeObserverRef
  */
 function useResizeObserverRef(
   callback: ResizeObserverCallback | undefined,

--- a/packages/rooks/src/hooks/useSafeSetState.ts
+++ b/packages/rooks/src/hooks/useSafeSetState.ts
@@ -1,7 +1,7 @@
 /**
  * useSafeSetState
  * @description set state but ignores if component has already unmounted
- * @see {@link https://rooks.vercel.app/docs/useSafeSetState}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useSafeSetState}
  */
 import { useState, useCallback, SetStateAction, Dispatch } from "react";
 import { useGetIsMounted } from "./useGetIsMounted";

--- a/packages/rooks/src/hooks/useScreenDetailsApi.ts
+++ b/packages/rooks/src/hooks/useScreenDetailsApi.ts
@@ -67,7 +67,7 @@ interface UseScreenDetailsApiReturn {
  * Hook for multi-screen information and management using Screen Details API
  * @param options Configuration options for the hook
  * @returns Object containing screen details and control functions
- * @see {@link https://rooks.vercel.app/docs/useScreenDetailsApi}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useScreenDetailsApi}
  */
 function useScreenDetailsApi(options: UseScreenDetailsApiOptions = {}): UseScreenDetailsApiReturn {
   const { requestOnMount = false, autoRefresh = true } = options;

--- a/packages/rooks/src/hooks/useSelect.ts
+++ b/packages/rooks/src/hooks/useSelect.ts
@@ -14,7 +14,7 @@ type SelectHandler<T> = {
  * @param list List of values to select a value from
  * @param {number} initialIndex Initial index which is selected
  * @returns handler
- * @see https://rooks.vercel.app/docs/useSelect
+ * @see https://rooks.vercel.app/docs/hooks/useSelect
  */
 function useSelect<T>(list: T[], initialIndex = 0): SelectHandler<T> {
   const [selectedIndex, setSelectedIndex] = useState(initialIndex);

--- a/packages/rooks/src/hooks/useSelectableList.ts
+++ b/packages/rooks/src/hooks/useSelectableList.ts
@@ -39,7 +39,7 @@ type UseSelectableListReturnType<T> = [
  * @param list - The list of values to select from
  * @param initialIndex  - The index of the initial selection
  * @param allowUnselected
- * @see https://rooks.vercel.app/docs/useSelectableList
+ * @see https://rooks.vercel.app/docs/hooks/useSelectableList
  */
 function useSelectableList<T>(
   list: T[] = [],

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -51,7 +51,7 @@ type BroadcastCustomEvent<S> = CustomEvent<{ newValue: S }>;
  * @param {string} key - Key of the sessionStorage object
  * @param {any} initialState - Default initial value
  * @returns {[any, Dispatch<SetStateAction<any>>, () => void]}
- * @see https://rooks.vercel.app/docs/useSessionstorageState
+ * @see https://rooks.vercel.app/docs/hooks/useSessionstorageState
  */
 function useSessionstorageState<S>(
   key: string,

--- a/packages/rooks/src/hooks/useSetState.ts
+++ b/packages/rooks/src/hooks/useSetState.ts
@@ -16,7 +16,7 @@ export type UseSetStateReturnValue<T> = [Set<T>, UseSetStateControls<T>];
  * @description Manage the state of a Set in React.
  * @param {Set<T>} initialSetValue The initial value of the set to manage.
  * @returns {UseSetStateReturnValue<T>} The state of the Set and the controls.
- * @see {@link https://rooks.vercel.app/docs/useSetState}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useSetState}
  * @example
  * import { useSetState } from "@/hooks/useSetState";
  * const [set, setControls] = useSetState(new Set());

--- a/packages/rooks/src/hooks/useStackState.ts
+++ b/packages/rooks/src/hooks/useStackState.ts
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from "react";
  * @description Manages a stack with react hooks.
  * @param initialList Initial value of the list
  * @returns The list and controls to modify the stack
- * @see https://rooks.vercel.app/docs/useStackState
+ * @see https://rooks.vercel.app/docs/hooks/useStackState
  */
 function useStackState<T>(initialList: T[]): [
   T[],

--- a/packages/rooks/src/hooks/useSuspenseNavigatorUserAgentData.ts
+++ b/packages/rooks/src/hooks/useSuspenseNavigatorUserAgentData.ts
@@ -1,7 +1,7 @@
 /**
  * useSuspenseNavigatorUserAgentData
  * @description Suspense-enabled hook for getting high entropy values from Navigator User Agent Data API
- * @see {@link https://rooks.vercel.app/docs/useSuspenseNavigatorUserAgentData}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useSuspenseNavigatorUserAgentData}
  */
 
 // Type definitions for NavigatorUAData based on the spec

--- a/packages/rooks/src/hooks/useThrottle.ts
+++ b/packages/rooks/src/hooks/useThrottle.ts
@@ -11,7 +11,7 @@ type Callback<T> = (...args: T[]) => void;
  * @param callback The callback to throttle
  * @param timeout Throttle timeout
  * @returns [Callback, isReady] The throttled callback and if it is currently throttled
- * @see https://rooks.vercel.app/docs/useThrottle
+ * @see https://rooks.vercel.app/docs/hooks/useThrottle
  */
 function useThrottle<T>(
   callback: Callback<T>,

--- a/packages/rooks/src/hooks/useTimeTravelState.ts
+++ b/packages/rooks/src/hooks/useTimeTravelState.ts
@@ -65,7 +65,7 @@ type UseTimeTravelStateReturnValue<T> = [
 /**
  * useTimeTravelState
  * @description A hook that manages state which can undo and redo. A more powerful version of useUndoState hook.
- * @see {@link https://rooks.vercel.app/docs/useTimeTravelState}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useTimeTravelState}
  * @param initialValue The initial value of the state.
  * @returns {UseTimeTravelStateReturnValue}
  * @example

--- a/packages/rooks/src/hooks/useTimeoutWhen.ts
+++ b/packages/rooks/src/hooks/useTimeoutWhen.ts
@@ -9,7 +9,7 @@ import { useFreshCallback } from "./useFreshCallback";
  * @param callback The callback to be invoked after timeout
  * @param timeoutDelayMs Amount of time in ms after which to invoke
  * @param when The condition which when true, sets the timeout
- * @see https://rooks.vercel.app/docs/useTimeoutWhen
+ * @see https://rooks.vercel.app/docs/hooks/useTimeoutWhen
  */
 function useTimeoutWhen(
   callback: () => void,

--- a/packages/rooks/src/hooks/useUndoRedoState.ts
+++ b/packages/rooks/src/hooks/useUndoRedoState.ts
@@ -1,7 +1,7 @@
 /**
  * useUndoRedoState
  * @description Setstate but can also undo and redo
- * @see {@link https://rooks.vercel.app/docs/useUndoRedoState}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useUndoRedoState}
  */
 import {
   useState,

--- a/packages/rooks/src/hooks/useUndoState.ts
+++ b/packages/rooks/src/hooks/useUndoState.ts
@@ -18,7 +18,7 @@ const defaultOptions: UseUndoStateOptions = { maxSize: 100 };
  * @param {any} defaultValue - Default value to use for the state. This will be the first value in the undo stack.
  * @param {UseUndoStateOptions} options - Options for the undo state. Currently takes the maxSize option.
  * @returns {UseUndoStateReturnValue}
- * @see https://rooks.vercel.app/docs/useUndoState
+ * @see https://rooks.vercel.app/docs/hooks/useUndoState
  */
 const useUndoState = <T>(
   defaultValue: ExcludeFunction<T>,

--- a/packages/rooks/src/hooks/useVibrate.ts
+++ b/packages/rooks/src/hooks/useVibrate.ts
@@ -1,7 +1,7 @@
 /**
  * useVibrate
  * @description Vibration API hook for React
- * @see {@link https://rooks.vercel.app/docs/useVibrate}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useVibrate}
  */
 import { useEffect } from "react";
 

--- a/packages/rooks/src/hooks/useVideo.ts
+++ b/packages/rooks/src/hooks/useVideo.ts
@@ -1,7 +1,7 @@
 /**
  * useVideo
  * @description Video hook for react
- * @see {@link https://rooks.vercel.app/docs/useVideo}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useVideo}
  */
 import { useRef, useState, useEffect, RefObject } from "react";
 

--- a/packages/rooks/src/hooks/useWarningOnMountInDevelopment.ts
+++ b/packages/rooks/src/hooks/useWarningOnMountInDevelopment.ts
@@ -4,7 +4,7 @@ import { warning } from "./warning";
 /**
  * useWarningOnMountInDevelopment
  * @param message The message to be shown in the console
- * @see https://rooks.vercel.app/docs/useWarningOnMountInDevelopment
+ * @see https://rooks.vercel.app/docs/hooks/useWarningOnMountInDevelopment
  */
 function useWarningOnMountInDevelopment(message: string) {
   useDidMount(() => {

--- a/packages/rooks/src/hooks/useWebLocksApi.ts
+++ b/packages/rooks/src/hooks/useWebLocksApi.ts
@@ -88,7 +88,7 @@ type UseWebLocksApiReturn = {
 /**
  * useWebLocksApi
  * @description Hook for coordinating operations across tabs/workers with Web Locks API
- * @see {@link https://rooks.vercel.app/docs/useWebLocksApi}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useWebLocksApi}
  */
 function useWebLocksApi(
   resourceName: string,

--- a/packages/rooks/src/hooks/useWhyDidYouUpdate.ts
+++ b/packages/rooks/src/hooks/useWhyDidYouUpdate.ts
@@ -1,7 +1,7 @@
 /**
  * useWhyDidYouUpdate
  * @description A hook that can track which value change caused a rerender
- * @see {@link https://rooks.vercel.app/docs/useWhyDidYouUpdate}
+ * @see {@link https://rooks.vercel.app/docs/hooks/useWhyDidYouUpdate}
  */
 import { useEffect, useRef } from "react";
 import { useDidUpdate } from "./useDidUpdate";

--- a/packages/rooks/src/hooks/useWillUnmount.ts
+++ b/packages/rooks/src/hooks/useWillUnmount.ts
@@ -7,7 +7,7 @@ type Callback = () => void;
  * Fires a callback just before component unmounts
  *
  * @param {Function} callback Callback to be called before unmount
- * @see https://rooks.vercel.app/docs/useWillUnmount
+ * @see https://rooks.vercel.app/docs/hooks/useWillUnmount
  */
 function useWillUnmount(callback: Callback): void {
   // run only once

--- a/packages/rooks/src/hooks/useWindowEventListener.ts
+++ b/packages/rooks/src/hooks/useWindowEventListener.ts
@@ -11,7 +11,7 @@ import type { ListenerOptions } from "@/types/utils";
  * @param {ListenerOptions} listenerOptions The options to be passed to the event listener
  * @param {boolean} isLayoutEffect Should it use layout effect. Defaults to false
  * @returns {undefined}
- * @see https://rooks.vercel.app/docs/useWindowEventListener
+ * @see https://rooks.vercel.app/docs/hooks/useWindowEventListener
  */
 function useWindowEventListener(
   eventName: keyof WindowEventMap,

--- a/packages/rooks/src/hooks/useWindowScrollPosition.ts
+++ b/packages/rooks/src/hooks/useWindowScrollPosition.ts
@@ -27,7 +27,7 @@ function computeScrollPosition(): ScrollPosition {
  * A React hook to get the scroll position of the window
  *
  * @returns an object containing scrollX and scrollY values
- * @see https://rooks.vercel.app/docs/useWindowScrollPosition
+ * @see https://rooks.vercel.app/docs/hooks/useWindowScrollPosition
  */
 function useWindowScrollPosition(): ScrollPosition {
   const [scrollPosition, setScrollPosition] = useState<ScrollPosition>(

--- a/packages/rooks/src/hooks/useWindowSize.ts
+++ b/packages/rooks/src/hooks/useWindowSize.ts
@@ -27,7 +27,7 @@ function getDimensions(): WindowDimensions {
  * A hook that provides information of the dimensions of the window
  *
  * @returns Dimensions of the window
- * @see https://rooks.vercel.app/docs/useWindowSize
+ * @see https://rooks.vercel.app/docs/hooks/useWindowSize
  */
 export function useWindowSize(): WindowDimensions {
   const [windowSize, setWindowSize] = useState<WindowDimensions>(() => {

--- a/scripts/update-package-list-to-markdown/index.ts
+++ b/scripts/update-package-list-to-markdown/index.ts
@@ -141,7 +141,7 @@ class PackageListUpdater {
   }
 
   private createHookEntry(hook: Hook): string {
-    return `[${hook.name}](https://rooks.vercel.app/docs/${hook.name}) - ${hook.description}`;
+    return `[${hook.name}](https://rooks.vercel.app/docs/hooks/${hook.name}) - ${hook.description}`;
   }
 
   private createHooksListMDAST(hooks: Hook[]): RootContent {

--- a/template/shared.template
+++ b/template/shared.template
@@ -1,7 +1,7 @@
 /**
  * %name%
  * @description %description%
- * @see {@link https://rooks.vercel.app/docs/%name%}
+ * @see {@link https://rooks.vercel.app/docs/hooks/%name%}
 */
 function %name%() {
   return null;


### PR DESCRIPTION
Fix incorrect documentation links in README and codebase to include `/hooks/` path.

The previous link generation script and some manual links used `rooks.vercel.app/docs/hookName`, which was incorrect. The correct path is `rooks.vercel.app/docs/hooks/hookName`. This PR updates the script to generate correct links and fixes all existing incorrect links across documentation and source files.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a0e5d275-0c2f-40ae-bafa-c754f2b5c4a1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a0e5d275-0c2f-40ae-bafa-c754f2b5c4a1)