### PR TITLE
Add docs examples and coverage for useFocus, useFocusWithin, useFreshCallback, useFullscreen

### DIFF
--- a/apps/website/content/docs/hooks/(events)/useFocus.mdx
+++ b/apps/website/content/docs/hooks/(events)/useFocus.mdx
@@ -10,20 +10,16 @@ Handles focus events for the immediate target element.
 
 ## Examples
 
+### Track focus on a single input
+
 ```tsx
+import { useState } from "react";
 import { useFocus } from "rooks";
+
 export default function App() {
-  const [isFocus, setIsFocus] = useState<boolean>(false);
+  const [isFocused, setIsFocused] = useState(false);
   const { focusProps } = useFocus<HTMLInputElement>({
-    onFocus: () => {
-      console.log("focus");
-    },
-    onBlur: () => {
-      console.log("blur");
-    },
-    onFocusChange: (isFocused) => {
-      setIsFocus(isFocused);
-    },
+    onFocusChange: setIsFocused,
   });
 
   return (
@@ -32,10 +28,39 @@ export default function App() {
       <input
         {...focusProps}
         style={{
-          border: isFocus ? "3px solid orange" : "1px solid gray",
+          border: isFocused ? "3px solid orange" : "1px solid gray",
         }}
       />
     </label>
+  );
+}
+```
+
+### Ignore focus from nested children
+
+```tsx
+import { useState } from "react";
+import { useFocus } from "rooks";
+
+export default function App() {
+  const [message, setMessage] = useState("Container is idle");
+  const { focusProps } = useFocus<HTMLDivElement>({
+    onFocus: () => setMessage("Container focused directly"),
+    onBlur: () => setMessage("Container blurred"),
+  });
+
+  return (
+    <div>
+      <div
+        {...focusProps}
+        tabIndex={0}
+        style={{ padding: 12, border: "1px solid #999" }}
+      >
+        Focus this container directly
+        <button type="button">Nested button</button>
+      </div>
+      <p>{message}</p>
+    </div>
   );
 }
 ```

--- a/apps/website/content/docs/hooks/(events)/useFocusWithin.mdx
+++ b/apps/website/content/docs/hooks/(events)/useFocusWithin.mdx
@@ -6,26 +6,20 @@ sidebar_label: useFocusWithin
 
 ## About
 
-Handles focus events for the target component.
+Handles focus events for the target component and any focusable descendants.
 
 ## Examples
+
+### Highlight a group when any child receives focus
 
 ```tsx
 import { useState } from "react";
 import { useFocusWithin } from "rooks";
 
-const Page = () => {
-  const [isFocusWithin, setIsFocusWithin] = useState<boolean>(false);
+export default function App() {
+  const [isFocusWithin, setIsFocusWithin] = useState(false);
   const { focusWithinProps } = useFocusWithin<HTMLDivElement>({
-    onFocusWithin: () => {
-      console.log("focus within");
-    },
-    onBlurWithin: () => {
-      console.log("blur within");
-    },
-    onFocusWithinChange: (isFocusWithin) => {
-      setIsFocusWithin(isFocusWithin);
-    },
+    onFocusWithinChange: setIsFocusWithin,
   });
 
   return (
@@ -35,7 +29,6 @@ const Page = () => {
         display: "inline-block",
         border: "1px solid gray",
         padding: 10,
-        margin: "auto",
         background: isFocusWithin ? "goldenrod" : "gray",
         color: isFocusWithin ? "black" : "white",
       }}
@@ -48,6 +41,30 @@ const Page = () => {
       </label>
     </div>
   );
-};
-export default Page;
+}
+```
+
+### Show group-level help text while focus stays inside
+
+```tsx
+import { useState } from "react";
+import { useFocusWithin } from "rooks";
+
+export default function App() {
+  const [message, setMessage] = useState(
+    "Focus a field to see keyboard hints."
+  );
+  const { focusWithinProps } = useFocusWithin<HTMLDivElement>({
+    onFocusWithin: () => setMessage("Tip: press Enter to submit this section."),
+    onBlurWithin: () => setMessage("Focus a field to see keyboard hints."),
+  });
+
+  return (
+    <section {...focusWithinProps}>
+      <input placeholder="Email" />
+      <input placeholder="Phone" />
+      <p>{message}</p>
+    </section>
+  );
+}
 ```

