### PR TITLE
feat: add useUpdateEffect and useUpdateLayoutEffect hooks

### DIFF
--- a/apps/website/content/docs/hooks/(lifecycle)/useUpdateEffect.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useUpdateEffect.mdx
@@ -1,0 +1,71 @@
+---
+id: useUpdateEffect
+title: useUpdateEffect
+sidebar_label: useUpdateEffect
+---
+
+## About
+
+Like `useEffect`, but skips the callback on the initial mount. The effect only runs on subsequent re-renders when dependencies change. Accepts the same arguments and return value as React's built-in `useEffect`.
+
+## Examples
+
+### Log a value change after mount
+
+```jsx
+import React, { useState } from "react";
+import { useUpdateEffect } from "rooks";
+
+export default function App() {
+  const [count, setCount] = useState(0);
+
+  useUpdateEffect(() => {
+    console.log("count changed to", count);
+  }, [count]);
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <p>Open the console and click the button to see logs (nothing on first render).</p>
+      <button onClick={() => setCount((c) => c + 1)}>Increment</button>
+    </div>
+  );
+}
+```
+
+### Run cleanup on dependency change
+
+```jsx
+import React, { useState } from "react";
+import { useUpdateEffect } from "rooks";
+
+export default function SubscriptionExample() {
+  const [topic, setTopic] = useState("general");
+
+  useUpdateEffect(() => {
+    const subscription = subscribe(topic);
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [topic]);
+
+  return (
+    <div>
+      <p>Subscribed to: {topic}</p>
+      <button onClick={() => setTopic("sports")}>Switch to sports</button>
+      <button onClick={() => setTopic("tech")}>Switch to tech</button>
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument | Type             | Description                                                      |
+| -------- | ---------------- | ---------------------------------------------------------------- |
+| effect   | `EffectCallback` | Imperative function that can optionally return a cleanup function |
+| deps     | `DependencyList` | Optional array of dependencies that control when the effect runs |
+
+### Returns
+
+`void`

--- a/apps/website/content/docs/hooks/(lifecycle)/useUpdateLayoutEffect.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useUpdateLayoutEffect.mdx
@@ -1,0 +1,87 @@
+---
+id: useUpdateLayoutEffect
+title: useUpdateLayoutEffect
+sidebar_label: useUpdateLayoutEffect
+---
+
+## About
+
+Like `useLayoutEffect`, but skips the callback on the initial mount. The effect only runs on subsequent re-renders when dependencies change. Uses the isomorphic effect pattern internally, so it is safe to use in SSR environments. Accepts the same arguments and return value as React's built-in `useLayoutEffect`.
+
+## Examples
+
+### Measure DOM element on update
+
+```jsx
+import React, { useRef, useState } from "react";
+import { useUpdateLayoutEffect } from "rooks";
+
+export default function App() {
+  const ref = useRef(null);
+  const [text, setText] = useState("Hello");
+  const [width, setWidth] = useState(null);
+
+  useUpdateLayoutEffect(() => {
+    if (ref.current) {
+      setWidth(ref.current.offsetWidth);
+    }
+  }, [text]);
+
+  return (
+    <div>
+      <p ref={ref} style={{ display: "inline-block" }}>{text}</p>
+      {width !== null && <p>Width after update: {width}px</p>}
+      <button onClick={() => setText((t) => t + "!")}>Add !</button>
+    </div>
+  );
+}
+```
+
+### Synchronize scroll position on content change
+
+```jsx
+import React, { useRef, useState } from "react";
+import { useUpdateLayoutEffect } from "rooks";
+
+export default function ScrollSync() {
+  const containerRef = useRef(null);
+  const [items, setItems] = useState(["Item 1", "Item 2", "Item 3"]);
+
+  useUpdateLayoutEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [items]);
+
+  return (
+    <div>
+      <div
+        ref={containerRef}
+        style={{ height: 120, overflowY: "auto", border: "1px solid #ccc" }}
+      >
+        {items.map((item) => (
+          <p key={item}>{item}</p>
+        ))}
+      </div>
+      <button
+        onClick={() =>
+          setItems((prev) => [...prev, `Item ${prev.length + 1}`])
+        }
+      >
+        Add item
+      </button>
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument | Type             | Description                                                      |
+| -------- | ---------------- | ---------------------------------------------------------------- |
+| effect   | `EffectCallback` | Imperative function that can optionally return a cleanup function |
+| deps     | `DependencyList` | Optional array of dependencies that control when the effect runs |
+
+### Returns
+
+`void`

--- a/packages/rooks/src/__tests__/useUpdateEffect.spec.tsx
+++ b/packages/rooks/src/__tests__/useUpdateEffect.spec.tsx
@@ -1,0 +1,113 @@
+import { renderHook, act, cleanup } from "@testing-library/react";
+import React, { useState } from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { useUpdateEffect } from "@/hooks/useUpdateEffect";
+
+describe("useUpdateEffect", () => {
+  afterEach(cleanup);
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useUpdateEffect).toBeDefined();
+  });
+
+  it("does not fire effect on initial mount", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    renderHook(() => useUpdateEffect(callback, []));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("fires effect on subsequent renders when deps change", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ count }: { count: number }) => useUpdateEffect(callback, [count]),
+      { initialProps: { count: 0 } }
+    );
+    expect(callback).not.toHaveBeenCalled();
+    rerender({ count: 1 });
+    expect(callback).toHaveBeenCalledTimes(1);
+    rerender({ count: 2 });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fire when deps have not changed", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ count }: { count: number }) => useUpdateEffect(callback, [count]),
+      { initialProps: { count: 0 } }
+    );
+    rerender({ count: 0 });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("fires effect on every re-render when no deps provided", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { rerender } = renderHook(() => useUpdateEffect(callback));
+    expect(callback).not.toHaveBeenCalled();
+    rerender();
+    expect(callback).toHaveBeenCalledTimes(1);
+    rerender();
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs cleanup function returned from effect", () => {
+    expect.hasAssertions();
+    const cleanup = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ count }: { count: number }) =>
+        useUpdateEffect(() => {
+          return cleanup;
+        }, [count]),
+      { initialProps: { count: 0 } }
+    );
+    // No effect yet (first mount is skipped)
+    expect(cleanup).not.toHaveBeenCalled();
+    // Trigger effect
+    rerender({ count: 1 });
+    expect(cleanup).not.toHaveBeenCalled();
+    // Trigger again — previous cleanup should run first
+    rerender({ count: 2 });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+
+  it("integrates correctly in a component — skips mount, fires on update", () => {
+    expect.hasAssertions();
+    const effectLog: string[] = [];
+
+    const App = () => {
+      const [value, setValue] = useState(0);
+      useUpdateEffect(() => {
+        effectLog.push(`effect:${value}`);
+      }, [value]);
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => setValue((v) => v + 1)}
+          type="button"
+        >
+          {value}
+        </button>
+      );
+    };
+
+    const { getByTestId } = render(<App />);
+    // On mount, effect should NOT have fired
+    expect(effectLog).toHaveLength(0);
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(effectLog).toEqual(["effect:1"]);
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(effectLog).toEqual(["effect:1", "effect:2"]);
+  });
+});

