### PR TITLE
Add docs examples and coverage for useAnimation, useAsyncDisposable, useBoundingclientrect, useBoundingclientrectRef, useClipboard

### DIFF
--- a/.oneignore
+++ b/.oneignore
@@ -1,0 +1,49 @@
+node_modules
+/.package.json
+package-lock.json
+lib
+yarn-error.log
+.next
+out
+dist
+lerna-debug.log
+.cache
+coverage
+/*.tsbuildinfo
+.out
+.DS_Store
+yarn-error*
+.rpt2_cache
+.github/actions/**/node_modules
+!.github/actions/**/package-lock.json
+*.d.ts
+.changelog
+**/tsconfig.tsbuildinfo
+src/declarations
+
+
+.docusaurus/*
+translated_docs
+build/
+yarn.lock
+i18n/*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# turbo
+.turbo
+.vercel
+
+
+# content-collections
+.content-collections/
+
+.jest-cache
+
+# ralph loop
+.ralph/progress.txt
+.ralph/learnings.txt

--- a/apps/website/content/docs/hooks/(animation)/useAnimation.mdx
+++ b/apps/website/content/docs/hooks/(animation)/useAnimation.mdx
@@ -6,7 +6,9 @@ description: "A hook that creates an animation with duration, easing, delay, and
 # useAnimation
 
 <Callout type="warn">
-**Deprecated:** This hook is deprecated and will be removed in a future major version. Please migrate to [useEasing](/docs/hooks/useEasing) for better control and features.
+  **Deprecated:** This hook is deprecated and will be removed in a future major
+  version. Please migrate to [useEasing](/docs/hooks/useEasing) for better
+  control and features.
 </Callout>
 
 `useAnimation` is a hook that creates an animation with duration, easing, delay, and loop options.
@@ -18,35 +20,78 @@ import { useAnimation } from "rooks";
 
 function App() {
   const value = useAnimation({
-      duration: 1000,
-      loop: true
+    duration: 1000,
+    loop: true,
   });
 
   return (
-    <div style={{ 
-        width: 100, 
-        height: 100, 
-        background: 'red',
-        transform: `rotate(${value * 360}deg)` 
-    }} />
+    <div
+      style={{
+        width: 100,
+        height: 100,
+        background: "red",
+        transform: `rotate(${value * 360}deg)`,
+      }}
+    />
+  );
+}
+```
+
+### Delayed animation with custom easing
+
+```jsx
+import { useAnimation } from "rooks";
+
+function easeOutQuad(t) {
+  return 1 - (1 - t) * (1 - t);
+}
+
+function DelayedProgress() {
+  const progress = useAnimation({
+    duration: 1200,
+    delay: 300,
+    easing: easeOutQuad,
+  });
+
+  return (
+    <div>
+      <div>Progress: {(progress * 100).toFixed(0)}%</div>
+      <div
+        style={{
+          height: 8,
+          width: 240,
+          background: "#e5e7eb",
+          borderRadius: 999,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${progress * 100}%`,
+            height: "100%",
+            background: "#2563eb",
+          }}
+        />
+      </div>
+    </div>
   );
 }
 ```
 
 ## Arguments
 
-| Argument | Type | Default | Description |
-| --- | --- | --- | --- |
-| options | AnimationOptions | - | Animation options. |
+| Argument | Type             | Default | Description        |
+| -------- | ---------------- | ------- | ------------------ |
+| options  | AnimationOptions | -       | Animation options. |
 
 ### AnimationOptions
 
-| Property | Type | Default | Description |
-| --- | --- | --- | --- |
-| duration | number | - | Duration of the animation in milliseconds. |
-| easing | (t: number) => number | t => t | Easing function to use. |
-| delay | number | 0 | Delay before starting the animation in milliseconds. |
-| loop | boolean | false | Whether to loop the animation. |
+| Property | Type                  | Default | Description                                          |
+| -------- | --------------------- | ------- | ---------------------------------------------------- |
+| duration | number                | -       | Duration of the animation in milliseconds.           |
+| easing   | (t: number) => number | t => t  | Easing function to use.                              |
+| delay    | number                | 0       | Delay before starting the animation in milliseconds. |
+| loop     | boolean               | false   | Whether to loop the animation.                       |
 
 ## Return Value
 

--- a/apps/website/content/docs/hooks/(browser)/useClipboard.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useClipboard.mdx
@@ -17,6 +17,7 @@ npm install rooks
 ## Usage
 
 ```jsx
+import { useState } from "react";
 import { useClipboard } from "rooks";
 
 function ClipboardDemo() {
@@ -72,17 +73,43 @@ function ClipboardDemo() {
 }
 ```
 
+## Another Example
+
+```jsx
+import { useClipboard } from "rooks";
+
+function ClipboardStatus() {
+  const { copy, paste, text, error, isSupported } = useClipboard();
+
+  if (!isSupported) {
+    return <p>Clipboard access is unavailable in this browser.</p>;
+  }
+
+  return (
+    <div>
+      <button onClick={() => copy("rooks is on the clipboard")}>
+        Copy preset text
+      </button>
+      <button onClick={paste}>Read clipboard</button>
+
+      {text ? <p>Clipboard value: {text}</p> : <p>Clipboard is empty.</p>}
+      {error ? <p>Error: {error.message}</p> : null}
+    </div>
+  );
+}
+```
+
 ## Return Value
 
 Returns an object with the following properties:
 
-| Property      | Type                              | Description                                         |
-| ------------- | --------------------------------- | --------------------------------------------------- |
-| text          | `string \| null`                  | The current text content from the clipboard         |
-| copy          | `(value: string) => Promise<void>`| Copy text to the clipboard                          |
-| paste         | `() => Promise<void>`             | Read text from the clipboard                        |
-| isSupported   | `boolean`                         | Whether the Clipboard API is supported              |
-| error         | `Error \| null`                   | Any error that occurred during clipboard operations |
+| Property    | Type                               | Description                                         |
+| ----------- | ---------------------------------- | --------------------------------------------------- |
+| text        | `string \| null`                   | The current text content from the clipboard         |
+| copy        | `(value: string) => Promise<void>` | Copy text to the clipboard                          |
+| paste       | `() => Promise<void>`              | Read text from the clipboard                        |
+| isSupported | `boolean`                          | Whether the Clipboard API is supported              |
+| error       | `Error \| null`                    | Any error that occurred during clipboard operations |
 
 ## Features
 
@@ -95,6 +122,7 @@ Returns an object with the following properties:
 ## Browser Support
 
 The Clipboard API requires:
+
 - HTTPS context (or localhost for development)
 - User permission for clipboard access
 - Modern browsers (Chrome 66+, Firefox 63+, Safari 13.1+, Edge 79+)

--- a/apps/website/content/docs/hooks/(experimental)/useAsyncDisposable.mdx
+++ b/apps/website/content/docs/hooks/(experimental)/useAsyncDisposable.mdx
@@ -42,18 +42,52 @@ function Screen() {
 }
 ```
 
+### Recreate the resource when dependencies change
+
+```tsx
+import { useState } from "react";
+import { useAsyncDisposable } from "rooks/experimental";
+
+class UserScopedConnection {
+  constructor(public userId: string) {}
+
+  async [Symbol.asyncDispose]() {
+    // close the user-specific resource
+  }
+}
+
+async function openUserConnection(userId: string) {
+  return new UserScopedConnection(userId);
+}
+
+function UserConnectionPanel() {
+  const [userId, setUserId] = useState("alice");
+  const resource = useAsyncDisposable(
+    () => openUserConnection(userId),
+    [userId]
+  );
+
+  return (
+    <div>
+      <button onClick={() => setUserId("bob")}>Switch user</button>
+      <div>{resource ? `Connected as ${resource.userId}` : "Loading..."}</div>
+    </div>
+  );
+}
+```
+
 ## Arguments
 
-| Argument | Type | Description | Default value |
-| -------- | ---- | ----------- | ------------- |
-| `factory` | `() => Promise<T>` | Async function that creates the resource | required |
-| `deps` | `DependencyList` | Dependency array controlling when the resource is replaced | `[]` |
+| Argument  | Type               | Description                                                | Default value |
+| --------- | ------------------ | ---------------------------------------------------------- | ------------- |
+| `factory` | `() => Promise<T>` | Async function that creates the resource                   | required      |
+| `deps`    | `DependencyList`   | Dependency array controlling when the resource is replaced | `[]`          |
 
 ## Return value
 
-| Return value | Type | Description |
-| ------------ | ---- | ----------- |
-| `resource` | `T \| null` | The resource, or `null` while the factory is still resolving |
+| Return value | Type        | Description                                                  |
+| ------------ | ----------- | ------------------------------------------------------------ |
+| `resource`   | `T \| null` | The resource, or `null` while the factory is still resolving |
 
 ## Notes
 

--- a/apps/website/content/docs/hooks/(ui)/useBoundingclientrect.mdx
+++ b/apps/website/content/docs/hooks/(ui)/useBoundingclientrect.mdx
@@ -7,7 +7,8 @@ sidebar_label: useBoundingclientrect
 ## About
 
 getBoundingClientRect hook for React.
-<br/>
+
+<br />
 
 ## Examples
 
@@ -68,6 +69,41 @@ function App() {
 }
 
 export default App;
+```
+
+### Read position and size together
+
+```jsx
+import { useRef } from "react";
+import { useBoundingclientrect } from "rooks";
+
+function PositionedCard() {
+  const cardRef = useRef(null);
+  const rect = useBoundingclientrect(cardRef);
+
+  return (
+    <div>
+      <div
+        ref={cardRef}
+        style={{
+          position: "absolute",
+          top: 24,
+          left: 32,
+          width: 260,
+          padding: 16,
+          border: "1px solid #d1d5db",
+        }}
+      >
+        Measure my size and position.
+      </div>
+
+      <p>Width: {rect?.width ?? 0}px</p>
+      <p>Height: {rect?.height ?? 0}px</p>
+      <p>Top: {rect?.top ?? 0}px</p>
+      <p>Left: {rect?.left ?? 0}px</p>
+    </div>
+  );
+}
 ```
 
 ### Arguments

--- a/apps/website/content/docs/hooks/(ui)/useBoundingclientrectRef.mdx
+++ b/apps/website/content/docs/hooks/(ui)/useBoundingclientrectRef.mdx
@@ -10,6 +10,8 @@ A hook that tracks the boundingclientrect of an element. It returns a callbackRe
 
 ## Examples
 
+### Basic callback-ref usage
+
 ```jsx
 import { useState } from "react";
 import { useBoundingclientrectRef } from "rooks";
@@ -60,6 +62,37 @@ export default function App() {
         <pre>{displayString}</pre>
       </div>
     </>
+  );
+}
+```
+
+### Force a manual re-measure
+
+```jsx
+import { useState } from "react";
+import { useBoundingclientrectRef } from "rooks";
+
+function ManualMeasureCard() {
+  const [ref, rect, update] = useBoundingclientrectRef();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          setIsExpanded((current) => !current);
+          update();
+        }}
+      >
+        Toggle content
+      </button>
+
+      <div ref={ref} style={{ width: isExpanded ? 280 : 180, padding: 16 }}>
+        {isExpanded ? "Expanded card content" : "Compact card"}
+      </div>
+
+      <pre>{JSON.stringify(rect, null, 2)}</pre>
+    </div>
   );
 }
 ```

--- a/packages/rooks/src/__tests__/useAnimation.spec.ts
+++ b/packages/rooks/src/__tests__/useAnimation.spec.ts
@@ -3,40 +3,71 @@ import { renderHook, act } from "@testing-library/react";
 import { useAnimation } from "../hooks/useAnimation";
 
 vi.mock("raf", () => {
-    const raf = (cb: any) => {
-        setTimeout(() => cb(performance.now()), 16);
-        return 1;
-    };
-    raf.cancel = () => { };
-    return { default: raf };
+  const raf = (cb: any) => {
+    setTimeout(() => cb(performance.now()), 16);
+    return 1;
+  };
+  raf.cancel = () => {};
+  return { default: raf };
 });
 
 describe("useAnimation", () => {
-    let nowSpy: vi.SpyInstance;
+  let nowSpy: vi.SpyInstance;
 
-    beforeAll(() => {
-        vi.useFakeTimers();
-        nowSpy = vi.spyOn(performance, "now").mockImplementation(() => Date.now());
+  beforeAll(() => {
+    vi.useFakeTimers();
+    nowSpy = vi.spyOn(performance, "now").mockImplementation(() => Date.now());
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+    nowSpy.mockRestore();
+  });
+
+  it("should start at 0", () => {
+    const { result } = renderHook(() => useAnimation({ duration: 1000 }));
+    expect(result.current).toBe(0);
+  });
+
+  it("should progress over time", () => {
+    const { result } = renderHook(() => useAnimation({ duration: 1000 }));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
     });
 
-    afterAll(() => {
-        vi.useRealTimers();
-        nowSpy.mockRestore();
+    expect(result.current).toBeGreaterThan(0);
+    expect(result.current).toBeLessThan(1);
+  });
+
+  it("should respect the configured delay before progressing", () => {
+    const { result } = renderHook(() =>
+      useAnimation({ duration: 1000, delay: 200 })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(150);
     });
 
-    it("should start at 0", () => {
-        const { result } = renderHook(() => useAnimation({ duration: 1000 }));
-        expect(result.current).toBe(0);
+    expect(result.current).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
     });
 
-    it("should progress over time", () => {
-        const { result } = renderHook(() => useAnimation({ duration: 1000 }));
+    expect(result.current).toBeGreaterThan(0);
+  });
 
-        act(() => {
-            vi.advanceTimersByTime(500);
-        });
+  it("should apply a custom easing function", () => {
+    const { result } = renderHook(() =>
+      useAnimation({ duration: 1000, easing: (t) => t * t })
+    );
 
-        expect(result.current).toBeGreaterThan(0);
-        expect(result.current).toBeLessThan(1);
+    act(() => {
+      vi.advanceTimersByTime(500);
     });
+
+    expect(result.current).toBeGreaterThan(0);
+    expect(result.current).toBeLessThan(0.5);
+  });
 });

--- a/packages/rooks/src/__tests__/useBoundingclientrect.spec.tsx
+++ b/packages/rooks/src/__tests__/useBoundingclientrect.spec.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useRef } from "react";
+import { vi } from "vitest";
+import { useBoundingclientrect } from "@/hooks/useBoundingclientrect";
+
+let currentRect = {
+  x: 10,
+  y: 20,
+  width: 100,
+  height: 50,
+  top: 20,
+  right: 110,
+  bottom: 70,
+  left: 10,
+  toJSON: () => ({}),
+};
+
+const mockGetBoundingClientRect = vi.fn(() => currentRect);
+const mockDisconnect = vi.fn();
+
+describe("useBoundingclientrect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentRect = {
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      top: 20,
+      right: 110,
+      bottom: 70,
+      left: 10,
+      toJSON: () => ({}),
+    };
+
+    Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+      value: mockGetBoundingClientRect,
+      writable: true,
+      configurable: true,
+    });
+
+    global.MutationObserver = vi.fn().mockImplementation(function (
+      callback: MutationCallback
+    ) {
+      return {
+        observe: vi.fn(),
+        disconnect: mockDisconnect,
+      };
+    }) as unknown as typeof MutationObserver;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function TestComponent() {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const rect = useBoundingclientrect(ref);
+
+    return (
+      <div>
+        <div ref={ref} data-testid="target">
+          Measure me
+        </div>
+        <div data-testid="rect">
+          {rect ? `${rect.width}x${rect.height}` : "No rect"}
+        </div>
+        <div data-testid="position">
+          {rect ? `${rect.left},${rect.top}` : "No position"}
+        </div>
+      </div>
+    );
+  }
+
+  it("measures the element after mount", async () => {
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rect")).toHaveTextContent("100x50");
+    });
+
+    expect(mockGetBoundingClientRect).toHaveBeenCalled();
+  });
+
+  it("exposes position values from the measured rect", async () => {
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rect")).toHaveTextContent("100x50");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("position")).toHaveTextContent("10,20");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expand canonical docs examples for useAnimation, useAsyncDisposable, useBoundingclientrect, useBoundingclientrectRef, and useClipboard
- add coverage for the new `useBoundingclientrect` docs-backed behavior and extend `useAnimation` example coverage

## Hooks changed
- useAnimation
- useAsyncDisposable
- useBoundingclientrect
- useBoundingclientrectRef
- useClipboard

## Test plan
- pnpm --filter rooks exec vitest run src/__tests__/useAnimation.spec.ts src/__tests__/useBoundingclientrect.spec.tsx