### PR TITLE
feat: add useRafState hook

### DIFF
--- a/apps/website/content/docs/hooks/(state)/useRafState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useRafState.mdx
@@ -1,0 +1,90 @@
+---
+id: useRafState
+title: useRafState
+sidebar_label: useRafState
+---
+
+## About
+
+A drop-in replacement for `useState` that batches updates through `requestAnimationFrame`. Ideal for high-frequency event handlers (mouse move, scroll, resize) where calling `setState` on every event would cause layout thrashing. If `setState` is called multiple times before the browser paints the next frame, only the last value is applied. Pending frames are cancelled on unmount. SSR-safe: falls back to synchronous state updates when `requestAnimationFrame` is unavailable.
+
+[//]: # "Main"
+
+## Examples
+
+#### Basic usage — tracking mouse position
+
+```jsx
+import { useEffect } from "react";
+import { useRafState } from "rooks";
+
+export default function App() {
+  const [position, setPosition] = useRafState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      setPosition({ x: e.clientX, y: e.clientY });
+    };
+    window.addEventListener("mousemove", handleMouseMove);
+    return () => window.removeEventListener("mousemove", handleMouseMove);
+  }, [setPosition]);
+
+  return (
+    <p>
+      Mouse: {position.x}, {position.y}
+    </p>
+  );
+}
+```
+
+#### With a lazy initializer
+
+```jsx
+import { useRafState } from "rooks";
+
+export default function App() {
+  const [value, setValue] = useRafState(() => expensiveComputation());
+
+  return <button onClick={() => setValue((prev) => prev + 1)}>{value}</button>;
+}
+```
+
+#### Scroll progress indicator
+
+```jsx
+import { useEffect } from "react";
+import { useRafState } from "rooks";
+
+export default function ScrollProgress() {
+  const [progress, setProgress] = useRafState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+      const total = scrollHeight - clientHeight;
+      setProgress(total > 0 ? (scrollTop / total) * 100 : 0);
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [setProgress]);
+
+  return (
+    <div style={{ width: `${progress}%`, height: 4, background: "blue" }} />
+  );
+}
+```
+
+### Arguments
+
+| Argument     | Type             | Description                                    | Default   |
+| ------------ | ---------------- | ---------------------------------------------- | --------- |
+| initialState | `T \| (() => T)` | Initial state value or lazy initializer function | undefined |
+
+### Returns
+
+Returns a tuple identical in shape to `React.useState`:
+
+| Index | Type                        | Description                                                                      |
+| ----- | --------------------------- | -------------------------------------------------------------------------------- |
+| 0     | `T`                         | Current state value                                                              |
+| 1     | `Dispatch<SetStateAction<T>>` | Setter that queues the update via `requestAnimationFrame`; multiple calls before the next frame apply only the last value |

--- a/packages/rooks/src/__tests__/useRafState.spec.tsx
+++ b/packages/rooks/src/__tests__/useRafState.spec.tsx
@@ -1,0 +1,142 @@
+import { act, renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+import { useRafState } from "@/hooks/useRafState";
+
+describe("useRafState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useRafState).toBeDefined();
+  });
+
+  it("should initialize with the given value", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useRafState(42));
+    expect(result.current[0]).toBe(42);
+  });
+
+  it("should initialize with a lazy initializer function", () => {
+    expect.hasAssertions();
+    const initializer = vi.fn(() => "hello");
+    const { result } = renderHook(() => useRafState(initializer));
+    expect(result.current[0]).toBe("hello");
+    expect(initializer).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return a stable setState function across re-renders", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(() => useRafState(0));
+    const setStateBefore = result.current[1];
+    rerender();
+    const setStateAfter = result.current[1];
+    expect(setStateBefore).toBe(setStateAfter);
+  });
+
+  it("should apply state update after the next animation frame", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useRafState(0));
+
+    act(() => {
+      result.current[1](99);
+    });
+
+    // Value not yet applied — rAF hasn't fired
+    // (fake timers means rAF callback hasn't run synchronously)
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current[0]).toBe(99);
+  });
+
+  it("should only apply the last value when setState is called multiple times before the next frame", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useRafState(0));
+
+    act(() => {
+      result.current[1](1);
+      result.current[1](2);
+      result.current[1](3);
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current[0]).toBe(3);
+  });
+
+  it("should support functional updater form", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useRafState(10));
+
+    act(() => {
+      result.current[1]((prev) => prev + 5);
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current[0]).toBe(15);
+  });
+
+  it("should cancel pending rAF on unmount and not update state", () => {
+    expect.hasAssertions();
+    const { result, unmount } = renderHook(() => useRafState(0));
+    const cancelSpy = vi.spyOn(globalThis, "cancelAnimationFrame");
+
+    act(() => {
+      result.current[1](100);
+    });
+
+    unmount();
+
+    expect(cancelSpy).toHaveBeenCalled();
+    cancelSpy.mockRestore();
+  });
+
+  it("should fall back to synchronous setState when requestAnimationFrame is undefined (SSR)", () => {
+    expect.hasAssertions();
+    const originalRaf = globalThis.requestAnimationFrame;
+    // @ts-expect-error — simulating SSR environment
+    delete globalThis.requestAnimationFrame;
+
+    try {
+      const { result } = renderHook(() => useRafState(0));
+
+      act(() => {
+        result.current[1](77);
+      });
+
+      // No rAF needed — state should be updated synchronously
+      expect(result.current[0]).toBe(77);
+    } finally {
+      globalThis.requestAnimationFrame = originalRaf;
+    }
+  });
+
+  it("should handle object state", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useRafState<{ x: number; y: number }>({ x: 0, y: 0 })
+    );
+
+    act(() => {
+      result.current[1]({ x: 100, y: 200 });
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current[0]).toEqual({ x: 100, y: 200 });
+  });
+});

