### PR TITLE
Add docs examples and coverage for useCountdown, useCounter, useDebounce, useDebouncedValue, useDidMount, useDidUpdate

### DIFF
--- a/apps/website/content/docs/hooks/(lifecycle)/useDidMount.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useDidMount.mdx
@@ -7,17 +7,39 @@ sidebar_label: useDidMount
 ## About
 
 componentDidMount hook for React
-<br/>
+
+<br />
 
 ## Examples
 
+### Run setup code once
+
 ```jsx
 import { useDidMount } from "rooks";
+
 export default function App() {
-  useDidMount(function() {
+  useDidMount(function () {
     console.log("mounted");
   });
+
   return null;
+}
+```
+
+### Set state after the component mounts
+
+```jsx
+import { useState } from "react";
+import { useDidMount } from "rooks";
+
+export default function MountedMessage() {
+  const [message, setMessage] = useState("Preparing…");
+
+  useDidMount(() => {
+    setMessage("Ready");
+  });
+
+  return <div>{message}</div>;
 }
 ```
 

--- a/apps/website/content/docs/hooks/(lifecycle)/useDidUpdate.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useDidUpdate.mdx
@@ -10,6 +10,8 @@ componentDidUpdate hook for react
 
 ## Examples
 
+### React to any update after mount
+
 ```jsx
 import React, { useState } from "react";
 import { useDidUpdate } from "rooks";
@@ -25,6 +27,34 @@ export default function App() {
       <p> Current value is {value}</p>
       <p> Open the sandbox in codesandbox to view the console </p>
       <button onClick={() => setValue(value + 1)}>Increment</button>
+    </div>
+  );
+}
+```
+
+### React only when a specific dependency changes
+
+```jsx
+import { useState } from "react";
+import { useDidUpdate } from "rooks";
+
+export default function FilterStatus() {
+  const [filter, setFilter] = useState("all");
+  const [count, setCount] = useState(0);
+  const [message, setMessage] = useState("No updates yet");
+
+  useDidUpdate(() => {
+    setMessage(`Filter changed to ${filter}`);
+  }, [filter]);
+
+  return (
+    <div>
+      <button onClick={() => setFilter("active")}>Set active filter</button>
+      <button onClick={() => setCount((current) => current + 1)}>
+        Increment unrelated count
+      </button>
+      <p>Count: {count}</p>
+      <p>{message}</p>
     </div>
   );
 }

--- a/apps/website/content/docs/hooks/(performance)/useDebounce.mdx
+++ b/apps/website/content/docs/hooks/(performance)/useDebounce.mdx
@@ -10,8 +10,10 @@ Debounce hook for react. Internally, it uses lodash debounce.
 
 ## Examples
 
+### Debounce a text input
+
 ```jsx