--- a/packages/rooks/src/__tests__/useUpdateLayoutEffect.spec.tsx
+++ b/packages/rooks/src/__tests__/useUpdateLayoutEffect.spec.tsx
@@ -1,0 +1,133 @@
+import { renderHook, act, cleanup } from "@testing-library/react";
+import React, { useState } from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { useUpdateLayoutEffect } from "@/hooks/useUpdateLayoutEffect";
+
+describe("useUpdateLayoutEffect", () => {
+  afterEach(cleanup);
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useUpdateLayoutEffect).toBeDefined();
+  });
+
+  it("does not fire effect on initial mount", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    renderHook(() => useUpdateLayoutEffect(callback, []));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("fires effect on subsequent renders when deps change", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ count }: { count: number }) =>
+        useUpdateLayoutEffect(callback, [count]),
+      { initialProps: { count: 0 } }
+    );
+    expect(callback).not.toHaveBeenCalled();
+    rerender({ count: 1 });
+    expect(callback).toHaveBeenCalledTimes(1);
+    rerender({ count: 2 });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fire when deps have not changed", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ count }: { count: number }) =>
+        useUpdateLayoutEffect(callback, [count]),
+      { initialProps: { count: 0 } }
+    );
+    rerender({ count: 0 });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("fires effect on every re-render when no deps provided", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const { rerender } = renderHook(() => useUpdateLayoutEffect(callback));
+    expect(callback).not.toHaveBeenCalled();
+    rerender();
+    expect(callback).toHaveBeenCalledTimes(1);
+    rerender();
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs cleanup function returned from effect", () => {
+    expect.hasAssertions();
+    const cleanupFn = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ count }: { count: number }) =>
+        useUpdateLayoutEffect(() => {
+          return cleanupFn;
+        }, [count]),
+      { initialProps: { count: 0 } }
+    );
+    // No effect yet (first mount is skipped)
+    expect(cleanupFn).not.toHaveBeenCalled();
+    // Trigger effect
+    rerender({ count: 1 });
+    expect(cleanupFn).not.toHaveBeenCalled();
+    // Trigger again — previous cleanup should run first
+    rerender({ count: 2 });
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(cleanupFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("integrates correctly in a component — skips mount, fires on update", () => {
+    expect.hasAssertions();
+    const effectLog: string[] = [];
+
+    const App = () => {
+      const [value, setValue] = useState(0);
+      useUpdateLayoutEffect(() => {
+        effectLog.push(`effect:${value}`);
+      }, [value]);
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => setValue((v) => v + 1)}
+          type="button"
+        >
+          {value}
+        </button>
+      );
+    };
+
+    const { getByTestId } = render(<App />);
+    // On mount, effect should NOT have fired
+    expect(effectLog).toHaveLength(0);
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(effectLog).toEqual(["effect:1"]);
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(effectLog).toEqual(["effect:1", "effect:2"]);
+  });
+
+  it("uses layout effect timing — runs synchronously before paint", () => {
+    expect.hasAssertions();
+    const order: string[] = [];
+    const { rerender } = renderHook(
+      ({ count }: { count: number }) => {
+        useUpdateLayoutEffect(() => {
+          order.push("layout");
+        }, [count]);
+      },
+      { initialProps: { count: 0 } }
+    );
+    // Nothing on mount
+    expect(order).toHaveLength(0);
+    // On update, layout effect fires synchronously (before paint)
+    rerender({ count: 1 });
+    expect(order).toEqual(["layout"]);
+  });
+});