--- a/apps/website/content/docs/hooks/(ui)/useFullscreen.mdx
+++ b/apps/website/content/docs/hooks/(ui)/useFullscreen.mdx
@@ -6,69 +6,85 @@ sidebar_label: useFullscreen
 
 ## About
 
-Use [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) to make beautiful and immersive experience. Present desired content using the entire user's screen. Commonly used in browser games or other applications using canvases.
+Use the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) to present content using the entire screen.
 
-## Example
+## Examples
+
+### Toggle fullscreen for the document
 
 ```tsx
-import React, { useRef } from "react";
 import { useFullscreen } from "rooks";
 
-export default function UseFullscreenTest() {
-  const fullscreenContainerRef = useRef<Element>(null);
-  const {
-    isFullscreenAvailable,
-    isFullscreenEnabled,
-    toggleFullscreen,
-  } = useFullscreen({ target: fullscreenContainerRef });
+export default function App() {
+  const { isFullscreenAvailable, isFullscreenEnabled, toggleFullscreen } =
+    useFullscreen();
+
+  if (!isFullscreenAvailable) {
+    return <p>Fullscreen API is not available.</p>;
+  }
 
   return (
-    <>
-      <div ref={fullscreenContainerRef}>
-        {isFullscreenAvailable ? (
-          <button onClick={toggleFullscreen}>
-            {isFullscreenEnabled ? 'Disable fullscreen' : 'Enable fullscreen'}
-          </button>
-        ) : (
-          <p>Fullscreen API is not available.</p>
-        )}
-      </div>
-      <div>
-       <p>Other content which won't be visible while in fullscreen mode...</p>
-      </div>
-    </>
+    <button onClick={() => void toggleFullscreen()}>
+      {isFullscreenEnabled ? "Exit fullscreen" : "Enter fullscreen"}
+    </button>
   );
 }
 ```
 
-### Arguments
+### Toggle fullscreen for a specific panel and react to changes
+
+```tsx
+import { useRef, useState } from "react";
+import { useFullscreen } from "rooks";
+
+export default function App() {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState("Windowed");
+  const { enableFullscreen, disableFullscreen, isFullscreenEnabled } =
+    useFullscreen({
+      target: panelRef,
+      onChange: () => {
+        setStatus(document.fullscreenElement ? "Fullscreen" : "Windowed");
+      },
+    });
+
+  return (
+    <div>
+      <div ref={panelRef} style={{ padding: 24, border: "1px solid #999" }}>
+        <p>Status: {status}</p>
+        <button onClick={() => void enableFullscreen()}>Open panel</button>
+        <button
+          onClick={() => void disableFullscreen()}
+          disabled={!isFullscreenEnabled}
+        >
+          Close panel
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+## Arguments
 
 An object with the following optional properties:
 
-| Argument value                   | Type                       | Description                                                                                                                          |
-| -------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| options.target                   | `React.RefObject&lt;Element&gt;` | React's ref to DOM node which should be present in fullscreen mode                                                                   |
-| options.onChange                 | `(event: Event) => void`   | Callback function to be called on `fullscreenchange` event                                                                           |
-| options.onError                  | `(event: Event) => void`   | Callback function to be called on `fullscreenerror` event                                                                            |
-| options.requestFullscreenOptions | `FullscreenOptions`        | `requestFullscreen` options as defined [here](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen#parameters) |
+| Argument value                     | Type                       | Description                           |
+| ---------------------------------- | -------------------------- | ------------------------------------- |
+| `options.target`                   | `React.RefObject<Element>` | DOM node that should enter fullscreen |
+| `options.onChange`                 | `(event: Event) => void`   | Called after fullscreen state changes |
+| `options.onError`                  | `(event: Event) => void`   | Called after a fullscreen error       |
+| `options.requestFullscreenOptions` | `FullscreenOptions`        | Options passed to `requestFullscreen` |
 
-If the `target` property is not specified, the whole document will be rendered in fullscreen mode.
+If `target` is omitted, the document element is used.
 
-### Returns
+## Returns
 
-Returns an object with following properties:
-
-| Property Name         | Type                  | Description                                             |
-| --------------------- | --------------------- | ------------------------------------------------------- |
-| isFullscreenAvailable | `boolean`             | Whether the `Fullscreen API` is available               |
-| isFullscreenEnabled   | `boolean`             | Whether the fullscreen is enabled                       |
-| fullscreenElement     | `Element | null`      | The currently rendered fullscreen element, null if none |
-| enableFullscreen      | `() => Promise<void>` | Enable the fullscreen                                   |
-| disableFullscreen     | `() => Promise<void>` | Disable the fullscreen                                  |
-| toggleFullscreen      | `() => Promise<void>` | Toggle the fullscreen                                   |
-
-#### Sidenote
-
-- Before using Fullscreen API, one should check if it is available using `isFullscreenAvailable` property. Otherwise, all method calls will result in an error. 
-- If the target is an `<iframe>`, it must have the `allowfullscreen` attribute applied to it.
-- All methods should be called while responding to a user interaction or a device orientation change. Otherwise, such operations will result in an error (eg., you cannot enable the fullscreen on component render using the `useEffect` hook).
+| Property Name           | Type                  | Description                             |
+| ----------------------- | --------------------- | --------------------------------------- |
+| `isFullscreenAvailable` | `boolean`             | Whether the Fullscreen API is available |
+| `isFullscreenEnabled`   | `boolean`             | Whether fullscreen is currently active  |
+| `fullscreenElement`     | `Element \| null`     | The current fullscreen element          |
+| `enableFullscreen`      | `() => Promise<void>` | Enters fullscreen                       |
+| `disableFullscreen`     | `() => Promise<void>` | Exits fullscreen                        |
+| `toggleFullscreen`      | `() => Promise<void>` | Toggles fullscreen on or off            |

--- a/apps/website/content/docs/hooks/(utilities)/useFreshCallback.mdx
+++ b/apps/website/content/docs/hooks/(utilities)/useFreshCallback.mdx
@@ -6,14 +6,49 @@ sidebar_label: useFreshCallback
 
 ## About
 
-Avoid stale closures and keep your callback fresh
+Avoid stale closures and keep your callback fresh.
 
 ## Examples
 
+### Call the latest callback after state changes
+
 ```tsx
