### PR TITLE
feat: add useScroll hook

### DIFF
--- a/apps/website/content/docs/hooks/(viewport)/useScroll.mdx
+++ b/apps/website/content/docs/hooks/(viewport)/useScroll.mdx
@@ -1,0 +1,77 @@
+---
+id: useScroll
+title: useScroll
+sidebar_label: useScroll
+---
+
+## About
+
+Tracks the scroll position of any scrollable element. Unlike `useWindowScrollPosition`, this hook works with any DOM element, not just the window.
+
+[//]: # "Main"
+
+## Examples
+
+### Basic Usage
+
+```jsx
+import { useRef } from "react";
+import { useScroll } from "rooks";
+
+function App() {
+  const ref = useRef(null);
+  const [{ left, top }, isScrolling] = useScroll(ref);
+
+  return (
+    <div
+      ref={ref}
+      style={{ overflow: "auto", height: 200, border: "1px solid #ccc" }}
+    >
+      <div style={{ height: 1000, width: 1000, padding: 16 }}>
+        <p>Scroll left: {left}</p>
+        <p>Scroll top: {top}</p>
+        <p>{isScrolling ? "Scrolling…" : "Idle"}</p>
+      </div>
+    </div>
+  );
+}
+
+export default App;
+```
+
+### Tracking a Window or Document
+
+```jsx
+import { useScroll } from "rooks";
+
+function App() {
+  const [{ left, top }, isScrolling] = useScroll(
+    typeof window !== "undefined" ? window : null
+  );
+
+  return (
+    <div style={{ height: 2000 }}>
+      <p style={{ position: "fixed", top: 0 }}>
+        Window scroll — left: {left}, top: {top} {isScrolling ? "(scrolling)" : ""}
+      </p>
+    </div>
+  );
+}
+
+export default App;
+```
+
+### Arguments
+
+| Argument | Type | Description | Default value |
+| -------- | ---- | ----------- | ------------- |
+| target | `RefObject<HTMLElement> \| HTMLElement \| (() => HTMLElement) \| Window \| Document \| null` | The scrollable element to observe | — |
+
+### Returns
+
+Returns a tuple `[scrollPosition, isScrolling]`.
+
+| Return value | Type | Description | Default value |
+| ------------ | ---- | ----------- | ------------- |
+| scrollPosition | `{ left: number; top: number }` | Current scroll offsets of the target element | `{ left: 0, top: 0 }` |
+| isScrolling | `boolean` | `true` while the element is being scrolled; resets to `false` 100 ms after the last scroll event | `false` |

--- a/packages/rooks/src/__tests__/useScroll.spec.tsx
+++ b/packages/rooks/src/__tests__/useScroll.spec.tsx
@@ -1,0 +1,249 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { useRef } from "react";
+import { vi } from "vitest";
+import { useScroll } from "@/hooks/useScroll";
+import { renderHook } from "@testing-library/react";
+
+// ─── Helper component ──────────────────────────────────────────────────────────
+
+function ScrollableComponent() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [{ left, top }, isScrolling] = useScroll(ref);
+  return (
+    <div
+      ref={ref}
+      data-testid="scrollable"
+      style={{ overflow: "auto", height: 100 }}
+    >
+      <div data-testid="left">{left}</div>
+      <div data-testid="top">{top}</div>
+      <div data-testid="scrolling">{String(isScrolling)}</div>
+      <div style={{ height: 1000, width: 1000 }} />
+    </div>
+  );
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useScroll", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useScroll).toBeDefined();
+  });
+
+  // ── initial state ──────────────────────────────────────────────────────────
+
+  describe("initial state", () => {
+    it("returns { left: 0, top: 0 } and isScrolling=false when target is null", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useScroll(null));
+      const [scrollPosition, isScrolling] = result.current;
+      expect(scrollPosition).toEqual({ left: 0, top: 0 });
+      expect(isScrolling).toBe(false);
+    });
+
+    it("starts with zero scroll position and isScrolling false after mount", () => {
+      expect.hasAssertions();
+      render(<ScrollableComponent />);
+      expect(screen.getByTestId("left")).toHaveTextContent("0");
+      expect(screen.getByTestId("top")).toHaveTextContent("0");
+      expect(screen.getByTestId("scrolling")).toHaveTextContent("false");
+    });
+  });
+
+  // ── scroll position updates ────────────────────────────────────────────────
+
+  describe("scroll position tracking", () => {
+    it("updates scroll position on scroll event", () => {
+      expect.hasAssertions();
+      render(<ScrollableComponent />);
+      const el = screen.getByTestId("scrollable");
+
+      Object.defineProperty(el, "scrollLeft", {
+        value: 50,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(el, "scrollTop", {
+        value: 120,
+        writable: true,
+        configurable: true,
+      });
+
+      act(() => {
+        fireEvent.scroll(el);
+      });
+
+      expect(screen.getByTestId("left")).toHaveTextContent("50");
+      expect(screen.getByTestId("top")).toHaveTextContent("120");
+    });
+
+    it("sets isScrolling to true immediately on scroll", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+      try {
+        render(<ScrollableComponent />);
+        const el = screen.getByTestId("scrollable");
+
+        act(() => {
+          fireEvent.scroll(el);
+        });
+
+        expect(screen.getByTestId("scrolling")).toHaveTextContent("true");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ── debounce / isScrolling reset ───────────────────────────────────────────
+
+  describe("isScrolling debounce", () => {
+    it("resets isScrolling to false after 100ms with no further scroll events", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+      try {
+        render(<ScrollableComponent />);
+        const el = screen.getByTestId("scrollable");
+
+        act(() => {
+          fireEvent.scroll(el);
+        });
+        expect(screen.getByTestId("scrolling")).toHaveTextContent("true");
+
+        act(() => {
+          vi.advanceTimersByTime(100);
+        });
+
+        expect(screen.getByTestId("scrolling")).toHaveTextContent("false");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("debounce resets on every new scroll, so isScrolling stays true across rapid scrolls", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+      try {
+        render(<ScrollableComponent />);
+        const el = screen.getByTestId("scrollable");
+
+        act(() => {
+          fireEvent.scroll(el);
+        });
+        act(() => {
+          vi.advanceTimersByTime(50);
+        });
+        act(() => {
+          fireEvent.scroll(el);
+        });
+
+        // 50 ms after the second scroll — still scrolling
+        act(() => {
+          vi.advanceTimersByTime(50);
+        });
+        expect(screen.getByTestId("scrolling")).toHaveTextContent("true");
+
+        // Full 100 ms after the second scroll — now idle
+        act(() => {
+          vi.advanceTimersByTime(50);
+        });
+        expect(screen.getByTestId("scrolling")).toHaveTextContent("false");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  // ── direct HTMLElement target ──────────────────────────────────────────────
+
+  describe("with a direct HTMLElement", () => {
+    it("attaches a scroll listener and reads the element's scroll offsets", () => {
+      expect.hasAssertions();
+      const div = document.createElement("div");
+      Object.defineProperty(div, "scrollLeft", {
+        value: 30,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(div, "scrollTop", {
+        value: 60,
+        writable: true,
+        configurable: true,
+      });
+      document.body.appendChild(div);
+
+      const { result } = renderHook(() => useScroll(div));
+
+      act(() => {
+        fireEvent.scroll(div);
+      });
+
+      const [pos] = result.current;
+      expect(pos.left).toBe(30);
+      expect(pos.top).toBe(60);
+
+      document.body.removeChild(div);
+    });
+  });
+
+  // ── getter function target ─────────────────────────────────────────────────
+
+  describe("with a getter function", () => {
+    it("calls the getter and tracks the returned element", () => {
+      expect.hasAssertions();
+      const div = document.createElement("div");
+      Object.defineProperty(div, "scrollLeft", {
+        value: 10,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(div, "scrollTop", {
+        value: 20,
+        writable: true,
+        configurable: true,
+      });
+      document.body.appendChild(div);
+
+      const getter = () => div;
+      const { result } = renderHook(() => useScroll(getter));
+
+      act(() => {
+        fireEvent.scroll(div);
+      });
+
+      const [pos] = result.current;
+      expect(pos.left).toBe(10);
+      expect(pos.top).toBe(20);
+
+      document.body.removeChild(div);
+    });
+  });
+
+  // ── cleanup ────────────────────────────────────────────────────────────────
+
+  describe("cleanup", () => {
+    it("removes the event listener on unmount", () => {
+      expect.hasAssertions();
+      const div = document.createElement("div");
+      const addSpy = vi.spyOn(div, "addEventListener");
+      const removeSpy = vi.spyOn(div, "removeEventListener");
+      document.body.appendChild(div);
+
+      const { unmount } = renderHook(() => useScroll(div));
+      expect(addSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+        { passive: true }
+      );
+
+      unmount();
+      expect(removeSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function)
+      );
+
+      document.body.removeChild(div);
+    });
+  });
+});

--- a/packages/rooks/src/hooks/useScroll.ts
+++ b/packages/rooks/src/hooks/useScroll.ts
@@ -1,0 +1,131 @@
+import { useState, useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { noop } from "@/utils/noop";
+
+type ScrollPosition = {
+  left: number;
+  top: number;
+};
+
+type ScrollTarget =
+  | RefObject<HTMLElement>
+  | HTMLElement
+  | (() => HTMLElement)
+  | Window
+  | Document
+  | null;
+
+const defaultScrollPosition: ScrollPosition = { left: 0, top: 0 };
+
+function getScrollPosition(
+  element: HTMLElement | Window | Document
+): ScrollPosition {
+  if (element instanceof Window) {
+    return {
+      left: element.scrollX ?? element.pageXOffset ?? 0,
+      top: element.scrollY ?? element.pageYOffset ?? 0,
+    };
+  }
+  if (element instanceof Document) {
+    return {
+      left:
+        element.documentElement.scrollLeft ??
+        element.body.scrollLeft ??
+        0,
+      top:
+        element.documentElement.scrollTop ??
+        element.body.scrollTop ??
+        0,
+    };
+  }
+  return {
+    left: element.scrollLeft,
+    top: element.scrollTop,
+  };
+}
+
+function resolveTarget(
+  target: ScrollTarget
+): HTMLElement | Window | Document | null {
+  if (target === null) return null;
+  if (typeof target === "function") return target();
+  if ("current" in target) return (target as RefObject<HTMLElement>).current;
+  return target as HTMLElement | Window | Document;
+}
+
+/**
+ * useScroll hook
+ *
+ * Tracks the scroll position of any scrollable element. For window-level
+ * scroll tracking, use useWindowScrollPosition instead.
+ *
+ * @param {ScrollTarget} target The scrollable element to observe. Accepts a
+ * React ref object, a direct DOM element, a getter function returning an
+ * element, a Window, a Document, or null.
+ * @returns {[ScrollPosition, boolean]} A tuple of [scrollPosition, isScrolling]
+ * where scrollPosition contains left and top scroll offsets (defaulting to
+ * { left: 0, top: 0 } during SSR), and isScrolling is true while the user is
+ * actively scrolling (resets after 100 ms of inactivity).
+ * @example
+ * import { useRef } from "react";
+ * import { useScroll } from "rooks";
+ *
+ * function App() {
+ *   const ref = useRef(null);
+ *   const [{ left, top }, isScrolling] = useScroll(ref);
+ *   return (
+ *     <div ref={ref} style={{ overflow: "auto", height: 200 }}>
+ *       <div style={{ height: 1000 }}>
+ *         <p>Scroll left: {left}, top: {top}</p>
+ *         <p>{isScrolling ? "Scrolling…" : "Idle"}</p>
+ *       </div>
+ *     </div>
+ *   );
+ * }
+ * @see https://rooks.vercel.app/docs/hooks/useScroll
+ */
+function useScroll(target: ScrollTarget): [ScrollPosition, boolean] {
+  const [scrollPosition, setScrollPosition] = useState<ScrollPosition>(
+    defaultScrollPosition
+  );
+  const [isScrolling, setIsScrolling] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return noop;
+
+    const element = resolveTarget(target);
+    if (!element) return noop;
+
+    // Sync the initial scroll position without waiting for a scroll event
+    setScrollPosition(getScrollPosition(element));
+
+    const handleScroll = () => {
+      setScrollPosition(getScrollPosition(element));
+      setIsScrolling(true);
+
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => {
+        setIsScrolling(false);
+        timeoutRef.current = null;
+      }, 100);
+    };
+
+    element.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      element.removeEventListener("scroll", handleScroll);
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [target]);
+
+  return [scrollPosition, isScrolling];
+}
+
+export { useScroll };
+export type { ScrollPosition, ScrollTarget };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -102,6 +102,8 @@ export { useRenderCount } from "./hooks/useRenderCount";
 export { useRefElement } from "./hooks/useRefElement";
 export { useSafeSetState } from "./hooks/useSafeSetState";
 export { useScreenDetailsApi } from "./hooks/useScreenDetailsApi";
+export { useScroll } from "./hooks/useScroll";
+export type { ScrollPosition, ScrollTarget } from "./hooks/useScroll";
 export { useSelect } from "./hooks/useSelect";
 export { useSelectableList } from "./hooks/useSelectableList";
 export { useSessionstorageState } from "./hooks/useSessionstorageState";


### PR DESCRIPTION
## Summary

- New `useScroll` hook that tracks the scroll position of **any scrollable element** (not just window — `useWindowScrollPosition` handles that case)
- Accepts a flexible `target` parameter: `RefObject<HTMLElement>`, `HTMLElement`, `() => HTMLElement`, `Window`, `Document`, or `null`
- Returns a tuple `[scrollPosition, isScrolling]` where `scrollPosition = { left, top }` and `isScrolling` resets after a 100 ms debounce
- SSR-safe: returns `{ left: 0, top: 0 }` / `false` when `window` is undefined

## Files changed

| File | Description |
|------|-------------|
| `packages/rooks/src/hooks/useScroll.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useScroll.spec.tsx` | 10 vitest tests covering null target, position updates, isScrolling, debounce, direct element, getter function, and cleanup |
| `apps/website/content/docs/hooks/(viewport)/useScroll.mdx` | MDX docs with examples and argument/return tables |
| `packages/rooks/src/index.ts` | Export `useScroll`, `ScrollPosition`, `ScrollTarget` |

## Test plan

- [x] All 10 `useScroll` tests pass (`pnpm exec vitest run src/__tests__/useScroll.spec.tsx`)
- [x] Full test suite passes (1467 passed, no new failures)
- [x] TypeScript strict check passes (`pnpm typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)