-import React, { useState } from "react";
+import { useState } from "react";
 import { useDebounce } from "rooks";
 
 export default function App() {
@@ -21,10 +23,35 @@ export default function App() {
   return (
     <div>
       <input
-        onChange={e => setValueDebounced(e.target.value)}
+        onChange={(e) => setValueDebounced(e.target.value)}
         placeholder="Please type here"
       />
       <div>{value}</div>
+    </div>
+  );
+}
+```
+
+### Trigger immediately on the leading edge
+
+```jsx
+import { useState } from "react";
+import { useDebounce } from "rooks";
+
+export default function LeadingSearch() {
+  const [logs, setLogs] = useState([]);
+  const logSearch = useDebounce(
+    (value) => {
+      setLogs((current) => [...current, `search:${value}`]);
+    },
+    500,
+    { leading: true }
+  );
+
+  return (
+    <div>
+      <button onClick={() => logSearch("react hooks")}>Run search</button>
+      <pre>{JSON.stringify(logs, null, 2)}</pre>
     </div>
   );
 }

--- a/apps/website/content/docs/hooks/(performance)/useDebouncedValue.mdx
+++ b/apps/website/content/docs/hooks/(performance)/useDebouncedValue.mdx
@@ -12,8 +12,10 @@ Tracks another value and gets updated in a debounced way.
 
 ## Examples
 
+### Debounce what the user types
+
 ```jsx
-import React, { useState } from "react";
+import { useState } from "react";
 import { useDebouncedValue } from "rooks";
 
 export default function App() {
@@ -27,10 +29,32 @@ export default function App() {
   return (
     <div>
       <input
-        onChange={e => setValue(e.target.value)}
+        onChange={(e) => setValue(e.target.value)}
         placeholder="Please type here"
       />
       <div>{debouncedValue}</div>
+    </div>
+  );
+}
+```
+
+### Update the debounced value immediately when needed
+
+```jsx
+import { useState } from "react";
+import { useDebouncedValue } from "rooks";
+
+export default function SubmitSearch() {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useDebouncedValue(query, 400, {
+    initializeWithNull: true,
+  });
+
+  return (
+    <div>
+      <input value={query} onChange={(event) => setQuery(event.target.value)} />
+      <button onClick={() => setDebouncedQuery(query)}>Search now</button>
+      <div>Searching for: {debouncedQuery ?? "nothing yet"}</div>
     </div>
   );
 }

--- a/apps/website/content/docs/hooks/(state)/useCountdown.mdx
+++ b/apps/website/content/docs/hooks/(state)/useCountdown.mdx
@@ -6,22 +6,47 @@ sidebar_label: useCountdown
 
 ## About
 
-Count down to a target timestamp and call callbacks every second (or provided peried)
+Count down to a target timestamp and call callbacks at a configurable interval.
 
 ## Examples
 
 ### Basic example
 
 ```jsx
-const endTime = new Date(Date.now() + 10000);
 import { useCountdown } from "rooks";
+
 export default function App() {
-  const count = useCountdown(endTime, {
-    interval: 1000,
-    onDown: time => console.log("onDown", time),
-    onEnd: time => console.log("onEnd", time),
+  const endTime = new Date(Date.now() + 10_000);
+  const count = useCountdown(endTime);
+
+  return <div>{count} seconds remaining</div>;
+}
+```
+
+### Use callbacks for progress and completion
+
+```jsx
+import { useState } from "react";
+import { useCountdown } from "rooks";
+
+export default function AutoDismissNotice() {
+  const [events, setEvents] = useState([]);
+  const count = useCountdown(new Date(Date.now() + 3_000), {
+    interval: 1_000,
+    onDown: (remaining) => {
+      setEvents((current) => [...current, `tick:${remaining}`]);
+    },
+    onEnd: () => {
+      setEvents((current) => [...current, "ended"]);
+    },
   });
-  return count;
+
+  return (
+    <div>
+      <p>{count === 0 ? "Dismissed" : `${count} seconds remaining`}</p>
+      <pre>{JSON.stringify(events, null, 2)}</pre>
+    </div>
+  );
 }
 ```
 
@@ -30,8 +55,8 @@ export default function App() {
 | Argument         | Type     | Description                                                         | Default value |
 | ---------------- | -------- | ------------------------------------------------------------------- | ------------- |
 | endTime          | Date     | the time when the countdown should end                              | undefined     |
-| options.interval | number   | milliseconds that it takes count down once                          | 1000          |
-| options.onDown   | function | (time) => {}, callback that would be called every interval          | undefined     |
+| options.interval | number   | milliseconds between countdown ticks                                | 1000          |
+| options.onDown   | function | `(restTime, newTime) => {}` callback called every interval          | undefined     |
 | options.onEnd    | function | (time) => {}, callback that would be called when the countdown ends | undefined     |
 
 ### Return Value

--- a/apps/website/content/docs/hooks/(state)/useCounter.mdx
+++ b/apps/website/content/docs/hooks/(state)/useCounter.mdx
@@ -7,23 +7,19 @@ sidebar_label: useCounter
 ## About
 
 Counter hook for React.
-<br/>
+
+<br />
 
 ## Examples
 
+### Basic counter controls
+
 ```jsx
-import React from "react";
-import { useCounter, useDidMount } from "rooks";
+import { useCounter } from "rooks";
 
 export default function App() {
-  const {
-    value,
-    increment,
-    decrement,
-    incrementBy,
-    decrementBy,
-    reset,
-  } = useCounter(3);
+  const { value, increment, decrement, incrementBy, decrementBy, reset } =
+    useCounter(3);
 
   function incrementBy5() {
     incrementBy(5);
@@ -43,6 +39,25 @@ export default function App() {
       <hr />
       <button onClick={reset}>reset</button>
     </>
+  );
+}
+```
+
+### Reset back to the initial value
+
+```jsx
+import { useCounter } from "rooks";
+
+export default function CounterWithReset() {
+  const { value, incrementBy, decrementBy, reset } = useCounter(10);
+
+  return (
+    <div>
+      <div>Current value: {value}</div>
+      <button onClick={() => incrementBy(10)}>Add 10</button>
+      <button onClick={() => decrementBy(4)}>Subtract 4</button>
+      <button onClick={reset}>Reset to 10</button>
+    </div>
   );
 }
 ```

--- a/packages/rooks/src/__tests__/useCountdown.spec.tsx
+++ b/packages/rooks/src/__tests__/useCountdown.spec.tsx
@@ -1,94 +1,74 @@
 import { vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
 import { useCountdown } from "@/hooks/useCountdown";
 
-vi.useFakeTimers();
-
 describe("useCountdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("is defined", () => {
     expect.hasAssertions();
     expect(useCountdown).toBeDefined();
   });
-  // it('works', () => {
-  //   const OriginalDate = global.Date;
-  //   const now = Date.now();
 
-  //   let advancedTime;
+  it("counts down at the configured interval", () => {
+    expect.hasAssertions();
+    const endTime = new Date(Date.now() + 3_000);
 
-  //   const advanceTimersInsideAct = time => {
-  //     advancedTime += time;
-  //     act(() => {
-  //       vi.advanceTimersByTime(time)
-  //     });
-  //   };
+    const { result } = renderHook(() => useCountdown(endTime));
 
-  // beforeEach(() => {
-  //   advancedTime = 0;
-  //   global.Date = class extends Date {
-  //     constructor(time) {
-  //       super(time);
-  //       return new OriginalDate(time || now + advancedTime);
-  //     }
-  //   };
-  // });
+    expect(result.current).toBe(3);
 
-  // afterEach(() => {
-  //   global.Date = OriginalDate;
-  // });
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(result.current).toBe(2);
 
-  // it('should run interval and clear it after unmount', () => {
-  //   const now = Date.now();
-  //   const endTime = new Date(now + 3000);
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(result.current).toBe(1);
 
-  //   global.Date = class extends Date {
-  //     constructor(time) {
-  //       return new OriginalDate(time || now);
-  //     }
-  //   };
-  //   const { result, unmount } = renderHook(() => useCountdown(endTime));
-  //   const countdown = result.current;
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(result.current).toBe(0);
+  });
 
-  //   expect(countdown).toEqual(3);
-  //   expect(setInterval).toHaveBeenCalledTimes(1);
+  it("calls onDown on each tick and onEnd when the countdown finishes", () => {
+    expect.hasAssertions();
+    const onDown = vi.fn();
+    const onEnd = vi.fn();
+    const endTime = new Date(Date.now() + 2_000);
 
-  //   unmount();
+    renderHook(() =>
+      useCountdown(endTime, {
+        interval: 1_000,
+        onDown,
+        onEnd,
+      })
+    );
 
-  //   expect(clearInterval).toHaveBeenCalledTimes(1);
-  //   expect(clearInterval).toHaveBeenCalledWith(
-  //     setInterval.mock.results[0].value,
-  //   );
-  // });
+    expect(onDown).toHaveBeenCalledTimes(1);
+    expect(onEnd).not.toHaveBeenCalled();
 
-  // it('should call onDown after every interval', () => {
-  //   const endTime = new Date(now + 3000);
-  //   const onDown = vi.fn();
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
 
-  //   renderHook(() => useCountdown(endTime, { onDown }));
+    expect(onDown.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(onEnd).not.toHaveBeenCalled();
 
-  //   expect(onDown).toHaveBeenCalledTimes(0);
-  //   advanceTimersInsideAct(1000);
-  //   expect(onDown).toHaveBeenCalledTimes(1);
-  //   advanceTimersInsideAct(1000);
-  //   expect(onDown).toHaveBeenCalledTimes(2);
-  //   advanceTimersInsideAct(1000);
-  //   expect(onDown).toHaveBeenCalledTimes(3);
-  //   advanceTimersInsideAct(1000);
-  //   expect(onDown).toHaveBeenCalledTimes(3);
-  // });
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
 
-  // it('should call onEnd after it ends', () => {
-  //   const endTime = new Date(now + 3000);
-  //   const onEnd = vi.fn();
-  //   renderHook(() => useCountdown(endTime, { interval: 1000, onEnd }));
-  //   expect(onEnd).toHaveBeenCalledTimes(0);
-  //   advanceTimersInsideAct(2000);
-  //   expect(onEnd).toHaveBeenCalledTimes(0);
-  //   advanceTimersInsideAct(2000);
-  //   expect(onEnd).toHaveBeenCalledTimes(1);
-  //   expect(clearInterval).toHaveBeenCalledWith(
-  //     setInterval.mock.results[0].value,
-  //   );
-  // });
-  // })
+    expect(onEnd.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
 });
-
-// figure out tests

--- a/packages/rooks/src/__tests__/useDebouncedValue.spec.ts
+++ b/packages/rooks/src/__tests__/useDebouncedValue.spec.ts
@@ -3,11 +3,10 @@ import type { RenderResult } from "@testing-library/react";
 import { act, renderHook } from "@testing-library/react";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
-  ? 1
-  : 2
-  ? true
-  : false;
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
 
 type Expect<T extends true> = T;
 
@@ -112,6 +111,21 @@ describe("useDebouncedValue", () => {
     expect(result.current[0]).toBe(mockValue);
   });
 
+  it("lets callers update the debounced value immediately", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useDebouncedValue("initial", 200, { initializeWithNull: true })
+    );
+
+    expect(result.current[0]).toBeNull();
+
+    act(() => {
+      result.current[1]("manual");
+    });
+
+    expect(result.current[0]).toBe("manual");
+  });
+
   describe("types", () => {
     it("should return a union with null when initializeWithNull is true", () => {
       doNotExecute(() => {
@@ -119,7 +133,7 @@ describe("useDebouncedValue", () => {
           useDebouncedValue("mock_value", 200, { initializeWithNull: true })
         );
         const result: Expect<
-          Equal<string | null, typeof hookResult.result.current[0]>
+          Equal<string | null, (typeof hookResult.result.current)[0]>
         > = true;
         return result;
       });
@@ -131,7 +145,7 @@ describe("useDebouncedValue", () => {
           useDebouncedValue("mock_value", 200)
         );
         const result: Expect<
-          Equal<string, typeof hookResult.result.current[0]>
+          Equal<string, (typeof hookResult.result.current)[0]>
         > = true;
         return result;
       });
@@ -143,7 +157,7 @@ describe("useDebouncedValue", () => {
           useDebouncedValue("mock_value", 200, { initializeWithNull: false })
         );
         const result: Expect<
-          Equal<string, typeof hookResult.result.current[0]>
+          Equal<string, (typeof hookResult.result.current)[0]>
         > = true;
         return result;
       });

--- a/packages/rooks/src/__tests__/useDidMount.spec.ts
+++ b/packages/rooks/src/__tests__/useDidMount.spec.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useState } from "react";
 import { useDidMount } from "@/hooks/useDidMount";
@@ -28,6 +29,22 @@ describe("useDidMount", () => {
       expect.hasAssertions();
       const { result } = renderHook(() => useHook());
       expect(result.current.value).toBe(9_000);
+    });
+
+    it("does not run again on rerender", () => {
+      expect.hasAssertions();
+      const callback = vi.fn();
+
+      const { rerender } = renderHook(() => {
+        useDidMount(callback);
+        return null;
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      rerender();
+
+      expect(callback).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- expand canonical docs examples for useCountdown, useCounter, useDebounce, useDebouncedValue, useDidMount, and useDidUpdate
- align example coverage with targeted tests

## Hooks changed
- useCountdown
- useCounter
- useDebounce
- useDebouncedValue
- useDidMount
- useDidUpdate

## Test plan
- pnpm --filter rooks exec vitest run src/__tests__/useCountdown.spec.tsx src/__tests__/useDebouncedValue.spec.ts src/__tests__/useDidMount.spec.ts