### PR TITLE
feat: add useTextSelection hook

### DIFF
--- a/apps/website/content/docs/hooks/(events)/useTextSelection.mdx
+++ b/apps/website/content/docs/hooks/(events)/useTextSelection.mdx
@@ -1,0 +1,116 @@
+---
+id: useTextSelection
+title: useTextSelection
+sidebar_label: useTextSelection
+---
+
+## About
+
+Tracks the currently selected text on the page or within a scoped element. Listens to the native `selectionchange` event and clears the selection state when the user clicks outside a scoped target. Returns empty state during SSR.
+
+## Examples
+
+### Track selection anywhere on the page
+
+```tsx
+import { useTextSelection } from "rooks";
+
+export default function App() {
+  const [{ text, rect }] = useTextSelection();
+
+  return (
+    <div>
+      <p>Select any text on this page.</p>
+      {text && (
+        <p>
+          You selected: <strong>{text}</strong>
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+### Scope tracking to a specific element
+
+```tsx
+import { useRef } from "react";
+import { useTextSelection } from "rooks";
+
+export default function Article() {
+  const articleRef = useRef<HTMLDivElement>(null);
+  const [{ text, startOffset, endOffset }] = useTextSelection(articleRef);
+
+  return (
+    <>
+      <div ref={articleRef}>
+        <p>
+          Only selections within this article are tracked. Try selecting
+          some of this text, or the paragraph below.
+        </p>
+        <p>Another paragraph inside the article.</p>
+      </div>
+      <p>Selection outside is ignored.</p>
+      {text && (
+        <pre>
+          {JSON.stringify({ text, startOffset, endOffset }, null, 2)}
+        </pre>
+      )}
+    </>
+  );
+}
+```
+
+### Show a floating tooltip at the selection position
+
+```tsx
+import { useRef } from "react";
+import { useTextSelection } from "rooks";
+
+export default function FloatingTooltip() {
+  const [{ text, rect }] = useTextSelection();
+
+  return (
+    <div style={{ position: "relative" }}>
+      <p>Select any text to see a tooltip appear.</p>
+      {text && rect && (
+        <div
+          style={{
+            position: "fixed",
+            top: rect.top - 40,
+            left: rect.left + rect.width / 2,
+            transform: "translateX(-50%)",
+            background: "#333",
+            color: "#fff",
+            padding: "4px 8px",
+            borderRadius: 4,
+            pointerEvents: "none",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {text.length} character{text.length !== 1 ? "s" : ""} selected
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## Arguments
+
+| Argument | Type                    | Description                                                              | Default     |
+| -------- | ----------------------- | ------------------------------------------------------------------------ | ----------- |
+| target   | `RefObject<HTMLElement>` | Optional ref to scope selection tracking to a specific element.         | `undefined` |
+
+## Return value
+
+Returns a tuple `[selectionState]`.
+
+| Attribute     | Type            | Description                                                      |
+| ------------- | --------------- | ---------------------------------------------------------------- |
+| text          | `string`        | The selected text. Empty string when nothing is selected.        |
+| rect          | `DOMRect \| null` | Bounding rect of the selection range, or `null`.               |
+| startOffset   | `number`        | Character offset within `anchorNode` where the selection starts. |
+| endOffset     | `number`        | Character offset within `focusNode` where the selection ends.    |
+| anchorNode    | `Node \| null`  | The node at which the selection begins.                          |
+| focusNode     | `Node \| null`  | The node at which the selection ends (the drag point).           |

--- a/packages/rooks/src/__tests__/useTextSelection.spec.tsx
+++ b/packages/rooks/src/__tests__/useTextSelection.spec.tsx
@@ -1,0 +1,496 @@
+import { renderHook, act } from "@testing-library/react";
+import { useRef } from "react";
+import { vi } from "vitest";
+import { useTextSelection } from "@/hooks/useTextSelection";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fireSelectionChange() {
+  const event = new Event("selectionchange", { bubbles: false });
+  document.dispatchEvent(event);
+}
+
+function fireMouseDown(target: EventTarget, relatedTarget?: Node) {
+  const event = new MouseEvent("mousedown", {
+    bubbles: true,
+    cancelable: true,
+  });
+  if (relatedTarget) {
+    Object.defineProperty(event, "target", {
+      value: relatedTarget,
+      writable: false,
+    });
+  }
+  target.dispatchEvent(event);
+}
+
+interface MockSelectionOptions {
+  anchorNode?: Node;
+  focusNode?: Node;
+  anchorOffset?: number;
+  focusOffset?: number;
+  isCollapsed?: boolean;
+  rangeCount?: number;
+}
+
+function mockWindowSelection(
+  text: string,
+  options: MockSelectionOptions = {}
+) {
+  const fakeRect: DOMRect = {
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 20,
+    top: 20,
+    right: 110,
+    bottom: 40,
+    left: 10,
+    toJSON: () => ({}),
+  };
+  const fakeRange = {
+    getBoundingClientRect: vi.fn(() => fakeRect),
+  };
+  const fakeSelection = {
+    toString: () => text,
+    isCollapsed: options.isCollapsed ?? !text,
+    anchorNode: options.anchorNode ?? document.body,
+    focusNode: options.focusNode ?? document.body,
+    anchorOffset: options.anchorOffset ?? 0,
+    focusOffset: options.focusOffset ?? text.length,
+    rangeCount: options.rangeCount ?? (text ? 1 : 0),
+    getRangeAt: vi.fn(() => fakeRange),
+  };
+  vi.spyOn(window, "getSelection").mockReturnValue(
+    fakeSelection as unknown as Selection
+  );
+  return { fakeSelection, fakeRange, fakeRect };
+}
+
+function mockEmptySelection() {
+  const fakeSelection = {
+    toString: () => "",
+    isCollapsed: true,
+    anchorNode: null,
+    focusNode: null,
+    anchorOffset: 0,
+    focusOffset: 0,
+    rangeCount: 0,
+    getRangeAt: vi.fn(),
+  };
+  vi.spyOn(window, "getSelection").mockReturnValue(
+    fakeSelection as unknown as Selection
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useTextSelection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEmptySelection();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -- existence --
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useTextSelection).toBeDefined();
+  });
+
+  // -- initial state --
+
+  it("should return a tuple", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    expect(Array.isArray(result.current)).toBe(true);
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("should start with empty selection state", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    const [state] = result.current;
+    expect(state).toEqual({
+      text: "",
+      rect: null,
+      startOffset: 0,
+      endOffset: 0,
+      anchorNode: null,
+      focusNode: null,
+    });
+  });
+
+  // -- selectionchange event --
+
+  it("should update text when selectionchange fires", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("hello world");
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("hello world");
+  });
+
+  it("should expose anchorOffset as startOffset", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("foo", { anchorOffset: 3, focusOffset: 6 });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].startOffset).toBe(3);
+  });
+
+  it("should expose focusOffset as endOffset", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("foo", { anchorOffset: 3, focusOffset: 6 });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].endOffset).toBe(6);
+  });
+
+  it("should expose anchorNode", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    const node = document.createTextNode("hello");
+
+    act(() => {
+      mockWindowSelection("hello", { anchorNode: node });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].anchorNode).toBe(node);
+  });
+
+  it("should expose focusNode", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    const node = document.createTextNode("world");
+
+    act(() => {
+      mockWindowSelection("world", { focusNode: node });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].focusNode).toBe(node);
+  });
+
+  it("should populate rect when selection has ranges", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("selected");
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].rect).not.toBeNull();
+    expect(result.current[0].rect?.width).toBe(100);
+    expect(result.current[0].rect?.height).toBe(20);
+  });
+
+  it("should reset to empty state when selection becomes empty", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    // Select something first
+    act(() => {
+      mockWindowSelection("some text");
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("some text");
+
+    // Clear selection
+    act(() => {
+      mockEmptySelection();
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("");
+    expect(result.current[0].rect).toBeNull();
+    expect(result.current[0].anchorNode).toBeNull();
+  });
+
+  it("should update on subsequent selections", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("first");
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("first");
+
+    act(() => {
+      mockWindowSelection("second");
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("second");
+  });
+
+  // -- event listener lifecycle --
+
+  it("should add selectionchange listener on mount", () => {
+    expect.hasAssertions();
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useTextSelection());
+
+    expect(addSpy).toHaveBeenCalledWith(
+      "selectionchange",
+      expect.any(Function)
+    );
+  });
+
+  it("should remove selectionchange listener on unmount", () => {
+    expect.hasAssertions();
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() => useTextSelection());
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith(
+      "selectionchange",
+      expect.any(Function)
+    );
+  });
+
+  it("should add mousedown listener on mount", () => {
+    expect.hasAssertions();
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useTextSelection());
+
+    expect(addSpy).toHaveBeenCalledWith("mousedown", expect.any(Function));
+  });
+
+  it("should remove mousedown listener on unmount", () => {
+    expect.hasAssertions();
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() => useTextSelection());
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("mousedown", expect.any(Function));
+  });
+
+  // -- collapsed / empty selection edge cases --
+
+  it("should return empty state when selection is collapsed", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("", { isCollapsed: true });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("");
+    expect(result.current[0].rect).toBeNull();
+  });
+
+  it("should return empty state when getSelection returns null", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      vi.spyOn(window, "getSelection").mockReturnValue(null);
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("");
+  });
+
+  // -- target scoping --
+
+  it("should accept a target ref parameter", () => {
+    expect.hasAssertions();
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      return useTextSelection(ref);
+    }
+    const { result } = renderHook(() => TestHook());
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("should ignore selections outside the target element", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const outsideNode = document.createTextNode("outside");
+    document.body.appendChild(outsideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      // Manually point ref at target
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    act(() => {
+      // Selection nodes are outside the target
+      mockWindowSelection("outside text", {
+        anchorNode: outsideNode,
+        focusNode: outsideNode,
+      });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("");
+
+    document.body.removeChild(target);
+    document.body.removeChild(outsideNode);
+  });
+
+  it("should track selections inside the target element", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const insideNode = document.createTextNode("inside text");
+    target.appendChild(insideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    act(() => {
+      mockWindowSelection("inside text", {
+        anchorNode: insideNode,
+        focusNode: insideNode,
+      });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("inside text");
+
+    document.body.removeChild(target);
+  });
+
+  it("should clear state on mousedown outside target when text is selected", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    const outside = document.createElement("button");
+    document.body.appendChild(target);
+    document.body.appendChild(outside);
+    const insideNode = document.createTextNode("selected");
+    target.appendChild(insideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    // First select some text inside the target
+    act(() => {
+      mockWindowSelection("selected", {
+        anchorNode: insideNode,
+        focusNode: insideNode,
+      });
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("selected");
+
+    // Then click outside the target
+    act(() => {
+      // Dispatch mousedown on a node outside the target
+      const mousedownEvent = new MouseEvent("mousedown", { bubbles: true });
+      // Override target to be the outside element
+      Object.defineProperty(mousedownEvent, "target", {
+        value: outside,
+        writable: false,
+      });
+      document.dispatchEvent(mousedownEvent);
+    });
+
+    expect(result.current[0].text).toBe("");
+    expect(result.current[0].rect).toBeNull();
+
+    document.body.removeChild(target);
+    document.body.removeChild(outside);
+  });
+
+  it("should NOT clear state on mousedown inside target", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const insideNode = document.createTextNode("stay");
+    target.appendChild(insideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    act(() => {
+      mockWindowSelection("stay", {
+        anchorNode: insideNode,
+        focusNode: insideNode,
+      });
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("stay");
+
+    // Click inside the target — should NOT clear
+    act(() => {
+      const mousedownEvent = new MouseEvent("mousedown", { bubbles: true });
+      Object.defineProperty(mousedownEvent, "target", {
+        value: target,
+        writable: false,
+      });
+      document.dispatchEvent(mousedownEvent);
+    });
+
+    expect(result.current[0].text).toBe("stay");
+
+    document.body.removeChild(target);
+  });
+
+  // -- multiple instances --
+
+  it("should support multiple independent hook instances", () => {
+    expect.hasAssertions();
+    const { result: r1 } = renderHook(() => useTextSelection());
+    const { result: r2 } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("shared");
+      fireSelectionChange();
+    });
+
+    expect(r1.current[0].text).toBe("shared");
+    expect(r2.current[0].text).toBe("shared");
+  });
+});

--- a/packages/rooks/src/hooks/useTextSelection.ts
+++ b/packages/rooks/src/hooks/useTextSelection.ts
@@ -1,0 +1,186 @@
+import { useCallback, useRef, useSyncExternalStore } from "react";
+import type { RefObject } from "react";
+
+/**
+ * The shape of the text selection state returned by useTextSelection.
+ */
+type TextSelectionState = {
+  /** The selected text string. Empty string when nothing is selected. */
+  text: string;
+  /** Bounding DOMRect of the first selection range, or null when nothing is selected. */
+  rect: DOMRect | null;
+  /** Character offset within anchorNode where the selection starts. */
+  startOffset: number;
+  /** Character offset within focusNode where the selection ends. */
+  endOffset: number;
+  /** The node at which the selection begins, or null. */
+  anchorNode: Node | null;
+  /** The node at which the selection ends (the drag point), or null. */
+  focusNode: Node | null;
+};
+
+const initialSelectionState: TextSelectionState = {
+  text: "",
+  rect: null,
+  startOffset: 0,
+  endOffset: 0,
+  anchorNode: null,
+  focusNode: null,
+};
+
+/**
+ * Reads the current window.getSelection() and returns a TextSelectionState.
+ * If `targetElement` is provided, returns empty state when the selection
+ * falls outside that element.
+ */
+function readSelectionState(
+  targetElement: HTMLElement | null
+): TextSelectionState {
+  if (typeof window === "undefined" || !window.getSelection) {
+    return initialSelectionState;
+  }
+
+  const selection = window.getSelection();
+
+  if (!selection || selection.isCollapsed) {
+    return initialSelectionState;
+  }
+
+  const text = selection.toString();
+  if (!text) {
+    return initialSelectionState;
+  }
+
+  // When scoped to a target, ignore selections that stray outside it
+  if (targetElement) {
+    const { anchorNode, focusNode } = selection;
+    if (
+      !anchorNode ||
+      !focusNode ||
+      !targetElement.contains(anchorNode) ||
+      !targetElement.contains(focusNode)
+    ) {
+      return initialSelectionState;
+    }
+  }
+
+  let rect: DOMRect | null = null;
+  if (selection.rangeCount > 0) {
+    try {
+      rect = selection.getRangeAt(0).getBoundingClientRect();
+    } catch {
+      // getBoundingClientRect can throw in detached-document edge cases
+    }
+  }
+
+  return {
+    text,
+    rect,
+    startOffset: selection.anchorOffset,
+    endOffset: selection.focusOffset,
+    anchorNode: selection.anchorNode,
+    focusNode: selection.focusNode,
+  };
+}
+
+/**
+ * useTextSelection hook
+ *
+ * Tracks the currently selected text on the page or within a target element.
+ * Listens to the native `selectionchange` event on the document. Returns an
+ * empty selection state during SSR. When a `target` ref is provided the hook
+ * automatically clears the selection state when the user clicks outside of
+ * that element.
+ *
+ * @param target - Optional ref to an HTMLElement that scopes selection
+ *   tracking. Defaults to the entire document.
+ * @returns A tuple `[selectionState]` containing the current selection data.
+ *
+ * @example
+ * // Track selection anywhere on the page
+ * import { useTextSelection } from "rooks";
+ *
+ * export default function App() {
+ *   const [{ text, rect }] = useTextSelection();
+ *   return <p>You selected: {text}</p>;
+ * }
+ *
+ * @example
+ * // Scope tracking to a specific element
+ * import { useRef } from "react";
+ * import { useTextSelection } from "rooks";
+ *
+ * export default function Article() {
+ *   const ref = useRef<HTMLDivElement>(null);
+ *   const [{ text }] = useTextSelection(ref);
+ *   return (
+ *     <>
+ *       <div ref={ref}>Select text from this element only.</div>
+ *       <p>Selection: {text}</p>
+ *     </>
+ *   );
+ * }
+ *
+ * @see https://rooks.vercel.app/docs/hooks/useTextSelection
+ */
+function useTextSelection(
+  target?: RefObject<HTMLElement>
+): [TextSelectionState] {
+  const cacheRef = useRef<TextSelectionState>(initialSelectionState);
+
+  // Store target in a ref so the subscribe function stays stable across renders
+  const targetRef = useRef<RefObject<HTMLElement> | undefined>(target);
+  targetRef.current = target;
+
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    if (typeof document === "undefined") {
+      return () => {};
+    }
+
+    const handleSelectionChange = () => {
+      cacheRef.current = readSelectionState(
+        targetRef.current?.current ?? null
+      );
+      onStoreChange();
+    };
+
+    // When scoped to a target, clear state on mousedown outside that target
+    const handleMouseDown = (event: MouseEvent) => {
+      const targetElement = targetRef.current?.current;
+      if (
+        targetElement &&
+        !targetElement.contains(event.target as Node) &&
+        cacheRef.current.text !== ""
+      ) {
+        cacheRef.current = initialSelectionState;
+        onStoreChange();
+      }
+    };
+
+    document.addEventListener("selectionchange", handleSelectionChange);
+    document.addEventListener("mousedown", handleMouseDown);
+
+    return () => {
+      document.removeEventListener("selectionchange", handleSelectionChange);
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, []);
+
+  const getSnapshot = useCallback(() => cacheRef.current, []);
+
+  const getServerSnapshot = useCallback(
+    (): TextSelectionState => initialSelectionState,
+    []
+  );
+
+  const selectionState = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
+
+  return [selectionState];
+}
+
+export { useTextSelection };
+export type { TextSelectionState };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -114,6 +114,8 @@ export { useTimeTravelState } from "./hooks/useTimeTravelState";
 export { useFetch } from "./hooks/useFetch";
 export { useThrottle } from "./hooks/useThrottle";
 export { useTimeoutWhen } from "./hooks/useTimeoutWhen";
+export { useTextSelection } from "./hooks/useTextSelection";
+export type { TextSelectionState } from "./hooks/useTextSelection";
 export { useToggle } from "./hooks/useToggle";
 export { useUndoState } from "./hooks/useUndoState";
 export { useTween } from "./hooks/useTween";


### PR DESCRIPTION
## Summary

- Adds `useTextSelection` hook that tracks currently selected text via the native `selectionchange` event
- Returns a tuple `[selectionState]` with `text`, `rect`, `startOffset`, `endOffset`, `anchorNode`, and `focusNode`
- Accepts an optional `target?: RefObject<HTMLElement>` to scope tracking to a specific element; auto-clears state on `mousedown` outside it
- SSR-safe: returns empty selection state on the server via `useSyncExternalStore`'s `getServerSnapshot`

## Files changed

| File | Description |
|------|-------------|
| `packages/rooks/src/hooks/useTextSelection.ts` | Hook implementation using `useSyncExternalStore` |
| `packages/rooks/src/__tests__/useTextSelection.spec.tsx` | 23 vitest tests (all passing) |
| `apps/website/content/docs/hooks/(events)/useTextSelection.mdx` | MDX docs with 3 usage examples |
| `packages/rooks/src/index.ts` | Export of hook and `TextSelectionState` type |

## Test plan

- [x] All 23 new tests pass
- [x] Full test suite (138 files, 1487 tests) passes with no regressions
- [x] Hook follows existing `useSyncExternalStore` pattern (same as `useMouse`, `useDocumentVisibilityState`)
- [x] Returns a tuple as per repo convention
- [x] JSDoc with `@example` blocks
- [x] TypeScript strict — no `any`, proper `Node | null` types

🤖 Generated with [Claude Code](https://claude.com/claude-code)