### PR TITLE
test: extend disposable hook coverage

### DIFF
--- a/data/docs/useAsyncDisposable.md
+++ b/data/docs/useAsyncDisposable.md
@@ -1,0 +1,235 @@
+---
+id: useAsyncDisposable
+title: useAsyncDisposable
+sidebar_label: useAsyncDisposable
+---
+
+## About
+
+Bridges TC39 [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) (`Symbol.asyncDispose`) with React component lifecycles.
+
+### The problem
+
+React's `useEffect` cleanup and the `await using` keyword solve the same problem — releasing a resource when it is no longer needed — but they live in separate worlds. `await using` ties disposal to a **block scope**; React components are not blocks, they **re-render** and can unmount at any time, including while an async factory is still running.
+
+Handling that correctly by hand requires a disposed-flag pattern:
+
+```tsx
+// Before — manual wiring with race condition guard
+useEffect(() => {
+  let disposed = false;
+  let db: MyDatabase | null = null;
+
+  openDatabase(userId).then((instance) => {
+    if (!disposed) {
+      db = instance;
+      setDb(instance);
+    } else {
+      instance[Symbol.asyncDispose]();
+    }
+  });
+
+  return () => {
+    disposed = true;
+    db?.[Symbol.asyncDispose]();
+    db = null;
+    setDb(null);
+  };
+}, [userId]);
+```
+
+`useAsyncDisposable` does all of that for you:
+
+```tsx
+// After — declarative
+const db = useAsyncDisposable(() => openDatabase(userId), [userId]);
+if (db === null) return <Spinner />;
+```
+
+> **When NOT to use this hook:** If the resource emits change events that should drive re-renders, reach for `useSyncExternalStore` instead. `useAsyncDisposable` is best for resources whose lifecycle matters but whose internal state is not reflected in the React tree.
+
+## Examples
+
+### IndexedDB connection
+
+```tsx
+import { useAsyncDisposable } from "rooks";
+
+class ManagedIDBConnection implements AsyncDisposable {
+  private db: IDBDatabase;
+
+  constructor(db: IDBDatabase) {
+    this.db = db;
+  }
+
+  transaction(stores: string[], mode: IDBTransactionMode) {
+    return this.db.transaction(stores, mode);
+  }
+
+  async [Symbol.asyncDispose]() {
+    this.db.close();
+  }
+}
+
+async function openManagedIDB(name: string): Promise<ManagedIDBConnection> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name, 1);
+    req.onsuccess = () => resolve(new ManagedIDBConnection(req.result));
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function UserStore({ userId }: { userId: string }) {
+  const db = useAsyncDisposable(
+    () => openManagedIDB(`user:${userId}`),
+    [userId]
+  );
+
+  if (db === null) return <p>Opening database…</p>;
+
+  return (
+    <button onClick={() => {
+      const tx = db.transaction(["items"], "readonly");
+      // ...
+    }}>
+      Read items
+    </button>
+  );
+}
+```
+
+### WebGPU device
+
+```tsx
+import { useAsyncDisposable } from "rooks";
+
+class ManagedGPUDevice implements AsyncDisposable {
+  constructor(
+    public readonly adapter: GPUAdapter,
+    public readonly device: GPUDevice
+  ) {}
+
+  async [Symbol.asyncDispose]() {
+    this.device.destroy();
+  }
+}
+
+async function requestGPUDevice(): Promise<ManagedGPUDevice> {
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) throw new Error("No GPU adapter");
+  const device = await adapter.requestDevice();
+  return new ManagedGPUDevice(adapter, device);
+}
+
+function Renderer() {
+  const gpu = useAsyncDisposable(() => requestGPUDevice(), []);
+
+  if (gpu === null) return <p>Initializing GPU…</p>;
+
+  return <canvas id="webgpu-canvas" />;
+}
+```
+
+### Scoped document lock with deps (Web Locks API)
+
+```tsx
+import { useAsyncDisposable } from "rooks";
+
+class ScopedLock implements AsyncDisposable {
+  private release?: () => void;
+  readonly acquired: boolean;
+
+  constructor(release: () => void) {
+    this.release = release;
+    this.acquired = true;
+  }
+
+  async [Symbol.asyncDispose]() {
+    this.release?.();
+    this.release = undefined;
+  }
+}
+
+async function acquireLock(name: string): Promise<ScopedLock> {
+  return new Promise((resolve) => {
+    navigator.locks.request(name, (lock) => {
+      return new Promise<void>((releaseLock) => {
+        resolve(new ScopedLock(releaseLock));
+      });
+    });
+  });
+}
+
+function DocumentEditor({ docId }: { docId: string }) {
+  // Lock changes with docId — old lock released, new one acquired
+  const lock = useAsyncDisposable(
+    () => acquireLock(`doc:${docId}`),
+    [docId]
+  );
+
+  if (lock === null) return <p>Acquiring lock…</p>;
+
+  return <textarea />;
+}
+```
+
+### Before vs after
+
+```tsx
+// ❌ Before — manual wiring, verbose and error-prone
+function Component({ userId }) {
+  const [db, setDb] = useState(null);
+
+  useEffect(() => {
+    let disposed = false;
+    let handle = null;
+
+    openDatabase(userId).then((instance) => {
+      if (!disposed) {
+        handle = instance;
+        setDb(instance);
+      } else {
+        instance[Symbol.asyncDispose]();
+      }
+    });
+
+    return () => {
+      disposed = true;
+      handle?.[Symbol.asyncDispose]();
+      handle = null;
+      setDb(null);
+    };
+  }, [userId]);
+
+  if (!db) return <Spinner />;
+  return <div>{db.version}</div>;
+}
+
+// ✅ After — useAsyncDisposable
+function Component({ userId }) {
+  const db = useAsyncDisposable(() => openDatabase(userId), [userId]);
+
+  if (db === null) return <Spinner />;
+  return <div>{db.version}</div>;
+}
+```
+
+## Arguments
+
+| Argument | Type                  | Description                                                                                        | Default value |
+| -------- | --------------------- | -------------------------------------------------------------------------------------------------- | ------------- |
+| factory  | `() => Promise<T>`    | Async function that creates and returns an `AsyncDisposable` resource                              | _required_    |
+| deps     | `DependencyList`      | Dependency array — when deps change, the old resource is disposed and the factory is called again  | `[]`          |
+
+## Return value
+
+| Return value | Type       | Description                                                           |
+| ------------ | ---------- | --------------------------------------------------------------------- |
+| resource     | `T \| null` | The disposable resource, or `null` while the factory is still resolving |
+
+## Notes
+
+- **Race conditions.** If the component unmounts (or deps change) while the factory promise is still pending, the arriving resource is disposed immediately and the component never receives it. This mirrors the `lastCallId` pattern used in `useAsyncEffect`.
+- **Two hooks, not one.** `useDisposable` and `useAsyncDisposable` are intentionally separate. The sync variant guarantees `T` (never null); merging the two would force every caller to handle `null`, even when the factory is synchronous.
+- **React Strict Mode.** The hook handles the mount → unmount → remount cycle correctly. In development, the factory is called twice; the first resource is disposed as part of Strict Mode's effect-idempotency check.
+- **Deps semantics** are identical to `useEffect` deps — use the same rules (primitive values, stable references).