--- a/packages/rooks/src/hooks/useUpdateEffect.ts
+++ b/packages/rooks/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+import type { DependencyList, EffectCallback } from "react";
+
+/**
+ * useUpdateEffect hook
+ *
+ * Fires a callback on every update (re-render) but skips the initial mount.
+ * Has the same API as React's built-in `useEffect`.
+ *
+ * @param {EffectCallback} effect Imperative function that can return a cleanup function
+ * @param {DependencyList} [deps] Dependencies that control when the effect re-runs
+ * @returns {void}
+ * @example
+ * function App() {
+ *   const [count, setCount] = useState(0);
+ *   useUpdateEffect(() => {
+ *     console.log("count changed", count);
+ *   }, [count]);
+ *   return <button onClick={() => setCount(c => c + 1)}>Increment</button>;
+ * }
+ * @see https://rooks.vercel.app/docs/hooks/useUpdateEffect
+ */
+function useUpdateEffect(effect: EffectCallback, deps?: DependencyList): void {
+  const hasMountedRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
+    return effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}
+
+export { useUpdateEffect };

--- a/packages/rooks/src/hooks/useUpdateLayoutEffect.ts
+++ b/packages/rooks/src/hooks/useUpdateLayoutEffect.ts
@@ -1,0 +1,45 @@
+import { useRef } from "react";
+import type { DependencyList, EffectCallback } from "react";
+import { useIsomorphicEffect } from "./useIsomorphicEffect";
+
+/**
+ * useUpdateLayoutEffect hook
+ *
+ * Fires a callback on every update (re-render) but skips the initial mount.
+ * Has the same API as React's built-in `useLayoutEffect`, and uses the
+ * isomorphic effect pattern to avoid SSR warnings.
+ *
+ * @param {EffectCallback} effect Imperative function that can return a cleanup function
+ * @param {DependencyList} [deps] Dependencies that control when the effect re-runs
+ * @returns {void}
+ * @example
+ * function App() {
+ *   const [width, setWidth] = useState(0);
+ *   const ref = useRef<HTMLDivElement>(null);
+ *   useUpdateLayoutEffect(() => {
+ *     if (ref.current) {
+ *       setWidth(ref.current.offsetWidth);
+ *     }
+ *   }, [someState]);
+ *   return <div ref={ref}>content</div>;
+ * }
+ * @see https://rooks.vercel.app/docs/hooks/useUpdateLayoutEffect
+ */
+function useUpdateLayoutEffect(
+  effect: EffectCallback,
+  deps?: DependencyList
+): void {
+  const hasMountedRef = useRef<boolean>(false);
+
+  useIsomorphicEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
+    return effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}
+
+export { useUpdateLayoutEffect };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -118,6 +118,8 @@ export { useToggle } from "./hooks/useToggle";
 export { useUndoState } from "./hooks/useUndoState";
 export { useTween } from "./hooks/useTween";
 export { useUndoRedoState } from "./hooks/useUndoRedoState";