-import {useFreshCallback} from "rooks"
+import { useState } from "react";
+import { useFreshCallback } from "rooks";
+
 export default function App() {
-  useFreshCallback();
-  return null
+  const [count, setCount] = useState(0);
+  const logLatestCount = useFreshCallback(() => {
+    console.log(`Latest count: ${count}`);
+  });
+
+  return (
+    <div>
+      <button onClick={() => setCount((current) => current + 1)}>
+        Increment
+      </button>
+      <button onClick={logLatestCount}>Log latest count</button>
+    </div>
+  );
+}
+```
+
+### Keep an event handler in sync with changing props
+
+```tsx
+import { useEffect } from "react";
+import { useFreshCallback } from "rooks";
+
+function ResizeLogger({ label }: { label: string }) {
+  const handleResize = useFreshCallback(() => {
+    console.log(`${label}: ${window.innerWidth}`);
+  });
+
+  useEffect(() => {
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [handleResize]);
+
+  return null;
 }
 ```

--- a/packages/rooks/src/__tests__/useFreshCallback.spec.ts
+++ b/packages/rooks/src/__tests__/useFreshCallback.spec.ts
@@ -1,8 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import { useState } from "react";
+import { vi } from "vitest";
 import { useFreshCallback } from "@/hooks/useFreshCallback";
 
 describe("useFreshCallback", () => {
   it("should be defined", () => {
     expect.hasAssertions();
     expect(useFreshCallback).toBeDefined();
+  });
+
+  it("should call the latest callback after rerenders", () => {
+    expect.hasAssertions();
+    const spy = vi.fn();
+
+    const { result } = renderHook(() => {
+      const [count, setCount] = useState(0);
+      const callback = useFreshCallback(() => {
+        spy(count);
+      });
+
+      return { callback, setCount };
+    });
+
+    act(() => {
+      result.current.callback();
+    });
+
+    act(() => {
+      result.current.setCount(2);
+    });
+
+    act(() => {
+      result.current.callback();
+    });
+
+    expect(spy).toHaveBeenNthCalledWith(1, 0);
+    expect(spy).toHaveBeenNthCalledWith(2, 2);
   });
 });


### PR DESCRIPTION
## Summary
- expand canonical docs examples for useFocus, useFocusWithin, useFreshCallback, and useFullscreen
- add behavior coverage for `useFreshCallback` so the docs-backed examples are exercised

## Hooks changed
- useFocus
- useFocusWithin
- useFreshCallback
- useFullscreen

## Test plan
- pnpm --filter rooks exec vitest run src/__tests__/useFreshCallback.spec.ts