### PR TITLE
feat: add useUpdate hook

### DIFF
--- a/apps/website/content/docs/hooks/(state)/useUpdate.mdx
+++ b/apps/website/content/docs/hooks/(state)/useUpdate.mdx
@@ -1,0 +1,99 @@
+---
+id: useUpdate
+title: useUpdate
+sidebar_label: useUpdate
+---
+
+## About
+
+Returns a stable function that forces the component to re-render when called.
+Intended for **imperative integrations** — cases where state lives outside React
+(e.g. MobX observables, `EventEmitter` callbacks, WebSocket handlers, canvas
+animation loops) and you need to tell React to pull fresh data without lifting
+that state into `useState`.
+
+:::warning
+Calling the update function schedules an extra render. Overuse can cause
+unnecessary re-renders and hurt performance. Prefer `useState` or `useReducer`
+when the data you are syncing _can_ live in React state. Reserve `useUpdate`
+for truly external, non-serialisable sources that cannot be wrapped in React
+state.
+:::
+
+<br />
+
+## Examples
+
+### Syncing with an external store
+
+```jsx
+import { useEffect } from "react";
+import { useUpdate } from "rooks";
+
+// An external store that lives outside React
+const store = {
+  count: 0,
+  listeners: new Set(),
+  increment() {
+    this.count++;
+    this.listeners.forEach((fn) => fn());
+  },
+  subscribe(fn) {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  },
+};
+
+export default function App() {
+  const update = useUpdate();
+
+  useEffect(() => {
+    // Re-render whenever the external store changes
+    const unsubscribe = store.subscribe(update);
+    return unsubscribe;
+  }, [update]);
+
+  return (
+    <div>
+      <p>External store count: {store.count}</p>
+      <button onClick={() => store.increment()}>Increment store</button>
+    </div>
+  );
+}
+```
+
+### Forcing a re-read of a mutable ref
+
+```jsx
+import { useRef } from "react";
+import { useUpdate } from "rooks";
+
+export default function MutableRefDisplay() {
+  const update = useUpdate();
+  const valueRef = useRef(0);
+
+  function handleClick() {
+    valueRef.current += 1;
+    update(); // React won't see the mutation unless we re-render manually
+  }
+
+  return (
+    <div>
+      <p>Ref value: {valueRef.current}</p>
+      <button onClick={handleClick}>Increment ref</button>
+    </div>
+  );
+}
+```
+
+## Arguments
+
+_No arguments._
+
+## Return value
+
+| Return value | Type         | Description                                                                               |
+| ------------ | ------------ | ----------------------------------------------------------------------------------------- |
+| update       | `() => void` | A stable callback (via `useCallback`) that increments a dummy counter to force a re-render. The reference is stable across renders. |
+
+---

--- a/packages/rooks/src/__tests__/useUpdate.spec.tsx
+++ b/packages/rooks/src/__tests__/useUpdate.spec.tsx
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { useUpdate } from "../hooks/useUpdate";
+
+describe("useUpdate", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useUpdate).toBeDefined();
+  });
+
+  it("should return a function", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useUpdate());
+
+    expect(typeof result.current).toBe("function");
+  });
+
+  it("should trigger a re-render when called", () => {
+    expect.hasAssertions();
+    let renderCount = 0;
+
+    const { result } = renderHook(() => {
+      renderCount++;
+      return useUpdate();
+    });
+
+    const countAfterMount = renderCount;
+
+    act(() => {
+      result.current();
+    });
+
+    expect(renderCount).toBeGreaterThan(countAfterMount);
+  });
+
+  it("should trigger multiple re-renders on multiple calls", () => {
+    expect.hasAssertions();
+    let renderCount = 0;
+
+    const { result } = renderHook(() => {
+      renderCount++;
+      return useUpdate();
+    });
+
+    const countAfterMount = renderCount;
+
+    act(() => {
+      result.current();
+    });
+    act(() => {
+      result.current();
+    });
+
+    expect(renderCount).toBeGreaterThanOrEqual(countAfterMount + 2);
+  });
+
+  it("should maintain a stable function reference across re-renders", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(() => useUpdate());
+
+    const initialUpdate = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(initialUpdate);
+  });
+
+  it("should maintain a stable function reference after calling update", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useUpdate());
+
+    const updateBeforeCall = result.current;
+
+    act(() => {
+      result.current();
+    });
+
+    expect(result.current).toBe(updateBeforeCall);
+  });
+
+  it("should work correctly when called in rapid succession", () => {
+    expect.hasAssertions();
+    let renderCount = 0;
+
+    const { result } = renderHook(() => {
+      renderCount++;
+      return useUpdate();
+    });
+
+    const countAfterMount = renderCount;
+
+    act(() => {
+      result.current();
+      result.current();
+      result.current();
+    });
+
+    expect(renderCount).toBeGreaterThan(countAfterMount);
+  });
+});

