### PR TITLE
Add docs examples and coverage for 20 hooks across animation, browser, events, lifecycle, state, and utility categories

### DIFF
--- a/apps/website/content/docs/hooks/(animation)/useRaf.mdx
+++ b/apps/website/content/docs/hooks/(animation)/useRaf.mdx
@@ -65,6 +65,31 @@ export default function App() {
 }
 ```
 
+### Pause and resume a frame counter
+
+```jsx
+import { useState } from "react";
+import { useRaf, useToggle } from "rooks";
+
+export default function FrameCounter() {
+  const [frames, setFrames] = useState(0);
+  const [isActive, toggleActive] = useToggle(true);
+
+  useRaf(() => {
+    setFrames((current) => current + 1);
+  }, isActive);
+
+  return (
+    <div>
+      <p>Frames processed: {frames}</p>
+      <button onClick={toggleActive}>
+        {isActive ? "Pause" : "Resume"} RAF loop
+      </button>
+    </div>
+  );
+}
+```
+
 ### Arguments
 
 | Argument value | Type                            | Description                                                                                  | Default value |

--- a/apps/website/content/docs/hooks/(animation)/useResizeObserverRef.mdx
+++ b/apps/website/content/docs/hooks/(animation)/useResizeObserverRef.mdx
@@ -7,7 +7,8 @@ sidebar_label: useResizeObserverRef
 ## About
 
 Resize Observer hook for React.
-<br/>
+
+<br />
 
 ## Examples
 
@@ -71,6 +72,37 @@ export default function App() {
 }
 ```
 
+### Measure the latest width and height
+
+```jsx
+import { useState } from "react";
+import { useResizeObserverRef } from "rooks";
+
+export default function SizeReadout() {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const [ref] = useResizeObserverRef((entries) => {
+    const entry = entries[0];
+    if (entry) {
+      setSize({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      });
+    }
+  });
+
+  return (
+    <div>
+      <div ref={ref} style={{ resize: "both", overflow: "auto", width: 200 }}>
+        Resize me
+      </div>
+      <p>
+        Current size: {size.width} x {size.height}
+      </p>
+    </div>
+  );
+}
+```
+
 ### Arguments
 
 | Argument | Type                   | Description                                                       | Default value            |
@@ -85,11 +117,3 @@ Returns an array with one element
 | Return value | Type        | Description                             |
 | ------------ | ----------- | --------------------------------------- |
 | ref          | CallbackRef | Ref which should be observed for Resize |
-
-## Codesandbox Example
-
-### Basic Usage
-
-## Join Bhargav's discord server
-
-You can click on the floating discord icon at the bottom right of the screen and talk to us in our server.

--- a/apps/website/content/docs/hooks/(browser)/useNotification.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useNotification.mdx
@@ -17,10 +17,12 @@ npm install rooks
 ## Usage
 
 ```jsx
+import { useState } from "react";
 import { useNotification } from "rooks";
 
 function NotificationDemo() {
-  const { show, permission, requestPermission, isSupported } = useNotification();
+  const { show, permission, requestPermission, isSupported } =
+    useNotification();
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
 
@@ -51,7 +53,9 @@ function NotificationDemo() {
   return (
     <div>
       <h2>Browser Notifications</h2>
-      <p>Current permission: <strong>{permission}</strong></p>
+      <p>
+        Current permission: <strong>{permission}</strong>
+      </p>
 
       {permission === "default" && (
         <div>
@@ -77,8 +81,42 @@ function NotificationDemo() {
       )}
 
       {permission === "denied" && (
-        <p>Permission denied. Please enable notifications in browser settings.</p>
+        <p>
+          Permission denied. Please enable notifications in browser settings.
+        </p>
       )}
+    </div>
+  );
+}
+```
+
+## Another Example
+
+```jsx
+import { useNotification } from "rooks";
+
+function PresetNotification() {
+  const { permission, requestPermission, show, isSupported } =
+    useNotification();
+
+  if (!isSupported) {
+    return <p>Your browser does not support notifications.</p>;
+  }
+
+  return (
+    <div>
+      <p>Permission: {permission}</p>
+      <button onClick={requestPermission}>Enable notifications</button>
+      <button
+        onClick={() =>
+          show("Build finished", {
+            body: "Your latest batch of examples is ready for review.",
+            tag: "batch-ready",
+          })
+        }
+      >
+        Send preset notification
+      </button>
     </div>
   );
 }
@@ -88,28 +126,28 @@ function NotificationDemo() {
 
 Returns an object with the following properties:
 
-| Property          | Type                                                           | Description                                  |
-| ----------------- | -------------------------------------------------------------- | -------------------------------------------- |
-| show              | `(title: string, options?: NotificationOptions) => Promise<Notification \| null>` | Show a notification |
-| permission        | `"default" \| "granted" \| "denied"`                           | Current permission state                     |
-| requestPermission | `() => Promise<NotificationPermission>`                        | Request notification permission from user    |
-| isSupported       | `boolean`                                                      | Whether the Notification API is supported    |
+| Property          | Type                                                                              | Description                               |
+| ----------------- | --------------------------------------------------------------------------------- | ----------------------------------------- |
+| show              | `(title: string, options?: NotificationOptions) => Promise<Notification \| null>` | Show a notification                       |
+| permission        | `"default" \| "granted" \| "denied"`                                              | Current permission state                  |
+| requestPermission | `() => Promise<NotificationPermission>`                                           | Request notification permission from user |
+| isSupported       | `boolean`                                                                         | Whether the Notification API is supported |
 
 ## Notification Options
 
 The `show` function accepts an options object with the following properties:
 
-| Option              | Type                | Description                                           |
-| ------------------- | ------------------- | ----------------------------------------------------- |
-| body                | `string`            | The body text of the notification                     |
-| icon                | `string`            | URL of an icon to display in the notification         |
-| badge               | `string`            | URL of a badge image                                  |
-| tag                 | `string`            | Unique tag to identify the notification               |
-| data                | `any`               | Custom data to associate with the notification        |
-| requireInteraction  | `boolean`           | Whether notification should remain active until clicked|
-| silent              | `boolean`           | Whether notification should be silent                 |
-| vibrate             | `number \| number[]`| Vibration pattern for devices that support it         |
-| image               | `string`            | URL of an image to display in the notification        |
+| Option             | Type                 | Description                                             |
+| ------------------ | -------------------- | ------------------------------------------------------- |
+| body               | `string`             | The body text of the notification                       |
+| icon               | `string`             | URL of an icon to display in the notification           |
+| badge              | `string`             | URL of a badge image                                    |
+| tag                | `string`             | Unique tag to identify the notification                 |
+| data               | `any`                | Custom data to associate with the notification          |
+| requireInteraction | `boolean`            | Whether notification should remain active until clicked |
+| silent             | `boolean`            | Whether notification should be silent                   |
+| vibrate            | `number \| number[]` | Vibration pattern for devices that support it           |
+| image              | `string`             | URL of an image to display in the notification          |
 
 ## Features
 
@@ -122,6 +160,7 @@ The `show` function accepts an options object with the following properties:
 ## Browser Support
 
 The Notifications API is supported in:
+
 - Chrome 22+
 - Firefox 22+
 - Safari 7+

--- a/apps/website/content/docs/hooks/(browser)/useOnline.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useOnline.mdx
@@ -33,6 +33,29 @@ function App() {
 export default App;
 ```
 