--- a/packages/rooks/src/hooks/useRafState.ts
+++ b/packages/rooks/src/hooks/useRafState.ts
@@ -1,0 +1,73 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+/**
+ * useRafState
+ *
+ * Like useState but batches updates via requestAnimationFrame to prevent layout
+ * thrashing for high-frequency updates (e.g. mousemove, scroll handlers).
+ * If setState is called multiple times before the next animation frame, only
+ * the last value is applied. Cancels any pending rAF on unmount.
+ * SSR-safe: falls back to synchronous setState when requestAnimationFrame is
+ * not available.
+ *
+ * @param initialState - Initial state value or initializer function
+ * @returns A tuple [state, setState] with identical API to React.useState
+ * @see https://rooks.vercel.app/docs/hooks/useRafState
+ * @example
+ * const [position, setPosition] = useRafState({ x: 0, y: 0 });
+ *
+ * useEffect(() => {
+ *   const handleMouseMove = (e: MouseEvent) => {
+ *     setPosition({ x: e.clientX, y: e.clientY });
+ *   };
+ *   window.addEventListener("mousemove", handleMouseMove);
+ *   return () => window.removeEventListener("mousemove", handleMouseMove);
+ * }, [setPosition]);
+ */
+export function useRafState<T>(
+  initialState: T | (() => T)
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(initialState);
+  const rafIdRef = useRef<number | null>(null);
+  // Wrap in an object so any value of T (including null/undefined) is unambiguous
+  const pendingRef = useRef<{ action: SetStateAction<T> } | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, []);
+
+  const rafSetState: Dispatch<SetStateAction<T>> = useCallback(
+    (action: SetStateAction<T>) => {
+      // SSR guard: requestAnimationFrame is not available on the server
+      if (typeof requestAnimationFrame === "undefined") {
+        setState(action);
+        return;
+      }
+
+      // Always keep only the latest pending action
+      pendingRef.current = { action };
+
+      // If a frame is already scheduled, reuse it
+      if (rafIdRef.current !== null) {
+        return;
+      }
+
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null;
+        if (pendingRef.current !== null) {
+          setState(pendingRef.current.action);
+          pendingRef.current = null;
+        }
+      });
+    },
+    []
+  );
+
+  return [state, rafSetState];
+}

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -97,6 +97,7 @@ export { usePreviousImmediate } from "./hooks/usePreviousImmediate";
 export { usePromise } from "./hooks/usePromise";
 export { useQueueState } from "./hooks/useQueueState";
 export { useRaf } from "./hooks/useRaf";
+export { useRafState } from "./hooks/useRafState";
 export { useResizeObserverRef } from "./hooks/useResizeObserverRef";
 export { useRenderCount } from "./hooks/useRenderCount";
 export { useRefElement } from "./hooks/useRefElement";


### PR DESCRIPTION
## Summary

- Adds `useRafState<T>` — a drop-in `useState` replacement that queues updates through `requestAnimationFrame` to prevent layout thrashing on high-frequency events (mousemove, scroll, resize)
- Multiple `setState` calls before the next frame coalesce: only the last value is applied
- Pending rAF is cancelled on unmount to avoid stale-closure updates
- SSR-safe: falls back to synchronous `setState` when `requestAnimationFrame` is unavailable

## Files changed

| File | Purpose |
|---|---|
| `packages/rooks/src/hooks/useRafState.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useRafState.spec.tsx` | Vitest tests (10 passing) |
| `apps/website/content/docs/hooks/(state)/useRafState.mdx` | MDX documentation |
| `packages/rooks/src/index.ts` | Export added after `useRaf` |

## Test plan

- [x] `useRafState` is defined
- [x] Initialises with a plain value
- [x] Initialises with a lazy function
- [x] `setState` reference is stable across re-renders (`useCallback([])`)
- [x] State updates after `requestAnimationFrame` fires
- [x] Multiple calls before next frame → only last value applied
- [x] Functional updater form (`prev => next`) works correctly
- [x] Pending rAF is cancelled on unmount (`cancelAnimationFrame` called)
- [x] Falls back to synchronous setState when `requestAnimationFrame` is `undefined` (SSR)
- [x] Works with object state
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)