--- a/packages/rooks/src/hooks/useUpdate.ts
+++ b/packages/rooks/src/hooks/useUpdate.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from "react";
+
+/**
+ * useUpdate hook
+ *
+ * Returns a function that forces the component to re-render when called.
+ * Useful for integrating imperative APIs or subscriptions that live outside
+ * of React's state model (e.g. MobX stores, EventEmitter callbacks, WebSocket
+ * message handlers).
+ *
+ * @returns {() => void} A stable callback that increments a dummy counter,
+ *   triggering a re-render. The function reference is stable across renders.
+ * @see https://rooks.vercel.app/docs/hooks/useUpdate
+ * @example
+ * const update = useUpdate();
+ *
+ * useEffect(() => {
+ *   const subscription = externalStore.subscribe(() => {
+ *     update(); // tell React to re-render and pull fresh data
+ *   });
+ *   return () => subscription.unsubscribe();
+ * }, [update]);
+ */
+function useUpdate(): () => void {
+  const [, setState] = useState(0);
+
+  const update = useCallback(() => {
+    setState((n) => n + 1);
+  }, []);
+
+  return update;
+}
+
+export { useUpdate };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -118,6 +118,7 @@ export { useToggle } from "./hooks/useToggle";
 export { useUndoState } from "./hooks/useUndoState";
 export { useTween } from "./hooks/useTween";
 export { useUndoRedoState } from "./hooks/useUndoRedoState";
+export { useUpdate } from "./hooks/useUpdate";
 export { useVibrate } from "./hooks/useVibrate";
 export { useVideo } from "./hooks/useVideo";
 export { useWebLocksApi } from "./hooks/useWebLocksApi";


### PR DESCRIPTION
## Summary

- Adds `useUpdate` — a hook that returns a stable `() => void` callback which forces a component to re-render by incrementing a dummy internal counter
- Intended for imperative integrations where state lives outside React (external stores, `EventEmitter`, WebSocket handlers, canvas loops)
- SSR safe: only uses `useState` + `useCallback`, no browser-only APIs

## Changes

| File | Description |
|---|---|
| `packages/rooks/src/hooks/useUpdate.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useUpdate.spec.tsx` | 7 vitest tests covering basic usage, reference stability, and rapid calls |
| `apps/website/content/docs/hooks/(state)/useUpdate.mdx` | MDX docs with 2 examples and an overuse warning |
| `packages/rooks/src/index.ts` | Named export added in alphabetical order |

## Implementation

```ts
function useUpdate(): () => void {
  const [, setState] = useState(0);
  const update = useCallback(() => {
    setState((n) => n + 1);
  }, []);
  return update;
}
```

## Test plan

- [x] `pnpm exec vitest run src/__tests__/useUpdate.spec.tsx` — 7/7 passing
- [x] Hook is defined and returns a function
- [x] Calling the function triggers a re-render
- [x] Multiple calls trigger multiple re-renders
- [x] Function reference is stable across re-renders (useCallback)
- [x] Function reference is stable after calling update

🤖 Generated with [Claude Code](https://claude.com/claude-code)