+```jsx
+import { useOnline } from "rooks";
+
+function ConnectionBanner() {
+  const isOnline = useOnline();
+
+  return (
+    <div
+      style={{
+        padding: "12px 16px",
+        borderRadius: 8,
+        background: isOnline ? "#dcfce7" : "#fee2e2",
+        color: isOnline ? "#166534" : "#991b1b",
+      }}
+    >
+      {isOnline
+        ? "Connected. Changes will sync normally."
+        : "Offline mode. Changes will sync when you reconnect."}
+    </div>
+  );
+}
+```
+
 ### Return value
 
 Offline status (boolean) is returned.

--- a/apps/website/content/docs/hooks/(browser)/useOrientation.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useOrientation.mdx
@@ -7,7 +7,8 @@ sidebar_label: useOrientation
 ## About
 
 Hook to detect and track device orientation changes in React applications.
-<br/>
+
+<br />
 
 ## Examples
 
@@ -31,21 +32,49 @@ export default function App() {
       <div>
         <strong>Type:</strong> {orientation.type}
       </div>
-      
-      <div style={{ marginTop: '20px' }}>
+
+      <div style={{ marginTop: "20px" }}>
         <p>Try rotating your device to see the orientation change!</p>
-        
-        {orientation.type.includes('portrait') && (
-          <div style={{ color: 'blue' }}>
-            📱 Portrait mode detected
-          </div>
+
+        {orientation.type.includes("portrait") && (
+          <div style={{ color: "blue" }}>📱 Portrait mode detected</div>
         )}
-        
-        {orientation.type.includes('landscape') && (
-          <div style={{ color: 'green' }}>
-            🔄 Landscape mode detected
-          </div>
+
+        {orientation.type.includes("landscape") && (
+          <div style={{ color: "green" }}>🔄 Landscape mode detected</div>
         )}
+      </div>
+    </div>
+  );
+}
+```
+
+```jsx
+import { useOrientation } from "rooks";
+
+function OrientationCard() {
+  const orientation = useOrientation();
+
+  if (!orientation) {
+    return null;
+  }
+
+  return (
+    <div>
+      <p>Current orientation: {orientation.type}</p>
+      <p>Angle: {orientation.angle}°</p>
+      <div
+        style={{
+          width: 120,
+          height: 120,
+          display: "grid",
+          placeItems: "center",
+          border: "1px solid #d1d5db",
+          transform: `rotate(${orientation.angle}deg)`,
+          transition: "transform 150ms ease",
+        }}
+      >
+        Preview
       </div>
     </div>
   );
@@ -58,15 +87,15 @@ This hook takes no arguments.
 
 ### Return value
 
-| Return value | Type                        | Description                                                                                   |
-| ------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
-| orientation  | ScreenOrientation \| null   | Current orientation object with `angle` and `type` properties, or null if not supported     |
+| Return value | Type                      | Description                                                                             |
+| ------------ | ------------------------- | --------------------------------------------------------------------------------------- |
+| orientation  | ScreenOrientation \| null | Current orientation object with `angle` and `type` properties, or null if not supported |
 
 ### ScreenOrientation Properties
 
-| Property | Type   | Description                                                                                        |
-| -------- | ------ | -------------------------------------------------------------------------------------------------- |
-| angle    | number | The orientation angle in degrees (0, 90, 180, or 270)                                             |
+| Property | Type   | Description                                                                                      |
+| -------- | ------ | ------------------------------------------------------------------------------------------------ |
+| angle    | number | The orientation angle in degrees (0, 90, 180, or 270)                                            |
 | type     | string | The orientation type (e.g., "portrait-primary", "landscape-primary", "portrait-secondary", etc.) |
 
 ---

--- a/apps/website/content/docs/hooks/(events)/useDocumentEventListener.mdx
+++ b/apps/website/content/docs/hooks/(events)/useDocumentEventListener.mdx
@@ -12,6 +12,8 @@ A react hook to an event listener to the document object
 
 ## Examples
 
+### Track document clicks
+
 ```jsx
 import { useDocumentEventListener } from "rooks";
 import { useState, useEffect } from "react";
@@ -19,7 +21,7 @@ import { useState, useEffect } from "react";
 export default function App() {
   const [myState, setMyState] = useState(0);
 
-  useDocumentEventListener("click", function() {
+  useDocumentEventListener("click", function () {
     setMyState(myState + 1);
   });
 
@@ -30,6 +32,25 @@ export default function App() {
       <h1>Clicked {myState} times</h1>
     </div>
   );
+}
+```
+
+### Use a document-level listener to close a surface
+
+```jsx
+import { useState } from "react";
+import { useDocumentEventListener } from "rooks";
+
+export default function DismissibleNotice() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  useDocumentEventListener("click", () => {
+    setIsOpen(false);
+  });
+
+  return isOpen ? (
+    <div>Click anywhere in the document to dismiss me.</div>
+  ) : null;
 }
 ```
 

--- a/apps/website/content/docs/hooks/(events)/useDocumentVisibilityState.mdx
+++ b/apps/website/content/docs/hooks/(events)/useDocumentVisibilityState.mdx
@@ -10,15 +10,35 @@ Returns the visibility state of the document. Returns `null` on the server.
 
 ## Examples
 
+### Read the current visibility state
+
 ```tsx
-import {useEffect} from 'react'
-import {useDocumentVisibilityState} from "rooks"
+import { useEffect } from "react";
+import { useDocumentVisibilityState } from "rooks";
 
 export default function App() {
-  const isDocumentVisible =  useDocumentVisibilityState();
+  const isDocumentVisible = useDocumentVisibilityState();
   useEffect(() => {
-    console.log(isDocumentVisible)
-  }, [isDocumentVisible])
-  return <p>Try switching to a different tab and check console </p>
+    console.log(isDocumentVisible);
+  }, [isDocumentVisible]);
+  return <p>Try switching to a different tab and check console </p>;
+}
+```
+
+### Pause work when the tab becomes hidden
+
+```tsx
+import { useEffect, useState } from "react";
+import { useDocumentVisibilityState } from "rooks";
+
+export default function PollingStatus() {
+  const visibilityState = useDocumentVisibilityState();
+  const [status, setStatus] = useState("active");
+
+  useEffect(() => {
+    setStatus(visibilityState === "hidden" ? "paused" : "active");
+  }, [visibilityState]);
+
+  return <p>Polling is currently {status}</p>;
 }
 ```

--- a/apps/website/content/docs/hooks/(events)/useOnLongPress.mdx
+++ b/apps/website/content/docs/hooks/(events)/useOnLongPress.mdx
@@ -43,9 +43,13 @@ export default function App() {
     console.log("Long press detected");
   };
 
+  const handleClick = () => {
+    console.log("Regular click detected");
+  };
+
   const longPressRef = useOnLongPress(handleLongPress, {
     duration: 1000,
-    onClick: handleTouchEnd,
+    onClick: handleClick,
   });
 
   return (

--- a/apps/website/content/docs/hooks/(events)/useOnWindowResize.mdx
+++ b/apps/website/content/docs/hooks/(events)/useOnWindowResize.mdx
@@ -26,6 +26,29 @@ export default function App() {
 }
 ```
 
+```jsx
+import { useState } from "react";
+import { useOnWindowResize } from "rooks";
+
+export default function ResponsivePreview() {
+  const [count, setCount] = useState(0);
+  const [enabled, setEnabled] = useState(true);
+
+  useOnWindowResize(() => {
+    setCount((current) => current + 1);
+  }, enabled);
+
+  return (
+    <div>
+      <button onClick={() => setEnabled((current) => !current)}>
+        {enabled ? "Pause resize tracking" : "Resume resize tracking"}
+      </button>
+      <p>Resize events recorded: {count}</p>
+    </div>
+  );
+}
+```
+
 ### Arguments
 
 | Arguments      | Type     | Description                                     | Default value |

--- a/apps/website/content/docs/hooks/(events)/useOnWindowScroll.mdx
+++ b/apps/website/content/docs/hooks/(events)/useOnWindowScroll.mdx
@@ -7,7 +7,8 @@ sidebar_label: useOnWindowScroll
 ## About
 
 A React hook for adding an event listener for window scroll
-<br/>
+
+<br />
 
 ## Examples
 
@@ -46,6 +47,29 @@ function App() {
 }
 
 export default App;
+```
+
+```jsx
+import { useState } from "react";
+import { useOnWindowScroll } from "rooks";
+
+function ScrollTracker() {
+  const [events, setEvents] = useState(0);
+  const [enabled, setEnabled] = useState(true);
+
+  useOnWindowScroll(() => {
+    setEvents((current) => current + 1);
+  }, enabled);
+
+  return (
+    <div>
+      <button onClick={() => setEnabled((current) => !current)}>
+        {enabled ? "Pause scroll tracking" : "Resume scroll tracking"}
+      </button>
+      <p>Scroll events recorded: {events}</p>
+    </div>
+  );
+}
 ```
 
 ### Arguments

--- a/apps/website/content/docs/hooks/(experimental)/useDisposable.mdx
+++ b/apps/website/content/docs/hooks/(experimental)/useDisposable.mdx
@@ -36,18 +36,45 @@ function ChatRoom() {
 }
 ```
 
+### Recreate a disposable resource when dependencies change
+
+```tsx
+import { useState } from "react";
+import { useDisposable } from "rooks/experimental";
+
+class UserScopedStore {
+  constructor(public userId: string) {}
+
+  [Symbol.dispose]() {
+    // clean up user-specific resources
+  }
+}
+
+export default function UserStorePanel() {
+  const [userId, setUserId] = useState("alice");
+  const store = useDisposable(() => new UserScopedStore(userId), [userId]);
+
+  return (
+    <div>
+      <button onClick={() => setUserId("bob")}>Switch user</button>
+      <p>Active store: {store.userId}</p>
+    </div>
+  );
+}
+```
+
 ## Arguments
 
-| Argument | Type | Description | Default value |
-| -------- | ---- | ----------- | ------------- |
-| `factory` | `() => T` | Function that creates the disposable resource | required |
-| `deps` | `DependencyList` | Dependency array controlling when the resource is replaced | `[]` |
+| Argument  | Type             | Description                                                | Default value |
+| --------- | ---------------- | ---------------------------------------------------------- | ------------- |
+| `factory` | `() => T`        | Function that creates the disposable resource              | required      |
+| `deps`    | `DependencyList` | Dependency array controlling when the resource is replaced | `[]`          |
 
 ## Return value
 
-| Return value | Type | Description |
-| ------------ | ---- | ----------- |
-| `resource` | `T` | The disposable resource, available synchronously on every render |
+| Return value | Type | Description                                                      |
+| ------------ | ---- | ---------------------------------------------------------------- |
+| `resource`   | `T`  | The disposable resource, available synchronously on every render |
 
 ## Notes
 

--- a/apps/website/content/docs/hooks/(form)/useFileDropRef.mdx
+++ b/apps/website/content/docs/hooks/(form)/useFileDropRef.mdx
@@ -10,10 +10,46 @@ Drop files easily
 
 ## Examples
 
+### Basic usage
+
 ```tsx
 import { useFileDropRef } from "rooks";
+
 export default function App() {
   useFileDropRef();
   return null;
+}
+```
+
+### Validate files before accepting them
+
+```tsx
+import { useState } from "react";
+import { useFileDropRef } from "rooks";
+
+export default function ImageDropZone() {
+  const [accepted, setAccepted] = useState([]);
+  const [rejected, setRejected] = useState([]);
+
+  const ref = useFileDropRef(
+    {
+      accept: ["image/png", "image/jpeg"],
+      maxFiles: 3,
+    },
+    {
+      onFileAccepted: (file) =>
+        setAccepted((current) => [...current, file.name]),
+      onFileRejected: (file) =>
+        setRejected((current) => [...current, file.name]),
+    }
+  );
+
+  return (
+    <div ref={ref}>
+      <p>Drop images here</p>
+      <p>Accepted: {accepted.join(", ") || "none"}</p>
+      <p>Rejected: {rejected.join(", ") || "none"}</p>
+    </div>
+  );
 }
 ```

--- a/apps/website/content/docs/hooks/(lifecycle)/useDocumentTitle.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useDocumentTitle.mdx
@@ -14,26 +14,6 @@ Sets the document title and optionally resets the title on unmount
 
 ### Basic example
 
-````jsx
-import { useDocumentTitle } from "rooks";
-
-function App() {
-  useDocumentTitle("New document title");
-
-  return (
-    <div>
-      <h1>Document title is now "New document title"</h1>
-    </div>
-  );
-}
-
-export default App;
-
-
-## Examples
-
-### Basic example
-
 ```jsx
 import { useDocumentTitle } from "rooks";
 
@@ -48,8 +28,7 @@ function App() {
 }
 
 export default App;
-
-````
+```
 
 ### Example with reset
 

--- a/apps/website/content/docs/hooks/(lifecycle)/useEffectOnceWhen.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useEffectOnceWhen.mdx
@@ -12,6 +12,8 @@ Runs a callback effect atmost one time when a condition becomes true
 
 ## Examples
 
+### Run once when a condition becomes true
+
 ```jsx
 import { useState } from "react";
 import { useEffectOnceWhen } from "rooks";
@@ -40,6 +42,29 @@ const App = () => {
 };
 
 export default App;
+```
+
+### Trigger one-time setup after a feature is enabled
+
+```jsx
+import { useState } from "react";
+import { useEffectOnceWhen } from "rooks";
+
+export default function WelcomeToast() {
+  const [isEnabled, setIsEnabled] = useState(false);
+  const [toast, setToast] = useState("Not enabled");
+
+  useEffectOnceWhen(() => {
+    setToast("Feature enabled for the first time");
+  }, isEnabled);
+
+  return (
+    <div>
+      <button onClick={() => setIsEnabled(true)}>Enable feature</button>
+      <p>{toast}</p>
+    </div>
+  );
+}
 ```
 
 ### Arguments

--- a/apps/website/content/docs/hooks/(state)/useSelect.mdx
+++ b/apps/website/content/docs/hooks/(state)/useSelect.mdx
@@ -13,7 +13,6 @@ Select values from a list easily. List selection hook for react.
 ### Basic usage
 
 ```jsx
-import "./styles.css";
 import { useSelect } from "rooks";
 
 const list = [
@@ -57,6 +56,28 @@ export default function App() {
         </button>
       ))}
       <p>{item.content}</p>
+    </div>
+  );
+}
+```
+
+### Keep the selected item in sync with external controls
+
+```jsx
+import { useSelect } from "rooks";
+
+const filters = ["all", "open", "done"];
+
+export default function FilterPicker() {
+  const { index, item, setIndex, setItem } = useSelect(filters, 0);
+
+  return (
+    <div>
+      <p>
+        Selected filter: {item} (index {index})
+      </p>
+      <button onClick={() => setIndex(1)}>Open</button>
+      <button onClick={() => setItem("done")}>Done</button>
     </div>
   );
 }

--- a/apps/website/content/docs/hooks/(state)/useSelectableList.mdx
+++ b/apps/website/content/docs/hooks/(state)/useSelectableList.mdx
@@ -12,9 +12,10 @@ Easily select a single value from a list of values. very useful for radio button
 
 ## Examples
 
+### Pizza topping selector
+
 ```jsx
 import { useEffect, useState } from "react";
-import "./styles.css";
 import { useSelectableList } from "rooks";
 import { createGlobalStyle } from "styled-components";
 
@@ -106,10 +107,8 @@ export const toppings = [
 
 export default function App() {
   const [total, setTotal] = useState(0);
-  const [
-    selection,
-    { matchSelection, toggleSelection, updateSelection },
-  ] = useSelectableList(toppings, 0);
+  const [selection, { matchSelection, toggleSelection, updateSelection }] =
+    useSelectableList(toppings, 0);
 
   useEffect(() => {
     setTotal(selection[1].price);
@@ -146,6 +145,39 @@ export default function App() {
           </div>
         </li>
       </ul>
+    </div>
+  );
+}
+```
+
+### Allow clearing the current selection
+
+```jsx
+import { useSelectableList } from "rooks";
+
+const statuses = ["draft", "review", "published"];
+
+export default function StatusPicker() {
+  const [selection, { toggleSelection, matchSelection }] = useSelectableList(
+    statuses,
+    0,
+    true
+  );
+
+  return (
+    <div>
+      {statuses.map((status) => (
+        <button
+          key={status}
+          onClick={toggleSelection({ value: status })}
+          style={{
+            fontWeight: matchSelection({ value: status }) ? "bold" : "normal",
+          }}
+        >
+          {status}
+        </button>
+      ))}
+      <p>Current selection: {selection[1] ?? "none"}</p>
     </div>
   );
 }

--- a/apps/website/content/docs/hooks/(state)/useSessionstorageState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useSessionstorageState.mdx
@@ -44,24 +44,24 @@ export default function UserProfile() {
     email: "",
     preferences: {
       theme: "light",
-      notifications: true
-    }
+      notifications: true,
+    },
   });
 
   const updateUser = (field, value) => {
-    setUser(prev => ({
+    setUser((prev) => ({
       ...prev,
-      [field]: value
+      [field]: value,
     }));
   };
 
   const updatePreferences = (pref, value) => {
-    setUser(prev => ({
+    setUser((prev) => ({
       ...prev,
       preferences: {
         ...prev.preferences,
-        [pref]: value
-      }
+        [pref]: value,
+      },
     }));
   };
 
@@ -98,18 +98,18 @@ export default function UserProfile() {
 }
 ```
 
-#### Cross-window synchronization with remove functionality
+#### Cross-window synchronization for shared drafts
 
 ```jsx
 import { useSessionstorageState } from "rooks";
 
 export default function SyncDemo() {
-  const [message, setMessage, removeMessage] = useSessionstorageState(
-    "sync-message", 
+  const [message, setMessage] = useSessionstorageState(
+    "sync-message",
     "Hello World"
   );
   const [lastUpdated, setLastUpdated] = useSessionstorageState(
-    "last-updated", 
+    "last-updated",
     Date.now()
   );
 
@@ -118,8 +118,8 @@ export default function SyncDemo() {
     setLastUpdated(Date.now());
   };
 
-  const clearAll = () => {
-    removeMessage();
+  const clearDraft = () => {
+    setMessage("");
     setLastUpdated(Date.now());
   };
 
@@ -127,29 +127,30 @@ export default function SyncDemo() {
     <div>
       <h2>Cross-Window Sync Demo</h2>
       <p>Open this page in multiple tabs to see real-time synchronization!</p>
-      
+
       <div>
         <strong>Current Message:</strong> {message || "No message"}
       </div>
       <div>
-        <strong>Last Updated:</strong> {new Date(lastUpdated).toLocaleTimeString()}
+        <strong>Last Updated:</strong>{" "}
+        {new Date(lastUpdated).toLocaleTimeString()}
       </div>
-      
+
       <input
         value={message || ""}
         onChange={(e) => updateMessage(e.target.value)}
         placeholder="Type a message..."
       />
-      
+
       <button onClick={() => updateMessage("Updated from tab!")}>
         Update Message
       </button>
-      <button onClick={clearAll}>
-        Clear Message
-      </button>
-      
+      <button onClick={clearDraft}>Clear Draft</button>
+
       <p>
-        <em>Try changing the message in one tab and watch it update in others!</em>
+        <em>
+          Try changing the draft in one tab and watch it update in others!
+        </em>
       </p>
     </div>
   );
@@ -158,44 +159,49 @@ export default function SyncDemo() {
 
 ### Arguments
 
-| Argument     | Type              | Description                                    | Default |
-| ------------ | ----------------- | ---------------------------------------------- | ------- |
-| key          | string            | The sessionStorage key to use for persistence | -       |
-| initialState | S \| (() => S)    | Initial state value or function that returns initial state | -       |
+| Argument     | Type           | Description                                                | Default |
+| ------------ | -------------- | ---------------------------------------------------------- | ------- |
+| key          | string         | The sessionStorage key to use for persistence              | -       |
+| initialState | S \| (() => S) | Initial state value or function that returns initial state | -       |
 
 ### Returns
 
 Returns an array with three elements:
 
-| Return value | Type                        | Description                                           |
-| ------------ | --------------------------- | ----------------------------------------------------- |
-| value        | S                           | Current state value, synchronized with sessionStorage |
+| Return value | Type                          | Description                                           |
+| ------------ | ----------------------------- | ----------------------------------------------------- |
+| value        | S                             | Current state value, synchronized with sessionStorage |
 | setValue     | `Dispatch<SetStateAction<S>>` | Function to update the state (similar to useState)    |
-| remove       | () => void                  | Function to remove the item from sessionStorage       |
+| remove       | () => void                    | Function to remove the item from sessionStorage       |
 
 ### Features
 
 #### Automatic Persistence
+
 - State changes are automatically saved to sessionStorage
 - Values are JSON serialized/deserialized automatically
 - Handles complex objects, arrays, and primitive values
 
 #### Cross-Window Synchronization
+
 - Changes in one browser tab/window automatically sync to other tabs/windows
 - Uses native `storage` events for cross-document communication
 - Real-time updates without page refresh
 
 #### Within-Document Synchronization
+
 - Multiple instances of the same hook with the same key stay synchronized
 - Uses custom events for efficient within-document communication
 - Prevents infinite update loops
 
 #### Error Handling
+
 - Gracefully handles JSON parsing errors
 - Safe fallback when sessionStorage is unavailable (SSR)
 - Console warnings for debugging in non-browser environments
 
 #### Memory Management
+
 - Automatically cleans up event listeners on unmount
 - Optimized re-renders using useCallback and useRef
 - No memory leaks from event listeners

--- a/apps/website/content/docs/hooks/(ui)/useDimensionsRef.mdx
+++ b/apps/website/content/docs/hooks/(ui)/useDimensionsRef.mdx
@@ -12,6 +12,8 @@ Easily grab dimensions of an element with a ref using this hook
 
 ## Examples
 
+### Basic measurement
+
 ```jsx
 import { useDimensionsRef } from "rooks";
 
@@ -33,6 +35,29 @@ export default function App() {
         <br />
         dimensions.width: {dimensions?.width}px
       </div>
+    </div>
+  );
+}
+```
+
+### Access the tracked node as well as its dimensions
+
+```jsx
+import { useDimensionsRef } from "rooks";
+
+export default function PreviewCard() {
+  const [ref, dimensions, node] = useDimensionsRef();
+
+  return (
+    <div>
+      <div
+        ref={ref}
+        style={{ width: 240, padding: 16, border: "1px solid #ccc" }}
+      >
+        Preview
+      </div>
+      <p>Width: {dimensions?.width ?? 0}px</p>
+      <p>Tracking node: {node ? node.tagName.toLowerCase() : "none"}</p>
     </div>
   );
 }

--- a/apps/website/content/docs/hooks/(utilities)/useEventListenerRef.mdx
+++ b/apps/website/content/docs/hooks/(utilities)/useEventListenerRef.mdx
@@ -21,7 +21,7 @@ import "./styles.css";
 
 export default function App() {
   const [value, setValue] = useState(0);
-  const ref = useEventListenerRef("click", function() {
+  const ref = useEventListenerRef("click", function () {
     setValue(value + 1);
   });
   return (
@@ -37,6 +37,22 @@ export default function App() {
       <p> Value is {value}</p>
     </div>
   );
+}
+```
+
+### Attach a listener to a specific interactive element
+
+```jsx
+import { useState } from "react";
+import { useEventListenerRef } from "rooks";
+
+export default function ClickTracker() {
+  const [clicks, setClicks] = useState(0);
+  const ref = useEventListenerRef("click", () => {
+    setClicks((current) => current + 1);
+  });
+
+  return <button ref={ref}>Button clicks tracked by the hook: {clicks}</button>;
 }
 ```
 

--- a/apps/website/content/docs/hooks/(utilities)/useRefElement.mdx
+++ b/apps/website/content/docs/hooks/(utilities)/useRefElement.mdx
@@ -10,10 +10,11 @@ Helps bridge gap between callback ref and state. Manages the element called with
 
 ## Examples
 
+### Attach an event listener to the current element
+
 ```jsx
 import { useEffect, useState } from "react";
 import { useRefElement } from "rooks";
-import "./styles.css";
 
 function useEventListenerRef(eventName, callback) {
   const [ref, element] = useRefElement();
@@ -33,7 +34,7 @@ function useEventListenerRef(eventName, callback) {
 
 export default function App() {
   const [value, setValue] = useState(0);
-  const ref = useEventListenerRef("click", function() {
+  const ref = useEventListenerRef("click", function () {
     setValue(value + 1);
   });
 
@@ -54,6 +55,23 @@ export default function App() {
 }
 ```
 
+### Read the current element from the callback ref
+
+```jsx
+import { useRefElement } from "rooks";
+
+export default function CurrentElementPreview() {
+  const [ref, element] = useRefElement();
+
+  return (
+    <div>
+      <button ref={ref}>Focusable trigger</button>
+      <p>Current tag: {element?.tagName ?? "none"}</p>
+    </div>
+  );
+}
+```
+
 ### Arguments
 
 No arguments.
@@ -63,4 +81,4 @@ No arguments.
 | Returned items | Type                                        | Description                   |
 | -------------- | ------------------------------------------- | ----------------------------- |
 | ref            | `(refElement: RefElementOrNull<T>) => void` | The callback ref              |
-| element        | `RefElementOrNull&lt;T&gt;`                       | The element linked to the ref |
+| element        | `RefElementOrNull&lt;T&gt;`                 | The element linked to the ref |

--- a/packages/rooks/src/__tests__/useOnWindowResize.spec.ts
+++ b/packages/rooks/src/__tests__/useOnWindowResize.spec.ts
@@ -20,5 +20,15 @@ describe("useOnWindowResize", () => {
       fireEvent(window, new Event("resize"));
       expect(mockCallback.mock.calls).toHaveLength(3);
     });
+
+    it("should not call callback when disabled", () => {
+      expect.hasAssertions();
+      const disabledCallback = vi.fn(() => {});
+      renderHook(() => useOnWindowResize(disabledCallback, false));
+
+      fireEvent(window, new Event("resize"));
+
+      expect(disabledCallback).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/rooks/src/__tests__/useOnWindowScroll.spec.ts
+++ b/packages/rooks/src/__tests__/useOnWindowScroll.spec.ts
@@ -20,5 +20,15 @@ describe("useOnWindowScroll", () => {
       fireEvent(window, new Event("scroll"));
       expect(mockCallback.mock.calls).toHaveLength(3);
     });
+
+    it("should not call callback when disabled", () => {
+      expect.hasAssertions();
+      const disabledCallback = vi.fn(() => {});
+      renderHook(() => useOnWindowScroll(disabledCallback, false));
+
+      fireEvent(window, new Event("scroll"));
+
+      expect(disabledCallback).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/rooks/src/__tests__/useRaf.spec.tsx
+++ b/packages/rooks/src/__tests__/useRaf.spec.tsx
@@ -1,6 +1,16 @@
-import { render } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import React, { useRef } from "react";
 import { useRaf } from "@/hooks/useRaf";
+import { vi } from "vitest";
+
+vi.mock("raf", () => {
+  const raf = (cb: (time: number) => void) => {
+    setTimeout(() => cb(Date.now()), 16);
+    return 1;
+  };
+  raf.cancel = vi.fn();
+  return { default: raf };
+});
 
 describe("useRaf", () => {
   let TestJSX = () => <canvas />;
@@ -44,6 +54,11 @@ describe("useRaf", () => {
 
   beforeEach(() => {
     TestJSX = App;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("should be defined", () => {
@@ -55,5 +70,31 @@ describe("useRaf", () => {
     expect.hasAssertions();
     const { container } = render(<TestJSX />);
     expect(container).toBeDefined();
+  });
+
+  it("should call the callback while active", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+
+    renderHook(() => useRaf(callback, true));
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it("should not call the callback when inactive", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+
+    renderHook(() => useRaf(callback, false));
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/packages/rooks/src/__tests__/useRefElement.spec.tsx
+++ b/packages/rooks/src/__tests__/useRefElement.spec.tsx
@@ -1,0 +1,46 @@
+import { act, renderHook } from "@testing-library/react";
+import { useRefElement } from "@/hooks/useRefElement";
+
+describe("useRefElement", () => {
+  it("should expose the current element after the callback ref is called", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useRefElement<HTMLButtonElement>());
+    const button = document.createElement("button");
+
+    act(() => {
+      result.current[0](button);
+    });
+
+    expect(result.current[1]).toBe(button);
+  });
+
+  it("should clear the current element when the ref receives null", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useRefElement<HTMLDivElement>());
+    const div = document.createElement("div");
+
+    act(() => {
+      result.current[0](div);
+    });
+
+    expect(result.current[1]).toBe(div);
+
+    act(() => {
+      result.current[0](null);
+    });
+
+    expect(result.current[1]).toBeNull();
+  });
+
+  it("should keep the callback ref stable across rerenders", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(() =>
+      useRefElement<HTMLDivElement>()
+    );
+
+    const firstRef = result.current[0];
+    rerender();
+
+    expect(result.current[0]).toBe(firstRef);
+  });
+});

--- a/packages/rooks/src/__tests__/useResizeObserverRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useResizeObserverRef.spec.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+import { useResizeObserverRef } from "@/hooks/useResizeObserverRef";
+
+const observe = vi.fn();
+const disconnect = vi.fn();
+let resizeCallback: ResizeObserverCallback | null = null;
+
+describe("useResizeObserverRef", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resizeCallback = null;
+
+    global.ResizeObserver = vi.fn().mockImplementation(function (
+      callback: ResizeObserverCallback
+    ) {
+      resizeCallback = callback;
+      return {
+        observe,
+        disconnect,
+      };
+    }) as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should observe the attached element", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { result } = renderHook(() => useResizeObserverRef(callback));
+    const element = document.createElement("div");
+
+    act(() => {
+      result.current[0](element);
+    });
+
+    expect(observe).toHaveBeenCalledWith(element, { box: "content-box" });
+  });
+
+  it("should forward resize entries to the latest callback", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { result } = renderHook(() => useResizeObserverRef(callback));
+    const element = document.createElement("div");
+
+    act(() => {
+      result.current[0](element);
+    });
+
+    const entry = {
+      target: element,
+      contentRect: { width: 240, height: 120 },
+    } as ResizeObserverEntry;
+    const observer = {} as ResizeObserver;
+
+    act(() => {
+      resizeCallback?.([entry], observer);
+    });
+
+    expect(callback).toHaveBeenCalledWith([entry], observer);
+  });
+
+  it("should disconnect the observer on unmount", () => {
+    expect.hasAssertions();
+    const { result, unmount } = renderHook(() => useResizeObserverRef(vi.fn()));
+    const element = document.createElement("div");
+
+    act(() => {
+      result.current[0](element);
+    });
+
+    unmount();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/packages/rooks/src/__tests__/useSelect.spec.ts
+++ b/packages/rooks/src/__tests__/useSelect.spec.ts
@@ -31,4 +31,16 @@ describe("useSelect", () => {
     expect(result.current.index).toBe(2);
     expect(result.current.item).toBe(5);
   });
+
+  it("should update the selected index directly", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useSelect(["all", "open", "done"], 0));
+
+    act(() => {
+      result.current.setIndex(1);
+    });
+
+    expect(result.current.index).toBe(1);
+    expect(result.current.item).toBe("open");
+  });
 });


### PR DESCRIPTION
## Summary
- expand canonical docs examples for a wide range of hooks spanning multiple categories
- repair the malformed `useDocumentTitle` docs page
- add test coverage for useOnWindowResize, useOnWindowScroll, useRaf, useRefElement, useResizeObserverRef, and useSelect

## Hooks changed

### Animation
- useRaf
- useResizeObserverRef

### Browser
- useNotification
- useOnline
- useOrientation

### Events
- useDocumentEventListener
- useDocumentVisibilityState
- useOnLongPress
- useOnWindowResize
- useOnWindowScroll

### Experimental
- useDisposable

### Form
- useFileDropRef

### Lifecycle
- useDocumentTitle
- useEffectOnceWhen

### State
- useSelect
- useSelectableList
- useSessionstorageState

### UI
- useDimensionsRef

### Utilities
- useEventListenerRef
- useRefElement

## Test plan
- pnpm --filter rooks exec vitest run src/__tests__/useOnWindowResize.spec.ts src/__tests__/useOnWindowScroll.spec.ts src/__tests__/useRaf.spec.tsx src/__tests__/useRefElement.spec.tsx src/__tests__/useResizeObserverRef.spec.tsx src/__tests__/useSelect.spec.ts