### PR TITLE
Add docs examples and coverage for useGlobalObjectEventListener, useIsDroppingFiles, useKeyBindings

### DIFF
--- a/apps/website/content/docs/hooks/(events)/useGlobalObjectEventListener.mdx
+++ b/apps/website/content/docs/hooks/(events)/useGlobalObjectEventListener.mdx
@@ -1,0 +1,57 @@
+---
+id: useGlobalObjectEventListener
+title: useGlobalObjectEventListener
+sidebar_label: useGlobalObjectEventListener
+---
+
+## About
+
+Attach an event listener to `window` or `document` and keep the callback fresh across rerenders.
+
+## Examples
+
+### Listen for window resize events
+
+```tsx
+import { useState } from "react";
+import { useGlobalObjectEventListener } from "rooks";
+
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  useGlobalObjectEventListener(window, "resize", () =>
+    setCount((current) => current + 1)
+  );
+
+  return <p>Resize events handled: {count}</p>;
+}
+```
+
+### Conditionally subscribe to document visibility changes
+
+```tsx
+import { useState } from "react";
+import { useGlobalObjectEventListener } from "rooks";
+
+export default function App() {
+  const [enabled, setEnabled] = useState(true);
+  const [message, setMessage] = useState("Waiting for visibility changes");
+
+  useGlobalObjectEventListener(
+    document,
+    "visibilitychange",
+    () => setMessage(`Document is ${document.visibilityState}`),
+    {},
+    enabled
+  );
+
+  return (
+    <div>
+      <button onClick={() => setEnabled((current) => !current)}>
+        Toggle listener
+      </button>
+      <p>{message}</p>
+    </div>
+  );
+}
+```

--- a/apps/website/content/docs/hooks/(events)/useIsDroppingFiles.mdx
+++ b/apps/website/content/docs/hooks/(events)/useIsDroppingFiles.mdx
@@ -6,14 +6,47 @@ sidebar_label: useIsDroppingFiles
 
 ## About
 
-Check if any files are currently being dropped anywhere. Useful for highlighting drop areas.
+Check if files are currently being dragged over an element or the window.
 
 ## Examples
 
+### Highlight a local drop zone
+
 ```tsx
 import { useIsDroppingFiles } from "rooks";
+
 export default function App() {
-  useIsDroppingFiles();
-  return null;
+  const [ref, isDropping] = useIsDroppingFiles();
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        padding: 24,
+        border: "2px dashed #999",
+        background: isDropping ? "#fee2e2" : "#fff",
+      }}
+    >
+      {isDropping ? "Release files to upload" : "Drag files here"}
+    </div>
+  );
+}
+```
+
+### Track file drags anywhere in the window
+
+```tsx
+import { useIsDroppingFiles } from "rooks";
+
+export default function App() {
+  const isDroppingOnWindow = useIsDroppingFiles(true);
+
+  return (
+    <p>
+      {isDroppingOnWindow
+        ? "Files are hovering over the window"
+        : "No files are being dragged right now"}
+    </p>
+  );
 }
 ```

--- a/apps/website/content/docs/hooks/(keyboard)/useKeyBindings.mdx
+++ b/apps/website/content/docs/hooks/(keyboard)/useKeyBindings.mdx
@@ -6,30 +6,59 @@ sidebar_label: useKeyBindings
 
 ## About
 
-useKeyBindings can bind pairs of keyboard events and handlers.
+Bind keys to callbacks on the document or a specific target element.
 
 [//]: # "Main"
 
 ## Examples
 
+### Bind shortcuts on the document
+
 ```jsx
-import "./styles.css";
 import { useKeyBindings, useCounter } from "rooks";
 
 export default function App() {
-  const { value, increment, incrementBy, decrementBy, reset } = useCounter(0);
-  const cb1 = () => increment();
-  const cb2 = () => decrementBy(3);
-  const cb3 = () => incrementBy(5);
-  const cb4 = () => reset();
+  const { value, increment, decrementBy, incrementBy, reset } = useCounter(0);
 
-  useKeyBindings({ a: cb1, b: cb2, Enter: cb3, Escape: cb4 });
+  useKeyBindings({
+    a: increment,
+    b: () => decrementBy(3),
+    Enter: () => incrementBy(5),
+    Escape: reset,
+  });
 
   return (
     <div>
       <p>
-        Counter value is : <strong>{value}</strong>
+        Counter value is: <strong>{value}</strong>
       </p>
+    </div>
+  );
+}
+```
+
+### Scope key bindings to a specific input
+
+```jsx
+import { useRef, useState } from "react";
+import { useKeyBindings } from "rooks";
+
+export default function App() {
+  const inputRef = useRef(null);
+  const [value, setValue] = useState(0);
+
+  useKeyBindings(
+    {
+      r: () => setValue((current) => current + 1),
+      v: () => setValue((current) => current + 1),
+    },
+    { target: inputRef }
+  );
+
+  return (
+    <div>
+      <input ref={inputRef} placeholder="Focus me and press R or V" />
+      <p>Scoped key presses handled: {value}</p>
     </div>
   );
 }
@@ -37,7 +66,7 @@ export default function App() {
 
 ### Arguments
 
-| Argument    | Type    | Description                           | Default value |
-| ----------- | ------- | ------------------------------------- | ------------- |
-| keyBindings | Object  | pairs of keyboard events and handlers | {}            |
-| options     | Options | refer to useKey                       | {}            |
+| Argument      | Type      | Description                            | Default value |
+| ------------- | --------- | -------------------------------------- | ------------- |
+| `keyBindings` | `Object`  | Pairs of keyboard events and handlers  | `{}`          |
+| `options`     | `Options` | Listener options forwarded to `useKey` | `{}`          |

--- a/packages/rooks/src/__tests__/useGlobalObjectEventListener.spec.ts
+++ b/packages/rooks/src/__tests__/useGlobalObjectEventListener.spec.ts
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+import { useGlobalObjectEventListener } from "@/hooks/useGlobalObjectEventListener";
+
+describe("useGlobalObjectEventListener", () => {
+  it("attaches and removes a window listener when enabled", () => {
+    expect.hasAssertions();
+    const addEventListener = vi.spyOn(window, "addEventListener");
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+    const callback = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useGlobalObjectEventListener(window, "resize", callback)
+    );
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function),
+      {}
+    );
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function),
+      {}
+    );
+  });
+
+  it("does not attach a listener when disabled", () => {
+    expect.hasAssertions();
+    const addEventListener = vi.spyOn(document, "addEventListener");
+    const callback = vi.fn();
+
+    renderHook(() =>
+      useGlobalObjectEventListener(
+        document,
+        "visibilitychange",
+        callback,
+        {},
+        false
+      )
+    );
+
+    expect(addEventListener).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add the missing canonical docs page for `useGlobalObjectEventListener`
- expand examples for `useIsDroppingFiles` and `useKeyBindings`
- add direct coverage for `useGlobalObjectEventListener`

## Hooks changed
- useGlobalObjectEventListener
- useIsDroppingFiles
- useKeyBindings

## Test plan
- pnpm --filter rooks exec vitest run src/__tests__/useGlobalObjectEventListener.spec.ts