+export { useUpdateEffect } from "./hooks/useUpdateEffect";
+export { useUpdateLayoutEffect } from "./hooks/useUpdateLayoutEffect";
 export { useVibrate } from "./hooks/useVibrate";
 export { useVideo } from "./hooks/useVideo";
 export { useWebLocksApi } from "./hooks/useWebLocksApi";


### PR DESCRIPTION
## Summary

- **`useUpdateEffect`**: Drop-in replacement for `useEffect` that skips the effect on the initial mount. Fires on every subsequent re-render when dependencies change. Supports the full `useEffect` API including cleanup function return values.
- **`useUpdateLayoutEffect`**: Same skip-first-mount behaviour as above but uses `useIsomorphicEffect` internally (resolves to `useLayoutEffect` in browser, `useEffect` in SSR) to avoid the `useLayoutEffect` SSR warning.

Both are distinct from the existing `useDidUpdate` hook because:
- They accept `EffectCallback` (effect can return a cleanup destructor), whereas `useDidUpdate` accepts `() => void`
- Their dependency array follows React's `DependencyList` semantics exactly, not the custom `conditions` processing `useDidUpdate` applies

## Files changed

| File | Purpose |
|---|---|
| `packages/rooks/src/hooks/useUpdateEffect.ts` | Hook implementation |
| `packages/rooks/src/hooks/useUpdateLayoutEffect.ts` | Hook implementation (uses `useIsomorphicEffect`) |
| `packages/rooks/src/__tests__/useUpdateEffect.spec.tsx` | 7 vitest tests |
| `packages/rooks/src/__tests__/useUpdateLayoutEffect.spec.tsx` | 8 vitest tests |
| `apps/website/content/docs/hooks/(lifecycle)/useUpdateEffect.mdx` | Docs |
| `apps/website/content/docs/hooks/(lifecycle)/useUpdateLayoutEffect.mdx` | Docs |
| `packages/rooks/src/index.ts` | Exports both hooks |

## Test plan

- [x] 15/15 tests pass locally (`npx vitest run ...`)
- [x] `does not fire effect on initial mount` — core contract verified
- [x] `fires effect on subsequent renders when deps change`
- [x] `does not fire when deps have not changed`
- [x] `fires effect on every re-render when no deps provided`
- [x] `runs cleanup function returned from effect`
- [x] Integration test with a real rendered component
- [x] Layout-effect timing test for `useUpdateLayoutEffect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)