--- a/data/docs/useDisposable.md
+++ b/data/docs/useDisposable.md
@@ -1,0 +1,174 @@
+---
+id: useDisposable
+title: useDisposable
+sidebar_label: useDisposable
+---
+
+## About
+
+Bridges TC39 [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) (`Symbol.dispose`) with React component lifecycles.
+
+### The problem
+
+React's `useEffect` cleanup and the `using` keyword solve the same underlying problem — disposing a resource when it is no longer needed — but they exist in separate worlds. A `using` declaration ties disposal to a **block scope**; React components are not blocks, they **re-render**. Wiring the two up manually looks like this:
+
+```tsx
+// Before — manual wiring
+useEffect(() => {
+  const ws = new MyWebSocket(url); // implements Symbol.dispose
+  return () => ws[Symbol.dispose]();
+}, [url]);
+```
+
+`useDisposable` does that wiring for you:
+
+```tsx
+// After — declarative
+const ws = useDisposable(() => new MyWebSocket(url), [url]);
+```
+
+Unlike `useAsyncDisposable`, this hook returns the resource **synchronously** (guaranteed non-null on every render) because the factory runs during the render phase.
+
+> **When NOT to use this hook:** If the resource emits change events that should drive re-renders, reach for `useSyncExternalStore` instead. `useDisposable` is best for resources whose lifecycle matters but whose internal state is not reflected in the React tree.
+
+## Examples
+
+### WebSocket wrapper
+
+```tsx
+import { useDisposable } from "rooks";
+
+class ManagedWebSocket implements Disposable {
+  private socket: WebSocket;
+
+  constructor(url: string) {
+    this.socket = new WebSocket(url);
+  }
+
+  send(data: string) {
+    this.socket.send(data);
+  }
+
+  [Symbol.dispose]() {
+    this.socket.close();
+  }
+}
+
+function Chat({ roomUrl }: { roomUrl: string }) {
+  const ws = useDisposable(
+    () => new ManagedWebSocket(roomUrl),
+    [roomUrl] // closes old socket and opens new one when roomUrl changes
+  );
+
+  return (
+    <button onClick={() => ws.send("hello")}>Send</button>
+  );
+}
+```
+
+### Event emitter with automatic listener cleanup
+
+```tsx
+import { useDisposable } from "rooks";
+import { EventEmitter } from "events";
+
+class ScopedEmitter implements Disposable {
+  private emitter: EventEmitter;
+  private listeners: Array<[string, (...args: unknown[]) => void]> = [];
+
+  constructor(emitter: EventEmitter) {
+    this.emitter = emitter;
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    this.emitter.on(event, handler);
+    this.listeners.push([event, handler]);
+  }
+
+  [Symbol.dispose]() {
+    for (const [event, handler] of this.listeners) {
+      this.emitter.off(event, handler);
+    }
+  }
+}
+
+function Dashboard({ emitter }: { emitter: EventEmitter }) {
+  const scope = useDisposable(() => new ScopedEmitter(emitter), [emitter]);
+
+  scope.on("data", (payload) => {
+    console.log("received", payload);
+  });
+
+  return <div>Listening…</div>;
+}
+```
+
+### Managed lock (Web Locks API)
+
+```tsx
+import { useDisposable } from "rooks";
+
+class ManagedLock implements Disposable {
+  private release?: () => void;
+
+  constructor(private name: string) {
+    navigator.locks.request(name, (lock) => {
+      return new Promise<void>((resolve) => {
+        this.release = resolve;
+      });
+    });
+  }
+
+  [Symbol.dispose]() {
+    this.release?.();
+  }
+}
+
+function ExclusiveEditor({ docId }: { docId: string }) {
+  const _lock = useDisposable(
+    () => new ManagedLock(`doc:${docId}`),
+    [docId]
+  );
+
+  return <textarea />;
+}
+```
+
+### Before vs after
+
+```tsx
+// ❌ Before — manual useEffect cleanup
+function Component({ id }) {
+  useEffect(() => {
+    const conn = openConnection(id);
+    return () => conn[Symbol.dispose]();
+  }, [id]);
+  // conn not accessible outside the effect
+}
+
+// ✅ After — useDisposable
+function Component({ id }) {
+  const conn = useDisposable(() => openConnection(id), [id]);
+  // conn is available in render and event handlers
+  return <button onClick={() => conn.query("SELECT 1")}>Run</button>;
+}
+```
+
+## Arguments
+
+| Argument  | Type                        | Description                                                                                        | Default value |
+| --------- | --------------------------- | -------------------------------------------------------------------------------------------------- | ------------- |
+| factory   | `() => T`                   | Function that synchronously creates and returns a `Disposable` resource                            | _required_    |
+| deps      | `DependencyList`            | Dependency array — when deps change, the old resource is disposed and the factory is called again  | `[]`          |
+
+## Return value
+
+| Return value | Type | Description                                                                |
+| ------------ | ---- | -------------------------------------------------------------------------- |
+| resource     | `T`  | The disposable resource — always non-null, available synchronously         |
+
+## Notes
+
+- **Two hooks, not one.** `useDisposable` and `useAsyncDisposable` are intentionally separate. Making one hook that handles both cases would force the sync path to return `T | null`, punishing the common synchronous case with an unnecessary null check.
+- **React Strict Mode.** The hook handles the mount → unmount → remount cycle correctly. In development Strict Mode, the factory is called twice (once per mount); the first resource is disposed as part of Strict Mode's effect-idempotency check.
+- **Deps semantics** are identical to `useEffect` deps — use the same rules (primitive values, stable references).

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -11,6 +11,11 @@
       "category": "state"
     },
     {
+      "name": "useAsyncDisposable",
+      "description": "Bridges TC39 Explicit Resource Management (Symbol.asyncDispose) with React lifecycles — creates an async disposable resource and disposes it on unmount or deps change",
+      "category": "lifecycle"
+    },
+    {
       "name": "useAsyncEffect",
       "description": "A version of useEffect that accepts an async function",
       "category": "lifecycle"
@@ -88,6 +93,11 @@
     {
       "name": "useDidMount",
       "description": "componentDidMount hook for React",
+      "category": "lifecycle"
+    },
+    {
+      "name": "useDisposable",
+      "description": "Bridges TC39 Explicit Resource Management (Symbol.dispose) with React lifecycles — creates a synchronous disposable resource (guaranteed non-null) and disposes it on unmount or deps change",
       "category": "lifecycle"
     },
     {

--- a/packages/rooks/src/__tests__/useAsyncDisposable.spec.ts
+++ b/packages/rooks/src/__tests__/useAsyncDisposable.spec.ts
@@ -1,0 +1,261 @@
+import { renderHook, act } from "@testing-library/react";
+import { StrictMode } from "react";
+import { vi } from "vitest";
+import { useAsyncDisposable } from "@/hooks/useAsyncDisposable";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAsyncResource() {
+  const asyncDispose = vi.fn().mockResolvedValue(undefined);
+  const resource: AsyncDisposable & { asyncDispose: typeof asyncDispose } = {
+    [Symbol.asyncDispose]: asyncDispose,
+    asyncDispose,
+  };
+  return resource;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useAsyncDisposable", () => {
+  it("is defined", () => {
+    expect.hasAssertions();
+    expect(useAsyncDisposable).toBeDefined();
+  });
+
+  it("returns null before the factory resolves", async () => {
+    expect.hasAssertions();
+    const deferred = createDeferred<ReturnType<typeof makeAsyncResource>>();
+
+    const { result } = renderHook(() =>
+      useAsyncDisposable(() => deferred.promise)
+    );
+
+    expect(result.current).toBeNull();
+
+    // resolve the factory
+    const resource = makeAsyncResource();
+    await act(async () => {
+      deferred.resolve(resource);
+    });
+
+    expect(result.current).toBe(resource);
+  });
+
+  it("returns the resource after the factory resolves", async () => {
+    expect.hasAssertions();
+    const resource = makeAsyncResource();
+
+    const { result } = renderHook(() =>
+      useAsyncDisposable(() => Promise.resolve(resource))
+    );
+
+    await act(async () => {});
+
+    expect(result.current).toBe(resource);
+  });
+
+  it("disposes the resource when the component unmounts", async () => {
+    expect.hasAssertions();
+    const resource = makeAsyncResource();
+
+    const { unmount } = renderHook(() =>
+      useAsyncDisposable(() => Promise.resolve(resource))
+    );
+
+    await act(async () => {});
+
+    expect(resource.asyncDispose).not.toHaveBeenCalled();
+    unmount();
+    expect(resource.asyncDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes old resource and creates new one when deps change", async () => {
+    expect.hasAssertions();
+    let callCount = 0;
+    const resources = [makeAsyncResource(), makeAsyncResource()];
+    const factory = vi.fn(() => {
+      const r = resources[callCount];
+      callCount += 1;
+      return Promise.resolve(r!);
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dep }: { dep: number }) => useAsyncDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    await act(async () => {});
+    expect(result.current).toBe(resources[0]);
+
+    rerender({ dep: 2 });
+    // state is reset to null immediately by the cleanup
+    expect(result.current).toBeNull();
+
+    await act(async () => {});
+
+    expect(resources[0]!.asyncDispose).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(resources[1]);
+    expect(resources[1]!.asyncDispose).not.toHaveBeenCalled();
+  });
+
+  it("returns null between a deps change and the new factory resolving", async () => {
+    expect.hasAssertions();
+    const deferred1 = createDeferred<ReturnType<typeof makeAsyncResource>>();
+    const deferred2 = createDeferred<ReturnType<typeof makeAsyncResource>>();
+    let callCount = 0;
+    const deferreds = [deferred1, deferred2];
+    const factory = vi.fn(() => {
+      const d = deferreds[callCount];
+      callCount += 1;
+      return d!.promise;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dep }: { dep: number }) => useAsyncDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    // Resolve first factory
+    const resource1 = makeAsyncResource();
+    await act(async () => {
+      deferred1.resolve(resource1);
+    });
+    expect(result.current).toBe(resource1);
+
+    // Change deps — cleanup resets to null immediately
+    rerender({ dep: 2 });
+    expect(result.current).toBeNull();
+
+    // Second factory still pending — still null
+    expect(result.current).toBeNull();
+
+    // Resolve second factory
+    const resource2 = makeAsyncResource();
+    await act(async () => {
+      deferred2.resolve(resource2);
+    });
+    expect(result.current).toBe(resource2);
+  });
+
+  it("race condition: disposes resource immediately if component unmounts while factory is resolving", async () => {
+    expect.hasAssertions();
+    const deferred = createDeferred<ReturnType<typeof makeAsyncResource>>();
+
+    const { result, unmount } = renderHook(() =>
+      useAsyncDisposable(() => deferred.promise)
+    );
+
+    // Factory still pending
+    expect(result.current).toBeNull();
+
+    // Unmount before factory resolves
+    unmount();
+
+    // Now factory resolves — resource should be disposed immediately
+    const resource = makeAsyncResource();
+    await act(async () => {
+      deferred.resolve(resource);
+    });
+
+    // Component never received the resource
+    expect(result.current).toBeNull();
+    // Resource was disposed immediately
+    expect(resource.asyncDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("race condition: disposes stale resource if deps change while factory is resolving", async () => {
+    expect.hasAssertions();
+    const deferred1 = createDeferred<ReturnType<typeof makeAsyncResource>>();
+    const deferred2 = createDeferred<ReturnType<typeof makeAsyncResource>>();
+    let callCount = 0;
+    const deferreds = [deferred1, deferred2];
+    const factory = vi.fn(() => {
+      const d = deferreds[callCount];
+      callCount += 1;
+      return d!.promise;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dep }: { dep: number }) => useAsyncDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    // Deps change before first factory resolves
+    rerender({ dep: 2 });
+
+    // First factory resolves — should be disposed, component should not see it
+    const resource1 = makeAsyncResource();
+    await act(async () => {
+      deferred1.resolve(resource1);
+    });
+    expect(resource1.asyncDispose).toHaveBeenCalledTimes(1);
+    expect(result.current).toBeNull();
+
+    // Second factory resolves — component should see this one
+    const resource2 = makeAsyncResource();
+    await act(async () => {
+      deferred2.resolve(resource2);
+    });
+    expect(result.current).toBe(resource2);
+    expect(resource2.asyncDispose).not.toHaveBeenCalled();
+  });
+
+  it("handles React Strict Mode: disposes Strict Mode resource and keeps live resource", async () => {
+    expect.hasAssertions();
+    const createdResources: ReturnType<typeof makeAsyncResource>[] = [];
+    const factory = vi.fn(() => {
+      const r = makeAsyncResource();
+      createdResources.push(r);
+      return Promise.resolve(r);
+    });
+
+    const { result, unmount } = renderHook(() => useAsyncDisposable(factory), {
+      wrapper: StrictMode,
+    });
+
+    await act(async () => {});
+
+    // factory called twice: once per mount in Strict Mode
+    expect(factory).toHaveBeenCalledTimes(2);
+
+    // First resource was disposed by the Strict Mode cleanup
+    expect(createdResources[0]!.asyncDispose).toHaveBeenCalledTimes(1);
+
+    // Second resource is the live one
+    expect(createdResources[1]!.asyncDispose).not.toHaveBeenCalled();
+    expect(result.current).toBe(createdResources[1]);
+
+    unmount();
+    expect(createdResources[1]!.asyncDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("with empty deps, factory is only called once", async () => {
+    expect.hasAssertions();
+    const resource = makeAsyncResource();
+    const factory = vi.fn(() => Promise.resolve(resource));
+
+    const { rerender } = renderHook(() =>
+      useAsyncDisposable(factory, [])
+    );
+
+    await act(async () => {});
+    rerender();
+    rerender();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/rooks/src/__tests__/useAsyncDisposable.spec.ts
+++ b/packages/rooks/src/__tests__/useAsyncDisposable.spec.ts
@@ -7,8 +7,10 @@ import { useAsyncDisposable } from "@/hooks/useAsyncDisposable";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeAsyncResource() {
-  const asyncDispose = vi.fn().mockResolvedValue(undefined);
+function makeAsyncResource(asyncDisposeImpl?: () => Promise<void>) {
+  const asyncDispose = vi.fn(
+    asyncDisposeImpl ?? (() => Promise.resolve(undefined))
+  );
   const resource: AsyncDisposable & { asyncDispose: typeof asyncDispose } = {
     [Symbol.asyncDispose]: asyncDispose,
     asyncDispose,
@@ -68,6 +70,19 @@ describe("useAsyncDisposable", () => {
     expect(result.current).toBe(resource);
   });
 
+  it("stays null when the factory rejects", async () => {
+    expect.hasAssertions();
+    const error = new Error("factory failed");
+    const factory = vi.fn(() => Promise.reject(error));
+
+    const { result } = renderHook(() => useAsyncDisposable(factory));
+
+    await act(async () => {});
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result.current).toBeNull();
+  });
+
   it("disposes the resource when the component unmounts", async () => {
     expect.hasAssertions();
     const resource = makeAsyncResource();
@@ -80,6 +95,23 @@ describe("useAsyncDisposable", () => {
 
     expect(resource.asyncDispose).not.toHaveBeenCalled();
     unmount();
+    expect(resource.asyncDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows asyncDispose rejections during cleanup", async () => {
+    expect.hasAssertions();
+    const resource = makeAsyncResource(() =>
+      Promise.reject(new Error("async dispose failed"))
+    );
+
+    const { unmount } = renderHook(() =>
+      useAsyncDisposable(() => Promise.resolve(resource))
+    );
+
+    await act(async () => {});
+
+    expect(resource.asyncDispose).not.toHaveBeenCalled();
+    expect(() => unmount()).not.toThrow();
     expect(resource.asyncDispose).toHaveBeenCalledTimes(1);
   });
 
@@ -110,6 +142,88 @@ describe("useAsyncDisposable", () => {
     expect(resources[0]!.asyncDispose).toHaveBeenCalledTimes(1);
     expect(result.current).toBe(resources[1]);
     expect(resources[1]!.asyncDispose).not.toHaveBeenCalled();
+  });
+
+  it("keeps only the latest resource after three rapid dep changes with out-of-order resolution", async () => {
+    expect.hasAssertions();
+    const deferreds = [
+      createDeferred<ReturnType<typeof makeAsyncResource>>(),
+      createDeferred<ReturnType<typeof makeAsyncResource>>(),
+      createDeferred<ReturnType<typeof makeAsyncResource>>(),
+      createDeferred<ReturnType<typeof makeAsyncResource>>(),
+    ];
+    const resources = deferreds.map(() => makeAsyncResource());
+    let callCount = 0;
+    const factory = vi.fn(() => {
+      const deferred = deferreds[callCount];
+      callCount += 1;
+      return deferred!.promise;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dep }: { dep: number }) => useAsyncDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    rerender({ dep: 2 });
+    rerender({ dep: 3 });
+    rerender({ dep: 4 });
+
+    expect(result.current).toBeNull();
+
+    await act(async () => {
+      deferreds[3]!.resolve(resources[3]!);
+    });
+    expect(result.current).toBe(resources[3]);
+
+    await act(async () => {
+      deferreds[1]!.resolve(resources[1]!);
+      deferreds[0]!.resolve(resources[0]!);
+      deferreds[2]!.resolve(resources[2]!);
+    });
+
+    expect(result.current).toBe(resources[3]);
+    expect(resources[0]!.asyncDispose).toHaveBeenCalledTimes(1);
+    expect(resources[1]!.asyncDispose).toHaveBeenCalledTimes(1);
+    expect(resources[2]!.asyncDispose).toHaveBeenCalledTimes(1);
+    expect(resources[3]!.asyncDispose).not.toHaveBeenCalled();
+    expect(callCount).toBe(4);
+  });
+
+  it("does not let a stale async result overwrite a newer resolved resource", async () => {
+    expect.hasAssertions();
+    const deferred1 = createDeferred<ReturnType<typeof makeAsyncResource>>();
+    const deferred2 = createDeferred<ReturnType<typeof makeAsyncResource>>();
+    const resource1 = makeAsyncResource();
+    const resource2 = makeAsyncResource();
+    let callCount = 0;
+    const deferreds = [deferred1, deferred2];
+    const factory = vi.fn(() => {
+      const deferred = deferreds[callCount];
+      callCount += 1;
+      return deferred!.promise;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dep }: { dep: number }) => useAsyncDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    rerender({ dep: 2 });
+
+    await act(async () => {
+      deferred2.resolve(resource2);
+    });
+
+    expect(result.current).toBe(resource2);
+
+    await act(async () => {
+      deferred1.resolve(resource1);
+    });
+
+    expect(result.current).toBe(resource2);
+    expect(resource1.asyncDispose).toHaveBeenCalledTimes(1);
+    expect(resource2.asyncDispose).not.toHaveBeenCalled();
   });
 
   it("returns null between a deps change and the new factory resolving", async () => {

--- a/packages/rooks/src/__tests__/useDisposable.spec.ts
+++ b/packages/rooks/src/__tests__/useDisposable.spec.ts
@@ -7,8 +7,8 @@ import { useDisposable } from "@/hooks/useDisposable";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeResource() {
-  const dispose = vi.fn();
+function makeResource(disposeImpl?: () => void) {
+  const dispose = vi.fn(disposeImpl ?? (() => undefined));
   const resource: Disposable & { dispose: typeof dispose } = {
     [Symbol.dispose]: dispose,
     dispose,
@@ -64,15 +64,18 @@ describe("useDisposable", () => {
     const resource = makeResource();
     const factory = vi.fn(() => resource);
 
-    const { rerender } = renderHook(() => useDisposable(factory));
+    const { result, rerender } = renderHook(() => useDisposable(factory));
+
+    expect(result.current).toBe(resource);
     rerender();
     rerender();
 
     expect(factory).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(resource);
     expect(resource.dispose).not.toHaveBeenCalled();
   });
 
-  it("disposes the old resource and creates a new one when deps change", async () => {
+  it("keeps the previous resource alive until a dep change recreates it exactly once", async () => {
     expect.hasAssertions();
     let callCount = 0;
     const resources = [makeResource(), makeResource()];
@@ -89,6 +92,7 @@ describe("useDisposable", () => {
 
     expect(result.current).toBe(resources[0]);
 
+    const previousResource = result.current;
     rerender({ dep: 2 });
 
     // After the deps change the old resource should have been disposed and the
@@ -99,8 +103,71 @@ describe("useDisposable", () => {
     });
 
     expect(resources[0]!.dispose).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
     expect(result.current).toBe(resources[1]);
+    expect(result.current).not.toBe(previousResource);
+    expect(resources[0]!.dispose).toHaveBeenCalledTimes(1);
     expect(resources[1]!.dispose).not.toHaveBeenCalled();
+  });
+
+  it("throws when the factory fails on the initial render", () => {
+    expect.hasAssertions();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("factory failed");
+    const factory = vi.fn(() => {
+      throw error;
+    });
+
+    try {
+      expect(() => renderHook(() => useDisposable(factory))).toThrow(error);
+      expect(factory).toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("throws when the factory fails during dep-driven recreation", () => {
+    expect.hasAssertions();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const firstResource = makeResource();
+    const error = new Error("recreation failed");
+    const factory = vi
+      .fn()
+      .mockReturnValueOnce(firstResource)
+      .mockImplementationOnce(() => {
+        throw error;
+      });
+
+    const { rerender } = renderHook(
+      ({ dep }: { dep: number }) => useDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    try {
+      expect(firstResource.dispose).not.toHaveBeenCalled();
+      expect(() => rerender({ dep: 2 })).toThrow(error);
+      expect(firstResource.dispose).toHaveBeenCalledTimes(1);
+      expect(factory).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("throws when Symbol.dispose throws during cleanup", () => {
+    expect.hasAssertions();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("dispose failed");
+    const resource = makeResource(() => {
+      throw error;
+    });
+
+    const { unmount } = renderHook(() => useDisposable(() => resource));
+
+    try {
+      expect(() => unmount()).toThrow(error);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("disposes the final resource on unmount after a deps change", async () => {

--- a/packages/rooks/src/__tests__/useDisposable.spec.ts
+++ b/packages/rooks/src/__tests__/useDisposable.spec.ts
@@ -1,0 +1,201 @@
+import { renderHook, act } from "@testing-library/react";
+import { StrictMode } from "react";
+import { vi } from "vitest";
+import { useDisposable } from "@/hooks/useDisposable";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResource() {
+  const dispose = vi.fn();
+  const resource: Disposable & { dispose: typeof dispose } = {
+    [Symbol.dispose]: dispose,
+    dispose,
+  };
+  return resource;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDisposable", () => {
+  it("is defined", () => {
+    expect.hasAssertions();
+    expect(useDisposable).toBeDefined();
+  });
+
+  it("creates the resource synchronously so it is available on first render", () => {
+    expect.hasAssertions();
+    const resource = makeResource();
+    const factory = vi.fn(() => resource);
+
+    const { result } = renderHook(() => useDisposable(factory));
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(resource);
+  });
+
+  it("disposes the resource when the component unmounts", () => {
+    expect.hasAssertions();
+    const resource = makeResource();
+
+    const { unmount } = renderHook(() => useDisposable(() => resource));
+
+    expect(resource.dispose).not.toHaveBeenCalled();
+    unmount();
+    expect(resource.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call dispose before unmount", () => {
+    expect.hasAssertions();
+    const resource = makeResource();
+
+    const { rerender } = renderHook(() => useDisposable(() => resource));
+
+    rerender();
+    rerender();
+    expect(resource.dispose).not.toHaveBeenCalled();
+  });
+
+  it("does not recreate the resource on unrelated rerenders", () => {
+    expect.hasAssertions();
+    const resource = makeResource();
+    const factory = vi.fn(() => resource);
+
+    const { rerender } = renderHook(() => useDisposable(factory));
+    rerender();
+    rerender();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(resource.dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes the old resource and creates a new one when deps change", async () => {
+    expect.hasAssertions();
+    let callCount = 0;
+    const resources = [makeResource(), makeResource()];
+    const factory = vi.fn(() => {
+      const r = resources[callCount];
+      callCount += 1;
+      return r!;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dep }: { dep: number }) => useDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    expect(result.current).toBe(resources[0]);
+
+    rerender({ dep: 2 });
+
+    // After the deps change the old resource should have been disposed and the
+    // component should have received the new resource (the hook schedules a
+    // forceUpdate after recreating in the effect).
+    await act(async () => {
+      // flush the forceUpdate microtask
+    });
+
+    expect(resources[0]!.dispose).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(resources[1]);
+    expect(resources[1]!.dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes the final resource on unmount after a deps change", async () => {
+    expect.hasAssertions();
+    let callCount = 0;
+    const resources = [makeResource(), makeResource()];
+    const factory = vi.fn(() => {
+      const r = resources[callCount];
+      callCount += 1;
+      return r!;
+    });
+
+    const { rerender, unmount } = renderHook(
+      ({ dep }: { dep: number }) => useDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    rerender({ dep: 2 });
+
+    await act(async () => {});
+
+    unmount();
+
+    expect(resources[0]!.dispose).toHaveBeenCalledTimes(1);
+    expect(resources[1]!.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispose new resource on a dep change that was not yet reflected", () => {
+    expect.hasAssertions();
+    const resources = [makeResource(), makeResource()];
+    let callCount = 0;
+    const factory = vi.fn(() => {
+      const r = resources[callCount];
+      callCount += 1;
+      return r!;
+    });
+
+    const { rerender } = renderHook(
+      ({ dep }: { dep: number }) => useDisposable(factory, [dep]),
+      { initialProps: { dep: 1 } }
+    );
+
+    rerender({ dep: 2 });
+
+    // resources[1] should not have been disposed yet
+    expect(resources[1]!.dispose).not.toHaveBeenCalled();
+  });
+
+  it("handles React Strict Mode: disposes Strict Mode resource and keeps live resource", async () => {
+    expect.hasAssertions();
+    const createdResources: ReturnType<typeof makeResource>[] = [];
+    const factory = vi.fn(() => {
+      const r = makeResource();
+      createdResources.push(r);
+      return r;
+    });
+
+    const { result, unmount } = renderHook(() => useDisposable(factory), {
+      wrapper: StrictMode,
+    });
+
+    // Wait for effects + forceUpdate flush
+    await act(async () => {});
+
+    // factory is called twice: once on the initial render and once on the
+    // Strict Mode remount render (after cleanup nulls the ref).
+    expect(factory).toHaveBeenCalledTimes(2);
+
+    // The first resource was disposed by the Strict Mode cleanup.
+    expect(createdResources[0]!.dispose).toHaveBeenCalledTimes(1);
+
+    // The second resource is the live one — not yet disposed.
+    expect(createdResources[1]!.dispose).not.toHaveBeenCalled();
+
+    // The hook returns the live resource.
+    expect(result.current).toBe(createdResources[1]);
+
+    unmount();
+    expect(createdResources[1]!.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("with empty deps, only disposes on unmount (not on rerenders)", () => {
+    expect.hasAssertions();
+    const resource = makeResource();
+    const factory = vi.fn(() => resource);
+
+    const { rerender, unmount } = renderHook(() =>
+      useDisposable(factory, [])
+    );
+
+    rerender();
+    rerender();
+    expect(resource.dispose).not.toHaveBeenCalled();
+
+    unmount();
+    expect(resource.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/rooks/src/hooks/useAsyncDisposable.ts
+++ b/packages/rooks/src/hooks/useAsyncDisposable.ts
@@ -48,16 +48,26 @@ function useAsyncDisposable<T extends AsyncDisposable>(
     // discarded rather than handed to the component.
     let disposed = false;
 
-    factory().then((newResource) => {
-      if (disposed) {
-        // Cleanup already ran — dispose immediately; the component never sees
-        // this resource.
-        void newResource[Symbol.asyncDispose]();
-      } else {
-        resourceRef.current = newResource;
-        setResource(newResource);
-      }
-    });
+    const disposeAsyncResource = (asyncResource: T) => {
+      void asyncResource[Symbol.asyncDispose]().catch(() => {});
+    };
+
+    factory()
+      .then((newResource) => {
+        if (disposed) {
+          // Cleanup already ran — dispose immediately; the component never sees
+          // this resource.
+          disposeAsyncResource(newResource);
+        } else {
+          resourceRef.current = newResource;
+          setResource(newResource);
+        }
+      })
+      .catch(() => {
+        // Rejected factories leave the hook in the loading state. The hook does
+        // not expose an error channel, so we intentionally swallow the rejection
+        // to avoid unhandled promise noise.
+      });
 
     return () => {
       disposed = true;
@@ -67,7 +77,7 @@ function useAsyncDisposable<T extends AsyncDisposable>(
       resourceRef.current = null;
       setResource(null);
       if (toDispose !== null) {
-        void toDispose[Symbol.asyncDispose]();
+        disposeAsyncResource(toDispose);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/rooks/src/hooks/useAsyncDisposable.ts
+++ b/packages/rooks/src/hooks/useAsyncDisposable.ts
@@ -1,0 +1,79 @@
+import { type DependencyList, useEffect, useRef, useState } from "react";
+
+/**
+ * useAsyncDisposable hook
+ *
+ * Bridges TC39 Explicit Resource Management (`Symbol.asyncDispose`) with React
+ * component lifecycles. Asynchronously creates a disposable resource and calls
+ * `resource[Symbol.asyncDispose]()` when the component unmounts or when the
+ * dependency array changes.
+ *
+ * Returns `null` until the factory promise resolves. Race conditions are handled
+ * via a `disposed` flag (similar to the `lastCallId` pattern in `useAsyncEffect`):
+ * if the component unmounts (or deps change) while the factory is still resolving,
+ * the arriving resource is disposed immediately and the component never receives it.
+ *
+ * Note: if the resource also emits change events that should drive re-renders,
+ * prefer `useSyncExternalStore` instead.
+ *
+ * @param {() => Promise<T>} factory Async function that creates and returns the
+ *   disposable resource
+ * @param {DependencyList} deps Dependency array — when deps change the old resource
+ *   is disposed and a new one is created (same semantics as `useEffect` deps)
+ * @returns {T | null} The disposable resource, or `null` while the factory is
+ *   still resolving
+ * @see https://rooks.vercel.app/docs/hooks/useAsyncDisposable
+ * @example
+ * ```tsx
+ * const db = useAsyncDisposable(
+ *   () => openManagedDatabase("mydb"),
+ *   [userId]
+ * );
+ * if (db === null) return <Spinner />;
+ * ```
+ */
+function useAsyncDisposable<T extends AsyncDisposable>(
+  factory: () => Promise<T>,
+  deps: DependencyList = []
+): T | null {
+  const [resource, setResource] = useState<T | null>(null);
+  // Ref allows the cleanup function to synchronously read and clear the latest
+  // resource without stale-closure issues.
+  const resourceRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    // `disposed` mirrors the `lastCallId` pattern from useAsyncEffect.
+    // When the cleanup runs (unmount or deps change) it sets disposed=true.
+    // If the factory resolves after that point the arriving resource is
+    // discarded rather than handed to the component.
+    let disposed = false;
+
+    factory().then((newResource) => {
+      if (disposed) {
+        // Cleanup already ran — dispose immediately; the component never sees
+        // this resource.
+        void newResource[Symbol.asyncDispose]();
+      } else {
+        resourceRef.current = newResource;
+        setResource(newResource);
+      }
+    });
+
+    return () => {
+      disposed = true;
+      const toDispose = resourceRef.current;
+      // Null out the ref and state synchronously so the component immediately
+      // shows null (loading state) while the next resource is being created.
+      resourceRef.current = null;
+      setResource(null);
+      if (toDispose !== null) {
+        void toDispose[Symbol.asyncDispose]();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return resource;
+}
+
+export { useAsyncDisposable };

--- a/packages/rooks/src/hooks/useDisposable.ts
+++ b/packages/rooks/src/hooks/useDisposable.ts
@@ -1,0 +1,70 @@
+import { type DependencyList, useEffect, useRef, useState } from "react";
+
+/**
+ * useDisposable hook
+ *
+ * Bridges TC39 Explicit Resource Management (`Symbol.dispose`) with React component
+ * lifecycles. Creates a disposable resource synchronously so it is available on the
+ * very first render, and calls `resource[Symbol.dispose]()` when the component
+ * unmounts or when the dependency array changes.
+ *
+ * Use this hook when a resource is cheap to create synchronously and its lifecycle
+ * should mirror a React component or a specific set of props/state values.
+ *
+ * Note: if the resource also emits change events that should drive re-renders,
+ * prefer `useSyncExternalStore` instead.
+ *
+ * @param {() => T} factory Function that creates and returns the disposable resource
+ * @param {DependencyList} deps Dependency array — when deps change the old resource is
+ *   disposed and a new one is created (same semantics as `useEffect` deps)
+ * @returns {T} The disposable resource — guaranteed non-null on every render
+ * @see https://rooks.vercel.app/docs/hooks/useDisposable
+ * @example
+ * ```tsx
+ * const ws = useDisposable(
+ *   () => createManagedWebSocket(url),
+ *   [url]
+ * );
+ * ws.send("hello");
+ * ```
+ */
+function useDisposable<T extends Disposable>(
+  factory: () => T,
+  deps: DependencyList = []
+): T {
+  const resourceRef = useRef<T | null>(null);
+  // Used to trigger a re-render after the effect creates a new resource on
+  // a deps change (cleanup nulls the ref; effect recreates and schedules a
+  // re-render so the component receives the fresh resource).
+  const [, forceUpdate] = useState(0);
+
+  // Create the resource synchronously so it is available on the first render.
+  // This same check also handles the React Strict Mode remount cycle: the effect
+  // cleanup nulls the ref, and the subsequent remount render recreates it here
+  // before any effects fire.
+  if (resourceRef.current === null) {
+    resourceRef.current = factory();
+  }
+
+  useEffect(() => {
+    // When deps change, the cleanup of the previous effect runs first and nulls
+    // the ref. There is no intermediate render, so we recreate here and schedule
+    // a re-render via forceUpdate so the component receives the new resource.
+    if (resourceRef.current === null) {
+      resourceRef.current = factory();
+      forceUpdate((n) => n + 1);
+    }
+
+    return () => {
+      if (resourceRef.current !== null) {
+        resourceRef.current[Symbol.dispose]();
+        resourceRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return resourceRef.current;
+}
+
+export { useDisposable };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -4,6 +4,7 @@ import { useMapState } from "./hooks/useMapState";
 
 export { useAnimation } from "./hooks/useAnimation";
 export { useArrayState } from "./hooks/useArrayState";
+export { useAsyncDisposable } from "./hooks/useAsyncDisposable";
 export { useAsyncEffect } from "./hooks/useAsyncEffect";
 export { useAudio } from "./hooks/useAudio";
 export { useBoundingclientrect } from "./hooks/useBoundingclientrect";
@@ -20,6 +21,7 @@ export { useDebouncedEffect } from "./hooks/useDebouncedEffect";
 export { useDebouncedValue } from "./hooks/useDebouncedValue";
 export { useDeepCompareEffect } from "./hooks/useDeepCompareEffect";
 export { useDidMount } from "./hooks/useDidMount";
+export { useDisposable } from "./hooks/useDisposable";
 export { useDidUpdate } from "./hooks/useDidUpdate";
 export { useDimensionsRef } from "./hooks/useDimensionsRef";
 export { useDocumentEventListener } from "./hooks/useDocumentEventListener";

--- a/packages/rooks/tsconfig.json
+++ b/packages/rooks/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "lib": ["es2022", "DOM", "DOM.Iterable", "ESNext.Disposable"],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- Added missing edge-case coverage for the disposable hooks from PR #1909
- Defined behavior for factory failures, cleanup throws, async factory rejection, async disposer rejection, and async race ordering

## Verification
- node /home/user/rooks/node_modules/.pnpm/vitest@4.1.0_@types+node@25.5.0_jsdom@29.0.0_vite@8.0.0_@types+node@25.5.0_esbuild@0.27_680eaccc4ba1d431b91ed2908e300b30/node_modules/vitest/vitest.mjs run -c vitest.config.ts src/__tests__/useDisposable.spec.ts
- node /home/user/rooks/node_modules/.pnpm/vitest@4.1.0_@types+node@25.5.0_jsdom@29.0.0_vite@8.0.0_@types+node@25.5.0_esbuild@0.27_680eaccc4ba1d431b91ed2908e300b30/node_modules/vitest/vitest.mjs run -c vitest.config.ts src/__tests__/useAsyncDisposable.spec.ts
