### PR TITLE
feat: add useCookieState hook

### DIFF
--- a/apps/website/content/docs/hooks/(events)/useTextSelection.mdx
+++ b/apps/website/content/docs/hooks/(events)/useTextSelection.mdx
@@ -1,0 +1,116 @@
+---
+id: useTextSelection
+title: useTextSelection
+sidebar_label: useTextSelection
+---
+
+## About
+
+Tracks the currently selected text on the page or within a scoped element. Listens to the native `selectionchange` event and clears the selection state when the user clicks outside a scoped target. Returns empty state during SSR.
+
+## Examples
+
+### Track selection anywhere on the page
+
+```tsx
+import { useTextSelection } from "rooks";
+
+export default function App() {
+  const [{ text, rect }] = useTextSelection();
+
+  return (
+    <div>
+      <p>Select any text on this page.</p>
+      {text && (
+        <p>
+          You selected: <strong>{text}</strong>
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+### Scope tracking to a specific element
+
+```tsx
+import { useRef } from "react";
+import { useTextSelection } from "rooks";
+
+export default function Article() {
+  const articleRef = useRef<HTMLDivElement>(null);
+  const [{ text, startOffset, endOffset }] = useTextSelection(articleRef);
+
+  return (
+    <>
+      <div ref={articleRef}>
+        <p>
+          Only selections within this article are tracked. Try selecting
+          some of this text, or the paragraph below.
+        </p>
+        <p>Another paragraph inside the article.</p>
+      </div>
+      <p>Selection outside is ignored.</p>
+      {text && (
+        <pre>
+          {JSON.stringify({ text, startOffset, endOffset }, null, 2)}
+        </pre>
+      )}
+    </>
+  );
+}
+```
+
+### Show a floating tooltip at the selection position
+
+```tsx
+import { useRef } from "react";
+import { useTextSelection } from "rooks";
+
+export default function FloatingTooltip() {
+  const [{ text, rect }] = useTextSelection();
+
+  return (
+    <div style={{ position: "relative" }}>
+      <p>Select any text to see a tooltip appear.</p>
+      {text && rect && (
+        <div
+          style={{
+            position: "fixed",
+            top: rect.top - 40,
+            left: rect.left + rect.width / 2,
+            transform: "translateX(-50%)",
+            background: "#333",
+            color: "#fff",
+            padding: "4px 8px",
+            borderRadius: 4,
+            pointerEvents: "none",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {text.length} character{text.length !== 1 ? "s" : ""} selected
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## Arguments
+
+| Argument | Type                    | Description                                                              | Default     |
+| -------- | ----------------------- | ------------------------------------------------------------------------ | ----------- |
+| target   | `RefObject<HTMLElement>` | Optional ref to scope selection tracking to a specific element.         | `undefined` |
+
+## Return value
+
+Returns a tuple `[selectionState]`.
+
+| Attribute     | Type            | Description                                                      |
+| ------------- | --------------- | ---------------------------------------------------------------- |
+| text          | `string`        | The selected text. Empty string when nothing is selected.        |
+| rect          | `DOMRect \| null` | Bounding rect of the selection range, or `null`.               |
+| startOffset   | `number`        | Character offset within `anchorNode` where the selection starts. |
+| endOffset     | `number`        | Character offset within `focusNode` where the selection ends.    |
+| anchorNode    | `Node \| null`  | The node at which the selection begins.                          |
+| focusNode     | `Node \| null`  | The node at which the selection ends (the drag point).           |

--- a/apps/website/content/docs/hooks/(lifecycle)/useTrackedEffect.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useTrackedEffect.mdx
@@ -1,0 +1,158 @@
+---
+id: useTrackedEffect
+title: useTrackedEffect
+sidebar_label: useTrackedEffect
+---
+
+## About
+
+Like `useEffect`, but the callback receives detailed information about **which dependencies changed**, their previous values, and their current values. Designed for debugging effects and writing conditional logic inside an effect based on what actually triggered the re-run.
+
+## Examples
+
+### Log which dependency triggered the effect
+
+```jsx
+import { useState } from "react";
+import { useTrackedEffect } from "rooks";
+
+export default function DebugEffect() {
+  const [userId, setUserId] = useState(1);
+  const [filter, setFilter] = useState("all");
+
+  useTrackedEffect(
+    (changes, previousDeps, currentDeps) => {
+      changes.forEach(({ index, previousValue, currentValue }) => {
+        console.log(`dep[${index}] changed: ${String(previousValue)} → ${String(currentValue)}`);
+      });
+    },
+    [userId, filter]
+  );
+
+  return (
+    <div>
+      <button onClick={() => setUserId((id) => id + 1)}>Change user</button>
+      <button onClick={() => setFilter("active")}>Set active filter</button>
+    </div>
+  );
+}
+```
+
+### Run conditional logic based on which dep changed
+
+```jsx
+import { useState } from "react";
+import { useTrackedEffect } from "rooks";
+
+export default function SmartFetch() {
+  const [userId, setUserId] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+
+  useTrackedEffect(
+    (changes) => {
+      const userChanged = changes.some((c) => c.index === 0);
+      const pageSizeChanged = changes.some((c) => c.index === 1);
+
+      if (userChanged) {
+        // Full reload needed when the user changes
+        console.log("Fetching all data for new user:", userId);
+      } else if (pageSizeChanged) {
+        // Only re-paginate when page size changes
+        console.log("Re-paginating with page size:", pageSize);
+      }
+    },
+    [userId, pageSize]
+  );
+
+  return (
+    <div>
+      <button onClick={() => setUserId((id) => id + 1)}>Next user</button>
+      <button onClick={() => setPageSize((s) => s + 5)}>Increase page size</button>
+    </div>
+  );
+}
+```
+
+### Inspect the full previous and current snapshots
+
+```jsx
+import { useState } from "react";
+import { useTrackedEffect } from "rooks";
+
+export default function SnapshotInspector() {
+  const [name, setName] = useState("Alice");
+  const [age, setAge] = useState(30);
+
+  useTrackedEffect(
+    (changes, previousDeps, currentDeps) => {
+      if (changes.length === 0) return;
+      console.log("Previous snapshot:", previousDeps);
+      console.log("Current snapshot:", currentDeps);
+      console.log("Changed indices:", changes.map((c) => c.index));
+    },
+    [name, age]
+  );
+
+  return (
+    <div>
+      <button onClick={() => setName("Bob")}>Change name</button>
+      <button onClick={() => setAge(31)}>Change age</button>
+    </div>
+  );
+}
+```
+
+### Return a cleanup function
+
+```jsx
+import { useState } from "react";
+import { useTrackedEffect } from "rooks";
+
+export default function SubscriptionExample() {
+  const [channelId, setChannelId] = useState("general");
+
+  useTrackedEffect(
+    (changes) => {
+      const sub = subscribeToChannel(channelId);
+      console.log("Subscribed to:", channelId);
+      if (changes.length > 0) {
+        console.log("Re-subscribed because channelId changed from", changes[0].previousValue);
+      }
+      return () => {
+        sub.unsubscribe();
+        console.log("Unsubscribed from:", channelId);
+      };
+    },
+    [channelId]
+  );
+
+  return (
+    <button onClick={() => setChannelId("random")}>Switch channel</button>
+  );
+}
+```
+
+## Arguments
+
+| Argument | Type                       | Description                                                                                                  |
+| -------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| effect   | `TrackedEffectCallback`    | Callback invoked after each render where deps changed. Receives `changes`, `previousDeps`, and `currentDeps`. May return an optional cleanup function. |
+| deps     | `readonly unknown[]`       | Dependency array — same semantics as the second argument of `useEffect`.                                     |
+
+### `changes` array entries (`DepChange`)
+
+| Field           | Type      | Description                                                                     |
+| --------------- | --------- | ------------------------------------------------------------------------------- |
+| `index`         | `number`  | Zero-based position of this dependency in the `deps` array.                     |
+| `previousValue` | `unknown` | Value of the dependency on the previous render. `undefined` on initial mount.   |
+| `currentValue`  | `unknown` | Value of the dependency on the current render.                                  |
+
+## Returns
+
+`void` — this hook does not return a value.
+
+## Notes
+
+- On the **initial mount**, every dependency is included in `changes` (with `previousValue: undefined`) because there is no prior run to compare with. `previousDeps` is `[]`.
+- Uses `Object.is` for equality checks, matching React's own dep-comparison behaviour.
+- SSR: behaves identically to `useEffect` — the callback is not invoked on the server.

--- a/apps/website/content/docs/hooks/(performance)/useCreation.mdx
+++ b/apps/website/content/docs/hooks/(performance)/useCreation.mdx
@@ -1,0 +1,94 @@
+---
+id: useCreation
+title: useCreation
+sidebar_label: useCreation
+---
+
+## About
+
+A stable alternative to `useMemo`. Unlike `useMemo`, `useCreation` guarantees that React will **never** silently discard your cached value.
+
+React's documentation explicitly notes that `useMemo` is a *performance hint* — future versions may choose to forget memoised values (e.g. to free memory during off-screen rendering). `useCreation` stores the value in a `useRef`, which React cannot reclaim, so the factory is called **only** when the dependency array actually changes.
+
+Use `useCreation` when:
+- The created value must remain **referentially stable** (e.g. class instances, event emitters, WebSocket connections).
+- Downstream hooks or components rely on reference equality and a silent recompute would cause subtle bugs.
+- You are building an expensive object whose recreation must be strictly controlled.
+
+For pure performance hints where occasional silent re-computation is acceptable, prefer the built-in `useMemo`.
+
+[//]: # "Main"
+
+## Examples
+
+### Stable class instance
+
+```jsx
+import { useCreation } from "rooks";
+
+class ExpensiveParser {
+  constructor(config) {
+    this.config = config;
+    // ... expensive initialisation
+  }
+  parse(input) {
+    return input.toUpperCase();
+  }
+}
+
+export default function App({ config }) {
+  // Guaranteed: only a new ExpensiveParser is created when `config` changes.
+  // React will never silently recreate it.
+  const parser = useCreation(() => new ExpensiveParser(config), [config]);
+
+  return <div>{parser.parse("hello world")}</div>;
+}
+```
+
+### Stable event emitter
+
+```jsx
+import { useCreation } from "rooks";
+import EventEmitter from "eventemitter3";
+
+export default function App() {
+  // The same EventEmitter instance is used for the entire component lifetime.
+  const emitter = useCreation(() => new EventEmitter(), []);
+
+  return (
+    <button onClick={() => emitter.emit("click", Date.now())}>
+      Emit event
+    </button>
+  );
+}
+```
+
+### Guarding against useMemo's non-guarantee
+
+```jsx
+import { useCreation } from "rooks";
+
+export default function ChartComponent({ data }) {
+  // If useMemo silently recomputed this, downstream effects keyed on
+  // `processedData` would re-run unnecessarily. useCreation prevents that.
+  const processedData = useCreation(
+    () => data.map((point) => ({ ...point, y: point.y * 2 })),
+    [data]
+  );
+
+  return <Chart data={processedData} />;
+}
+```
+
+### Arguments
+
+| Argument | Type                  | Description                                                                                      |
+| -------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| factory  | `() => T`             | A function that produces the value. Called once on mount, then again only when `deps` change.    |
+| deps     | `readonly unknown[]`  | Dependency array. The factory is re-run whenever any element changes (compared with `Object.is`). |
+
+### Return Value
+
+| Return value | Type | Description                                                         |
+| ------------ | ---- | ------------------------------------------------------------------- |
+| value        | `T`  | The stable cached value. Only a new value is returned when deps change. |

--- a/apps/website/content/docs/hooks/(performance)/useLockFn.mdx
+++ b/apps/website/content/docs/hooks/(performance)/useLockFn.mdx
@@ -1,0 +1,140 @@
+---
+id: useLockFn
+title: useLockFn
+sidebar_label: useLockFn
+---
+
+## About
+
+Wraps an async function with a concurrency lock to prevent duplicate in-flight calls (anti-double-submit pattern). While a call is in-flight, any subsequent call returns `undefined` immediately without invoking the original function. The lock is implemented with a ref, so no extra re-renders are triggered. Safe to use in SSR environments.
+
+[//]: # "Main"
+
+## Examples
+
+#### Prevent double form submission
+
+```jsx
+import { useLockFn } from "rooks";
+
+export default function App() {
+  const handleSubmit = useLockFn(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    alert("Form submitted!");
+  });
+
+  return (
+    <div>
+      <p>Click the button multiple times — only the first click submits.</p>
+      <button onClick={handleSubmit}>Submit</button>
+    </div>
+  );
+}
+```
+
+#### With loading state using useState alongside the lock
+
+```jsx
+import { useLockFn } from "rooks";
+import { useState } from "react";
+
+export default function App() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [result, setResult] = useState(null);
+
+  const fetchData = useLockFn(async (id) => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`https://jsonplaceholder.typicode.com/todos/${id}`);
+      const data = await response.json();
+      setResult(data);
+    } finally {
+      setIsLoading(false);
+    }
+  });
+
+  return (
+    <div>
+      <button onClick={() => fetchData(1)} disabled={isLoading}>
+        {isLoading ? "Loading..." : "Fetch Todo #1"}
+      </button>
+      {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
+    </div>
+  );
+}
+```
+
+#### Typed generics — preserving argument and return types
+
+```jsx
+import { useLockFn } from "rooks";
+
+async function saveUser(name, age) {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return { id: Date.now(), name, age };
+}
+
+export default function App() {
+  const lockedSave = useLockFn(saveUser);
+
+  const handleClick = async () => {
+    const user = await lockedSave("Alice", 30);
+    if (user !== undefined) {
+      console.log("Saved:", user);
+    } else {
+      console.log("Call was skipped — already in-flight.");
+    }
+  };
+
+  return <button onClick={handleClick}>Save user</button>;
+}
+```
+
+#### Cleanup on unmount — no dangling lock after component is removed
+
+```jsx
+import { useLockFn } from "rooks";
+import { useState } from "react";
+
+function AsyncButton() {
+  const handleClick = useLockFn(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    console.log("Done! (only fires if still mounted during the call)");
+  });
+
+  return <button onClick={handleClick}>Start long task</button>;
+}
+
+export default function App() {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div>
+      <button onClick={() => setShow((s) => !s)}>
+        {show ? "Unmount" : "Mount"} button
+      </button>
+      {show && <AsyncButton />}
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument | Type                                         | Description                                  | Default |
+| -------- | -------------------------------------------- | -------------------------------------------- | ------- |
+| fn       | `(...args: TParams) => Promise<TResult>`     | The async function to wrap with a lock       | -       |
+
+### Returns
+
+| Return value | Type                                                      | Description                                                                                        |
+| ------------ | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| lockedFn     | `(...args: TParams) => Promise<TResult \| undefined>`     | Wrapped function. Returns `undefined` immediately if a previous call is still in-flight; otherwise delegates to `fn` and returns its resolved value. |
+
+### Notes
+
+- The lock uses `useRef` internally — no React state is updated when a call is blocked, so components do **not** re-render on blocked calls. Use a separate `useState` if you need to show a loading indicator.
+- The lock is released in a `finally` block, so it is always cleared whether `fn` resolves or rejects.
+- The lock ref is reset to `false` on component unmount to prevent stale lock state if the component remounts.
+- The wrapped function is memoised with `useCallback` and always calls the latest version of `fn` (via `useFreshRef`), so it is safe to pass to child components or event handlers without causing unnecessary re-renders.
+- SSR safe — no `window` or browser-specific APIs are used.

--- a/apps/website/content/docs/hooks/(state)/useCookieState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useCookieState.mdx
@@ -1,0 +1,119 @@
+---
+id: useCookieState
+title: useCookieState
+sidebar_label: useCookieState
+---
+
+## About
+
+useState but backed by a browser cookie. Values are JSON-serialised automatically. The hook is SSR-safe — on the server it returns the default value and a no-op setter. Changes are synced across same-origin tabs via the BroadcastChannel API and across multiple hook instances in the same document via custom events.
+
+[//]: # "Main"
+
+## Examples
+
+### Basic example
+
+```jsx
+import { useCookieState } from "rooks";
+
+export default function App() {
+  const [theme, setTheme] = useCookieState("app-theme", {
+    defaultValue: "light",
+    expires: 30,
+    path: "/",
+  });
+
+  return (
+    <div>
+      <p>Current theme: {theme}</p>
+      <button onClick={() => setTheme("dark")}>Dark</button>
+      <button onClick={() => setTheme("light")}>Light</button>
+    </div>
+  );
+}
+```
+
+### Using an updater function
+
+```jsx
+import { useCookieState } from "rooks";
+
+export default function Counter() {
+  const [count, setCount] = useCookieState("visit-count", {
+    defaultValue: 0,
+    expires: 365,
+  });
+
+  return (
+    <div>
+      <p>Visits: {count}</p>
+      <button onClick={() => setCount((prev) => prev + 1)}>Increment</button>
+      <button onClick={() => setCount(0)}>Reset</button>
+    </div>
+  );
+}
+```
+
+### Storing an object
+
+```jsx
+import { useCookieState } from "rooks";
+
+const defaultPrefs = { fontSize: 16, language: "en" };
+
+export default function Settings() {
+  const [prefs, setPrefs] = useCookieState("user-prefs", {
+    defaultValue: defaultPrefs,
+    expires: 90,
+    sameSite: "lax",
+    secure: true,
+  });
+
+  return (
+    <div>
+      <p>Font size: {prefs.fontSize}</p>
+      <button
+        onClick={() =>
+          setPrefs((prev) => ({ ...prev, fontSize: prev.fontSize + 2 }))
+        }
+      >
+        Increase font size
+      </button>
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument     | Type                          | Description                    | Default     |
+| ------------ | ----------------------------- | ------------------------------ | ----------- |
+| cookieName   | `string`                      | Name of the cookie             | _required_  |
+| options      | `UseCookieStateOptions<T>`    | Cookie attributes and defaults | `{}`        |
+
+#### options
+
+| Option         | Type                               | Description                                                                                       | Default     |
+| -------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- | ----------- |
+| defaultValue   | `T \| (() => T)`                   | Value (or factory) used when the cookie does not exist yet                                        | `undefined` |
+| expires        | `number \| Date`                   | Expiry as days from now (number) or an explicit `Date`. Omit for a session cookie.                | `undefined` |
+| path           | `string`                           | Cookie `path` attribute                                                                           | `"/"`       |
+| domain         | `string`                           | Cookie `domain` attribute                                                                         | `undefined` |
+| secure         | `boolean`                          | Sets the `Secure` flag                                                                            | `undefined` |
+| sameSite       | `"strict" \| "lax" \| "none"`      | `SameSite` cookie attribute                                                                       | `undefined` |
+
+### Returns
+
+Returns a tuple of two items:
+
+| Return value     | Type                         | Description                                                              |
+| ---------------- | ---------------------------- | ------------------------------------------------------------------------ |
+| cookieValue      | `T`                          | The current cookie value (deserialised from JSON)                        |
+| setCookieValue   | `Dispatch<SetStateAction<T>>`| Set a new value directly or via an updater function `(prev: T) => T`     |
+
+### Notes
+
+- Values are stored as JSON, so any JSON-serialisable type works (string, number, boolean, object, array).
+- Cookies do not fire the native `storage` event. Cross-tab synchronisation is handled via **BroadcastChannel** (supported in all modern browsers). In environments where `BroadcastChannel` is unavailable, changes made in another tab will only be visible after a page reload.
+- The hook is fully SSR-safe. When `document` is undefined (server-side rendering), the initial state is the resolved `defaultValue` and the setter is a no-op.

--- a/apps/website/content/docs/hooks/(utilities)/useLatest.mdx
+++ b/apps/website/content/docs/hooks/(utilities)/useLatest.mdx
@@ -1,0 +1,113 @@
+---
+id: useLatest
+title: useLatest
+sidebar_label: useLatest
+---
+
+## About
+
+Returns a ref that always holds the latest value, solving the stale closure problem. The ref is updated synchronously during render, so `ref.current` is always up-to-date—even in callbacks and effects that were set up long ago.
+
+<br />
+
+## Why useLatest?
+
+React closures capture the value of state and props at the time the function is created. This causes **stale closures**: an interval or event listener created once will keep reading the old value forever.
+
+`useLatest` solves this by storing the value in a ref. Refs are mutable objects whose identity never changes, so any callback that holds a reference to the ref will always read the latest value via `.current`.
+
+```
+Stale closure:           With useLatest:
+render #1 → count = 0   render #1 → ref.current = 0
+render #2 → count = 1   render #2 → ref.current = 1
+                                        ↑ always fresh
+interval callback reads 0 forever    interval callback reads ref.current ✓
+```
+
+<br />
+
+## Examples
+
+### Keep an interval in sync with state
+
+```jsx
+import { useState, useEffect } from "react";
+import { useLatest } from "rooks";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+  const latestCount = useLatest(count);
+
+  useEffect(() => {
+    // Registered once — no stale closure because we read latestCount.current
+    const id = setInterval(() => {
+      setCount(latestCount.current + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []); // empty deps intentional
+
+  return <h1>Count: {count}</h1>;
+}
+```
+
+### Use latest value inside an event handler
+
+```jsx
+import { useState, useEffect } from "react";
+import { useLatest } from "rooks";
+
+export default function SearchLogger() {
+  const [query, setQuery] = useState("");
+  const latestQuery = useLatest(query);
+
+  useEffect(() => {
+    function onKeyDown(e) {
+      if (e.key === "Enter") {
+        // Always logs the current query, not the one captured at mount
+        console.log("Searching for:", latestQuery.current);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []); // add listener once, always reads fresh query
+
+  return (
+    <input
+      value={query}
+      onChange={(e) => setQuery(e.target.value)}
+      placeholder="Type and press Enter"
+    />
+  );
+}
+```
+
+### Difference from useFreshRef
+
+`useFreshRef` updates its ref inside a `useEffect`, meaning the ref holds the previous value during the current render. `useLatest` updates synchronously during render, so the ref is always current.
+
+```jsx
+import { useLatest, useFreshRef } from "rooks";
+
+function Example({ value }) {
+  const latest = useLatest(value);      // ref.current === value right now
+  const fresh = useFreshRef(value);     // ref.current === previous value until after paint
+
+  // ...
+}
+```
+
+Use `useLatest` when you need the value to be current during the render itself (e.g. to pass into an immediately-invoked callback). Use `useFreshRef` when you need the update to be deferred (e.g. in layout effects that depend on paint timing).
+
+## Arguments
+
+| Argument | Type | Description                                     |
+| -------- | ---- | ----------------------------------------------- |
+| value    | T    | The value to keep fresh inside the returned ref |
+
+## Returns
+
+| Return value | Type                | Description                                              |
+| ------------ | ------------------- | -------------------------------------------------------- |
+| ref          | MutableRefObject\<T\> | A ref whose `.current` always equals the latest `value` |
+
+---

--- a/packages/rooks/src/__tests__/useCookieState.spec.tsx
+++ b/packages/rooks/src/__tests__/useCookieState.spec.tsx
@@ -1,0 +1,261 @@
+import { vi } from "vitest";
+import React from "react";
+import {
+  render,
+  cleanup,
+  getByTestId,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+
+import { useCookieState } from "@/hooks/useCookieState";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function clearAllCookies() {
+  document.cookie.split("; ").forEach((c) => {
+    const name = c.split("=")[0];
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+    }
+  });
+}
+
+function setCookieRaw(name: string, value: unknown) {
+  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(
+    JSON.stringify(value)
+  )}; path=/`;
+}
+
+// ─── suites ──────────────────────────────────────────────────────────────────
+
+describe("useCookieState defined", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useCookieState).toBeDefined();
+  });
+});
+
+describe("useCookieState basic", () => {
+  afterEach(() => {
+    clearAllCookies();
+    cleanup();
+  });
+
+  it("initializes with default value when cookie does not exist", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("cookie-init", { defaultValue: "hello" })
+    );
+    expect(result.current[0]).toBe("hello");
+  });
+
+  it("initializes with function default value", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("cookie-fn", { defaultValue: () => "fn-default" })
+    );
+    expect(result.current[0]).toBe("fn-default");
+  });
+
+  it("reads existing cookie value on mount (prefers cookie over default)", () => {
+    expect.hasAssertions();
+    setCookieRaw("cookie-existing", "stored-value");
+    const { result } = renderHook(() =>
+      useCookieState("cookie-existing", { defaultValue: "fallback" })
+    );
+    expect(result.current[0]).toBe("stored-value");
+  });
+
+  it("reads existing numeric cookie value", () => {
+    expect.hasAssertions();
+    setCookieRaw("cookie-num", 42);
+    const { result } = renderHook(() =>
+      useCookieState<number>("cookie-num", { defaultValue: 0 })
+    );
+    expect(result.current[0]).toBe(42);
+  });
+
+  it("reads existing object cookie value", () => {
+    expect.hasAssertions();
+    setCookieRaw("cookie-obj", { foo: "bar" });
+    const { result } = renderHook(() =>
+      useCookieState<{ foo: string }>("cookie-obj")
+    );
+    expect(result.current[0]).toEqual({ foo: "bar" });
+  });
+
+  it("sets a new value", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("cookie-set", { defaultValue: "initial" })
+    );
+    act(() => {
+      result.current[1]("updated");
+    });
+    expect(result.current[0]).toBe("updated");
+  });
+
+  it("sets a new value with an updater function", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState<number>("cookie-updater", { defaultValue: 5 })
+    );
+    act(() => {
+      result.current[1]((prev) => prev + 1);
+    });
+    expect(result.current[0]).toBe(6);
+  });
+
+  it("setter is stable across re-renders (memo)", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(() =>
+      useCookieState("cookie-memo", { defaultValue: "value" })
+    );
+
+    const setterBefore = result.current[1];
+    rerender();
+    const setterAfterRerender = result.current[1];
+    expect(setterBefore).toBe(setterAfterRerender);
+
+    act(() => {
+      setterBefore("new-value");
+    });
+    const setterAfterSet = result.current[1];
+    expect(setterBefore).toBe(setterAfterSet);
+  });
+});
+
+describe("useCookieState document.cookie writes", () => {
+  afterEach(() => {
+    clearAllCookies();
+    vi.restoreAllMocks();
+  });
+
+  it("writes value to document.cookie on init", () => {
+    expect.hasAssertions();
+
+    renderHook(() =>
+      useCookieState("cookie-write", { defaultValue: "init-value" })
+    );
+
+    // After renderHook (which wraps in act), the useEffect should have run
+    expect(document.cookie).toContain("cookie-write");
+  });
+
+  it("writes new value to document.cookie when setValue is called", () => {
+    expect.hasAssertions();
+
+    const { result } = renderHook(() =>
+      useCookieState("cookie-write2", { defaultValue: "old" })
+    );
+
+    act(() => {
+      result.current[1]("new");
+    });
+
+    expect(result.current[0]).toBe("new");
+    // Verify the new value was persisted to the cookie jar
+    expect(document.cookie).toContain("cookie-write2");
+    // Read the cookie back and verify the value
+    const raw = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith("cookie-write2="));
+    expect(raw).toBeDefined();
+    expect(decodeURIComponent(raw!.split("=")[1])).toBe(JSON.stringify("new"));
+  });
+
+  it("includes path attribute in cookie string", () => {
+    expect.hasAssertions();
+    const writtenStrings: string[] = [];
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      "cookie"
+    )!;
+    vi.spyOn(Document.prototype, "cookie", "set").mockImplementation(function (
+      this: Document,
+      val: string
+    ) {
+      writtenStrings.push(val);
+      originalDescriptor.set!.call(this, val);
+    });
+
+    renderHook(() =>
+      useCookieState("cookie-path", { defaultValue: "v", path: "/admin" })
+    );
+
+    expect(writtenStrings.some((s) => s.includes("path=/admin"))).toBe(true);
+  });
+});
+
+describe("useCookieState React component integration", () => {
+  afterEach(() => {
+    clearAllCookies();
+    cleanup();
+  });
+
+  it("renders with default value and updates on click", async () => {
+    expect.hasAssertions();
+
+    const App = () => {
+      const [theme, setTheme] = useCookieState("app-theme", {
+        defaultValue: "light",
+      });
+      return (
+        <div data-testid="container">
+          <p data-testid="value">{theme}</p>
+          <button
+            data-testid="toggle"
+            onClick={() => setTheme((prev) => (prev === "light" ? "dark" : "light"))}
+            type="button"
+          >
+            Toggle
+          </button>
+        </div>
+      );
+    };
+
+    const { container } = render(<App />);
+    expect(getByTestId(container as HTMLElement, "value").textContent).toBe(
+      "light"
+    );
+
+    act(() => {
+      fireEvent.click(getByTestId(container as HTMLElement, "toggle"));
+    });
+
+    await waitFor(() =>
+      expect(
+        getByTestId(container as HTMLElement, "value").textContent
+      ).toBe("dark")
+    );
+  });
+});
+
+describe("useCookieState within-document sync", () => {
+  afterEach(() => {
+    clearAllCookies();
+    cleanup();
+  });
+
+  it("syncs value across two hook instances in the same document", () => {
+    expect.hasAssertions();
+
+    const { result: a } = renderHook(() =>
+      useCookieState("cookie-sync", { defaultValue: "first" })
+    );
+    const { result: b } = renderHook(() =>
+      useCookieState("cookie-sync", { defaultValue: "first" })
+    );
+
+    act(() => {
+      a.current[1]("updated");
+    });
+
+    // Both instances should reflect the new value
+    expect(a.current[0]).toBe("updated");
+    expect(b.current[0]).toBe("updated");
+  });
+});

--- a/packages/rooks/src/__tests__/useCreation.spec.ts
+++ b/packages/rooks/src/__tests__/useCreation.spec.ts
@@ -1,0 +1,129 @@
+import { renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+import { useCreation } from "@/hooks/useCreation";
+
+describe("useCreation", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useCreation).toBeDefined();
+  });
+
+  it("should call the factory on initial render", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({ id: 1 }));
+    renderHook(() => useCreation(factory, []));
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return the value produced by the factory", () => {
+    expect.hasAssertions();
+    const value = { id: 42 };
+    const { result } = renderHook(() => useCreation(() => value, []));
+    expect(result.current).toBe(value);
+  });
+
+  it("should not call the factory again when deps have not changed", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({ id: 1 }));
+    const { rerender } = renderHook(() => useCreation(factory, [1, "a"]));
+    rerender();
+    rerender();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return the same reference across re-renders when deps are stable", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(() =>
+      useCreation(() => ({ id: 1 }), [])
+    );
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it("should call the factory again when deps change", () => {
+    expect.hasAssertions();
+    const factory = vi.fn((n: number) => ({ value: n }));
+    let dep = 1;
+    const { result, rerender } = renderHook(() =>
+      useCreation(() => factory(dep), [dep])
+    );
+    expect(result.current).toEqual({ value: 1 });
+
+    dep = 2;
+    rerender();
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ value: 2 });
+  });
+
+  it("should produce a new reference when deps change", () => {
+    expect.hasAssertions();
+    let dep = 1;
+    const { result, rerender } = renderHook(() =>
+      useCreation(() => ({ value: dep }), [dep])
+    );
+    const first = result.current;
+
+    dep = 2;
+    rerender();
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual({ value: 2 });
+  });
+
+  it("should use Object.is semantics for dep comparison (NaN equals NaN)", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({}));
+    const { rerender } = renderHook(() =>
+      useCreation(factory, [NaN])
+    );
+    rerender();
+    rerender();
+    // NaN is the same dep in two consecutive renders: factory called once
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("should recompute when one dep in a multi-dep array changes", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({}));
+    let a = 1;
+    let b = "hello";
+    const { rerender } = renderHook(() => useCreation(factory, [a, b]));
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    b = "world";
+    rerender();
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("should work with primitive return types", () => {
+    expect.hasAssertions();
+    let counter = 0;
+    const { result, rerender } = renderHook(() =>
+      useCreation(() => ++counter, [])
+    );
+    expect(result.current).toBe(1);
+    rerender();
+    // counter should still be 1 — factory not re-invoked
+    expect(result.current).toBe(1);
+  });
+
+  it("should work with function return types", () => {
+    expect.hasAssertions();
+    const fn = () => 42;
+    const { result } = renderHook(() => useCreation(() => fn, []));
+    expect(result.current).toBe(fn);
+    expect(result.current()).toBe(42);
+  });
+
+  it("should handle changing dep array length", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({}));
+    let deps: unknown[] = [1];
+    const { rerender } = renderHook(() => useCreation(factory, deps));
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    deps = [1, 2];
+    rerender();
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/rooks/src/__tests__/useLatest.spec.tsx
+++ b/packages/rooks/src/__tests__/useLatest.spec.tsx
@@ -1,0 +1,169 @@
+import { vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useEffect, useState } from "react";
+import { useLatest } from "@/hooks/useLatest";
+
+describe("useLatest", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useLatest).toBeDefined();
+  });
+
+  it("should return a ref with the initial value", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useLatest(42));
+    expect(result.current.current).toBe(42);
+  });
+
+  it("should update ref.current synchronously when value changes", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(
+      ({ value }) => useLatest(value),
+      { initialProps: { value: "hello" } }
+    );
+    expect(result.current.current).toBe("hello");
+
+    rerender({ value: "world" });
+    expect(result.current.current).toBe("world");
+  });
+
+  it("should return a stable ref object across re-renders", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(
+      ({ value }) => useLatest(value),
+      { initialProps: { value: 1 } }
+    );
+    const refBefore = result.current;
+
+    rerender({ value: 2 });
+    const refAfter = result.current;
+
+    expect(refBefore).toBe(refAfter);
+  });
+
+  it("should work with function values", () => {
+    expect.hasAssertions();
+    const fn1 = () => "first";
+    const fn2 = () => "second";
+
+    const { result, rerender } = renderHook(
+      ({ fn }) => useLatest(fn),
+      { initialProps: { fn: fn1 } }
+    );
+    expect(result.current.current).toBe(fn1);
+    expect(result.current.current()).toBe("first");
+
+    rerender({ fn: fn2 });
+    expect(result.current.current).toBe(fn2);
+    expect(result.current.current()).toBe("second");
+  });
+
+  it("should work with object values", () => {
+    expect.hasAssertions();
+    const obj1 = { a: 1 };
+    const obj2 = { a: 2 };
+
+    const { result, rerender } = renderHook(
+      ({ obj }) => useLatest(obj),
+      { initialProps: { obj: obj1 } }
+    );
+    expect(result.current.current).toBe(obj1);
+
+    rerender({ obj: obj2 });
+    expect(result.current.current).toBe(obj2);
+  });
+
+  it("should work with null and undefined values", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(
+      ({ value }) => useLatest<string | null | undefined>(value),
+      { initialProps: { value: "test" as string | null | undefined } }
+    );
+    expect(result.current.current).toBe("test");
+
+    rerender({ value: null });
+    expect(result.current.current).toBeNull();
+
+    rerender({ value: undefined });
+    expect(result.current.current).toBeUndefined();
+  });
+
+  it("should solve the stale closure problem in callbacks", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => {
+      const [count, setCount] = useState(0);
+      const latestCount = useLatest(count);
+
+      function handleClick() {
+        // Always reads the latest count, no stale closure
+        setCount(latestCount.current + 1);
+      }
+
+      return { count, handleClick };
+    });
+
+    act(() => {
+      result.current.handleClick();
+    });
+    expect(result.current.count).toBe(1);
+
+    act(() => {
+      result.current.handleClick();
+    });
+    expect(result.current.count).toBe(2);
+
+    act(() => {
+      result.current.handleClick();
+    });
+    expect(result.current.count).toBe(3);
+  });
+
+  describe("with fake timers", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should allow interval callback to use the latest value without re-registering the interval", () => {
+      expect.hasAssertions();
+      const { result, unmount } = renderHook(() => {
+        const [currentValue, setCurrentValue] = useState(0);
+        function increment() {
+          setCurrentValue(currentValue + 1);
+        }
+        const latestIncrement = useLatest(increment);
+
+        useEffect(() => {
+          const intervalId = setInterval(() => {
+            latestIncrement.current();
+          }, 1_000);
+          return () => clearInterval(intervalId);
+        }, []); // empty deps — interval registered once, always uses latest
+
+        return { currentValue };
+      });
+
+      expect(result.current.currentValue).toBe(0);
+
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(result.current.currentValue).toBe(1);
+
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(result.current.currentValue).toBe(2);
+
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(result.current.currentValue).toBe(3);
+
+      unmount();
+    });
+  });
+});

--- a/packages/rooks/src/__tests__/useLockFn.spec.ts
+++ b/packages/rooks/src/__tests__/useLockFn.spec.ts
@@ -1,0 +1,197 @@
+import { vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useLockFn } from "@/hooks/useLockFn";
+
+describe("useLockFn", () => {
+  it("is defined", () => {
+    expect.hasAssertions();
+    expect(useLockFn).toBeDefined();
+  });
+
+  it("should return a function", () => {
+    expect.hasAssertions();
+    const fn = vi.fn().mockResolvedValue("result");
+    const { result } = renderHook(() => useLockFn(fn));
+    expect(typeof result.current).toBe("function");
+  });
+
+  it("should call fn and return its result", async () => {
+    expect.hasAssertions();
+    const fn = vi.fn().mockResolvedValue("result");
+    const { result } = renderHook(() => useLockFn(fn));
+
+    let returnValue: string | undefined;
+    await act(async () => {
+      returnValue = await result.current();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(returnValue).toBe("result");
+  });
+
+  it("should pass arguments to fn", async () => {
+    expect.hasAssertions();
+    const fn = vi.fn().mockResolvedValue("ok");
+    const { result } = renderHook(() =>
+      useLockFn(fn as (...args: unknown[]) => Promise<string>)
+    );
+
+    await act(async () => {
+      await result.current("arg1", 42, true);
+    });
+
+    expect(fn).toHaveBeenCalledWith("arg1", 42, true);
+  });
+
+  it("should prevent concurrent calls while first is in-flight", async () => {
+    expect.hasAssertions();
+    let resolveFirst!: (value: string) => void;
+    const firstPromise = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fn = vi.fn().mockReturnValue(firstPromise);
+    const { result } = renderHook(() => useLockFn(fn));
+
+    let firstReturn: string | undefined;
+    let secondReturn: string | undefined;
+
+    await act(async () => {
+      const firstCall = result.current();
+      const secondCall = result.current();
+
+      resolveFirst("first");
+
+      [firstReturn, secondReturn] = await Promise.all([firstCall, secondCall]);
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(firstReturn).toBe("first");
+    expect(secondReturn).toBeUndefined();
+  });
+
+  it("should allow a new call after the previous one completes", async () => {
+    expect.hasAssertions();
+    const fn = vi.fn().mockResolvedValue("result");
+    const { result } = renderHook(() => useLockFn(fn));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("should release lock even when fn throws", async () => {
+    expect.hasAssertions();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("first failed"))
+      .mockResolvedValueOnce("second succeeded");
+    const { result } = renderHook(() => useLockFn(fn));
+
+    await act(async () => {
+      try {
+        await result.current();
+      } catch {
+        // expected rejection
+      }
+    });
+
+    let returnValue: string | undefined;
+    await act(async () => {
+      returnValue = await result.current();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(returnValue).toBe("second succeeded");
+  });
+
+  it("should block all concurrent calls, not just the second", async () => {
+    expect.hasAssertions();
+    let resolveFirst!: (value: string) => void;
+    const firstPromise = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fn = vi.fn().mockReturnValue(firstPromise);
+    const { result } = renderHook(() => useLockFn(fn));
+
+    let results: Array<string | undefined> = [];
+
+    await act(async () => {
+      const calls = [
+        result.current(),
+        result.current(),
+        result.current(),
+        result.current(),
+      ];
+      resolveFirst("only-one");
+      results = await Promise.all(calls);
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(results[0]).toBe("only-one");
+    expect(results[1]).toBeUndefined();
+    expect(results[2]).toBeUndefined();
+    expect(results[3]).toBeUndefined();
+  });
+
+  it("should use the latest version of fn without re-creating the wrapper", async () => {
+    expect.hasAssertions();
+    const fn1 = vi.fn().mockResolvedValue("from-fn1");
+    const fn2 = vi.fn().mockResolvedValue("from-fn2");
+
+    const { result, rerender } = renderHook(
+      ({ fn }) => useLockFn(fn),
+      { initialProps: { fn: fn1 } }
+    );
+
+    const wrappedBefore = result.current;
+
+    rerender({ fn: fn2 });
+
+    // The wrapper identity should remain stable
+    expect(result.current).toBe(wrappedBefore);
+
+    let returnValue: string | undefined;
+    await act(async () => {
+      returnValue = await result.current();
+    });
+
+    // Should have called the latest fn (fn2), not the stale fn1
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).toHaveBeenCalledTimes(1);
+    expect(returnValue).toBe("from-fn2");
+  });
+
+  it("should clean up lock ref on unmount", async () => {
+    expect.hasAssertions();
+    let resolveFirst!: (value: string) => void;
+    const firstPromise = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fn = vi.fn().mockReturnValue(firstPromise);
+    const { result, unmount } = renderHook(() => useLockFn(fn));
+
+    // Start a call but don't await it yet
+    let firstCallPromise: Promise<string | undefined>;
+    act(() => {
+      firstCallPromise = result.current();
+    });
+
+    // Unmount while the call is still in-flight
+    unmount();
+
+    // Resolve the underlying promise after unmount
+    await act(async () => {
+      resolveFirst("value");
+      await firstCallPromise;
+    });
+
+    // No errors should be thrown; the lock was cleared on unmount
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/rooks/src/__tests__/useTextSelection.spec.tsx
+++ b/packages/rooks/src/__tests__/useTextSelection.spec.tsx
@@ -1,0 +1,496 @@
+import { renderHook, act } from "@testing-library/react";
+import { useRef } from "react";
+import { vi } from "vitest";
+import { useTextSelection } from "@/hooks/useTextSelection";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fireSelectionChange() {
+  const event = new Event("selectionchange", { bubbles: false });
+  document.dispatchEvent(event);
+}
+
+function fireMouseDown(target: EventTarget, relatedTarget?: Node) {
+  const event = new MouseEvent("mousedown", {
+    bubbles: true,
+    cancelable: true,
+  });
+  if (relatedTarget) {
+    Object.defineProperty(event, "target", {
+      value: relatedTarget,
+      writable: false,
+    });
+  }
+  target.dispatchEvent(event);
+}
+
+interface MockSelectionOptions {
+  anchorNode?: Node;
+  focusNode?: Node;
+  anchorOffset?: number;
+  focusOffset?: number;
+  isCollapsed?: boolean;
+  rangeCount?: number;
+}
+
+function mockWindowSelection(
+  text: string,
+  options: MockSelectionOptions = {}
+) {
+  const fakeRect: DOMRect = {
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 20,
+    top: 20,
+    right: 110,
+    bottom: 40,
+    left: 10,
+    toJSON: () => ({}),
+  };
+  const fakeRange = {
+    getBoundingClientRect: vi.fn(() => fakeRect),
+  };
+  const fakeSelection = {
+    toString: () => text,
+    isCollapsed: options.isCollapsed ?? !text,
+    anchorNode: options.anchorNode ?? document.body,
+    focusNode: options.focusNode ?? document.body,
+    anchorOffset: options.anchorOffset ?? 0,
+    focusOffset: options.focusOffset ?? text.length,
+    rangeCount: options.rangeCount ?? (text ? 1 : 0),
+    getRangeAt: vi.fn(() => fakeRange),
+  };
+  vi.spyOn(window, "getSelection").mockReturnValue(
+    fakeSelection as unknown as Selection
+  );
+  return { fakeSelection, fakeRange, fakeRect };
+}
+
+function mockEmptySelection() {
+  const fakeSelection = {
+    toString: () => "",
+    isCollapsed: true,
+    anchorNode: null,
+    focusNode: null,
+    anchorOffset: 0,
+    focusOffset: 0,
+    rangeCount: 0,
+    getRangeAt: vi.fn(),
+  };
+  vi.spyOn(window, "getSelection").mockReturnValue(
+    fakeSelection as unknown as Selection
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useTextSelection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEmptySelection();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -- existence --
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useTextSelection).toBeDefined();
+  });
+
+  // -- initial state --
+
+  it("should return a tuple", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    expect(Array.isArray(result.current)).toBe(true);
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("should start with empty selection state", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    const [state] = result.current;
+    expect(state).toEqual({
+      text: "",
+      rect: null,
+      startOffset: 0,
+      endOffset: 0,
+      anchorNode: null,
+      focusNode: null,
+    });
+  });
+
+  // -- selectionchange event --
+
+  it("should update text when selectionchange fires", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("hello world");
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("hello world");
+  });
+
+  it("should expose anchorOffset as startOffset", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("foo", { anchorOffset: 3, focusOffset: 6 });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].startOffset).toBe(3);
+  });
+
+  it("should expose focusOffset as endOffset", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("foo", { anchorOffset: 3, focusOffset: 6 });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].endOffset).toBe(6);
+  });
+
+  it("should expose anchorNode", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    const node = document.createTextNode("hello");
+
+    act(() => {
+      mockWindowSelection("hello", { anchorNode: node });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].anchorNode).toBe(node);
+  });
+
+  it("should expose focusNode", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+    const node = document.createTextNode("world");
+
+    act(() => {
+      mockWindowSelection("world", { focusNode: node });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].focusNode).toBe(node);
+  });
+
+  it("should populate rect when selection has ranges", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("selected");
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].rect).not.toBeNull();
+    expect(result.current[0].rect?.width).toBe(100);
+    expect(result.current[0].rect?.height).toBe(20);
+  });
+
+  it("should reset to empty state when selection becomes empty", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    // Select something first
+    act(() => {
+      mockWindowSelection("some text");
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("some text");
+
+    // Clear selection
+    act(() => {
+      mockEmptySelection();
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("");
+    expect(result.current[0].rect).toBeNull();
+    expect(result.current[0].anchorNode).toBeNull();
+  });
+
+  it("should update on subsequent selections", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("first");
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("first");
+
+    act(() => {
+      mockWindowSelection("second");
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("second");
+  });
+
+  // -- event listener lifecycle --
+
+  it("should add selectionchange listener on mount", () => {
+    expect.hasAssertions();
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useTextSelection());
+
+    expect(addSpy).toHaveBeenCalledWith(
+      "selectionchange",
+      expect.any(Function)
+    );
+  });
+
+  it("should remove selectionchange listener on unmount", () => {
+    expect.hasAssertions();
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() => useTextSelection());
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith(
+      "selectionchange",
+      expect.any(Function)
+    );
+  });
+
+  it("should add mousedown listener on mount", () => {
+    expect.hasAssertions();
+    const addSpy = vi.spyOn(document, "addEventListener");
+
+    renderHook(() => useTextSelection());
+
+    expect(addSpy).toHaveBeenCalledWith("mousedown", expect.any(Function));
+  });
+
+  it("should remove mousedown listener on unmount", () => {
+    expect.hasAssertions();
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() => useTextSelection());
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("mousedown", expect.any(Function));
+  });
+
+  // -- collapsed / empty selection edge cases --
+
+  it("should return empty state when selection is collapsed", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("", { isCollapsed: true });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("");
+    expect(result.current[0].rect).toBeNull();
+  });
+
+  it("should return empty state when getSelection returns null", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useTextSelection());
+
+    act(() => {
+      vi.spyOn(window, "getSelection").mockReturnValue(null);
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("");
+  });
+
+  // -- target scoping --
+
+  it("should accept a target ref parameter", () => {
+    expect.hasAssertions();
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      return useTextSelection(ref);
+    }
+    const { result } = renderHook(() => TestHook());
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("should ignore selections outside the target element", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const outsideNode = document.createTextNode("outside");
+    document.body.appendChild(outsideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      // Manually point ref at target
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    act(() => {
+      // Selection nodes are outside the target
+      mockWindowSelection("outside text", {
+        anchorNode: outsideNode,
+        focusNode: outsideNode,
+      });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("");
+
+    document.body.removeChild(target);
+    document.body.removeChild(outsideNode);
+  });
+
+  it("should track selections inside the target element", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const insideNode = document.createTextNode("inside text");
+    target.appendChild(insideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    act(() => {
+      mockWindowSelection("inside text", {
+        anchorNode: insideNode,
+        focusNode: insideNode,
+      });
+      fireSelectionChange();
+    });
+
+    expect(result.current[0].text).toBe("inside text");
+
+    document.body.removeChild(target);
+  });
+
+  it("should clear state on mousedown outside target when text is selected", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    const outside = document.createElement("button");
+    document.body.appendChild(target);
+    document.body.appendChild(outside);
+    const insideNode = document.createTextNode("selected");
+    target.appendChild(insideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    // First select some text inside the target
+    act(() => {
+      mockWindowSelection("selected", {
+        anchorNode: insideNode,
+        focusNode: insideNode,
+      });
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("selected");
+
+    // Then click outside the target
+    act(() => {
+      // Dispatch mousedown on a node outside the target
+      const mousedownEvent = new MouseEvent("mousedown", { bubbles: true });
+      // Override target to be the outside element
+      Object.defineProperty(mousedownEvent, "target", {
+        value: outside,
+        writable: false,
+      });
+      document.dispatchEvent(mousedownEvent);
+    });
+
+    expect(result.current[0].text).toBe("");
+    expect(result.current[0].rect).toBeNull();
+
+    document.body.removeChild(target);
+    document.body.removeChild(outside);
+  });
+
+  it("should NOT clear state on mousedown inside target", () => {
+    expect.hasAssertions();
+
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const insideNode = document.createTextNode("stay");
+    target.appendChild(insideNode);
+
+    function TestHook() {
+      const ref = useRef<HTMLDivElement>(null);
+      (ref as React.MutableRefObject<HTMLDivElement>).current = target;
+      return useTextSelection(ref);
+    }
+
+    const { result } = renderHook(() => TestHook());
+
+    act(() => {
+      mockWindowSelection("stay", {
+        anchorNode: insideNode,
+        focusNode: insideNode,
+      });
+      fireSelectionChange();
+    });
+    expect(result.current[0].text).toBe("stay");
+
+    // Click inside the target — should NOT clear
+    act(() => {
+      const mousedownEvent = new MouseEvent("mousedown", { bubbles: true });
+      Object.defineProperty(mousedownEvent, "target", {
+        value: target,
+        writable: false,
+      });
+      document.dispatchEvent(mousedownEvent);
+    });
+
+    expect(result.current[0].text).toBe("stay");
+
+    document.body.removeChild(target);
+  });
+
+  // -- multiple instances --
+
+  it("should support multiple independent hook instances", () => {
+    expect.hasAssertions();
+    const { result: r1 } = renderHook(() => useTextSelection());
+    const { result: r2 } = renderHook(() => useTextSelection());
+
+    act(() => {
+      mockWindowSelection("shared");
+      fireSelectionChange();
+    });
+
+    expect(r1.current[0].text).toBe("shared");
+    expect(r2.current[0].text).toBe("shared");
+  });
+});

--- a/packages/rooks/src/__tests__/useTrackedEffect.spec.tsx
+++ b/packages/rooks/src/__tests__/useTrackedEffect.spec.tsx
@@ -1,0 +1,238 @@
+/**
+ */
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useState } from "react";
+import { vi } from "vitest";
+import { useTrackedEffect } from "@/hooks/useTrackedEffect";
+
+describe("useTrackedEffect", () => {
+  afterEach(cleanup);
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useTrackedEffect).toBeDefined();
+  });
+
+  describe("on mount", () => {
+    it("calls effect once on mount", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      renderHook(() => useTrackedEffect(effect, [1, "hello"]));
+      expect(effect).toHaveBeenCalledTimes(1);
+    });
+
+    it("includes all deps in changes on mount with undefined previousValues", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      renderHook(() => useTrackedEffect(effect, [1, "hello"]));
+      const [changes] = effect.mock.calls[0] as Parameters<typeof effect>;
+      expect(changes).toHaveLength(2);
+      expect(changes[0]).toEqual({
+        index: 0,
+        previousValue: undefined,
+        currentValue: 1,
+      });
+      expect(changes[1]).toEqual({
+        index: 1,
+        previousValue: undefined,
+        currentValue: "hello",
+      });
+    });
+
+    it("passes empty array as previousDeps on mount", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      renderHook(() => useTrackedEffect(effect, [42]));
+      const [, previousDeps] = effect.mock.calls[0] as Parameters<typeof effect>;
+      expect(previousDeps).toEqual([]);
+    });
+
+    it("passes current deps as currentDeps on mount", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      renderHook(() => useTrackedEffect(effect, [42, "world"]));
+      const [, , currentDeps] = effect.mock.calls[0] as Parameters<typeof effect>;
+      expect(currentDeps).toEqual([42, "world"]);
+    });
+  });
+
+  describe("when a single dep changes", () => {
+    it("calls effect with only the changed dep in changes", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      const { rerender } = renderHook(
+        ({ count, name }: { count: number; name: string }) =>
+          useTrackedEffect(effect, [count, name]),
+        { initialProps: { count: 0, name: "Alice" } }
+      );
+      effect.mockClear();
+
+      rerender({ count: 1, name: "Alice" });
+
+      expect(effect).toHaveBeenCalledTimes(1);
+      const [changes] = effect.mock.calls[0] as Parameters<typeof effect>;
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toEqual({
+        index: 0,
+        previousValue: 0,
+        currentValue: 1,
+      });
+    });
+
+    it("passes correct previousDeps and currentDeps on update", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      const { rerender } = renderHook(
+        ({ count, name }: { count: number; name: string }) =>
+          useTrackedEffect(effect, [count, name]),
+        { initialProps: { count: 0, name: "Alice" } }
+      );
+      effect.mockClear();
+
+      rerender({ count: 1, name: "Alice" });
+
+      const [, previousDeps, currentDeps] =
+        effect.mock.calls[0] as Parameters<typeof effect>;
+      expect(previousDeps).toEqual([0, "Alice"]);
+      expect(currentDeps).toEqual([1, "Alice"]);
+    });
+  });
+
+  describe("when multiple deps change simultaneously", () => {
+    it("includes all changed deps in changes array", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      const { rerender } = renderHook(
+        ({ count, name }: { count: number; name: string }) =>
+          useTrackedEffect(effect, [count, name]),
+        { initialProps: { count: 0, name: "Alice" } }
+      );
+      effect.mockClear();
+
+      rerender({ count: 5, name: "Bob" });
+
+      const [changes] = effect.mock.calls[0] as Parameters<typeof effect>;
+      expect(changes).toHaveLength(2);
+      expect(changes[0]).toEqual({
+        index: 0,
+        previousValue: 0,
+        currentValue: 5,
+      });
+      expect(changes[1]).toEqual({
+        index: 1,
+        previousValue: "Alice",
+        currentValue: "Bob",
+      });
+    });
+  });
+
+  describe("cleanup function", () => {
+    it("calls cleanup returned by effect when deps change", () => {
+      expect.hasAssertions();
+      const cleanupFn = vi.fn();
+      const effect = vi.fn(() => cleanupFn);
+
+      const { rerender } = renderHook(
+        ({ count }: { count: number }) =>
+          useTrackedEffect(effect, [count]),
+        { initialProps: { count: 0 } }
+      );
+
+      rerender({ count: 1 });
+
+      expect(cleanupFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls cleanup on unmount", () => {
+      expect.hasAssertions();
+      const cleanupFn = vi.fn();
+      const effect = vi.fn(() => cleanupFn);
+
+      const { unmount } = renderHook(() =>
+        useTrackedEffect(effect, [1])
+      );
+
+      unmount();
+
+      expect(cleanupFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not throw when effect returns void", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+
+      expect(() => {
+        const { rerender } = renderHook(
+          ({ count }: { count: number }) =>
+            useTrackedEffect(effect, [count]),
+          { initialProps: { count: 0 } }
+        );
+        rerender({ count: 1 });
+      }).not.toThrow();
+    });
+  });
+
+  describe("with state-driven deps", () => {
+    it("tracks changes correctly across multiple state updates", () => {
+      expect.hasAssertions();
+      const changes: Array<{ index: number; previousValue: unknown; currentValue: unknown }[]> = [];
+
+      const useHook = () => {
+        const [count, setCount] = useState(0);
+        const [label, setLabel] = useState("start");
+        useTrackedEffect(
+          (c) => {
+            changes.push([...c]);
+          },
+          [count, label]
+        );
+        return { setCount, setLabel };
+      };
+
+      const { result } = renderHook(() => useHook());
+
+      act(() => {
+        result.current.setCount(10);
+      });
+
+      act(() => {
+        result.current.setLabel("end");
+      });
+
+      // First call (mount): both deps in changes
+      expect(changes[0]).toHaveLength(2);
+      // Second call (count changed): only index 0
+      expect(changes[1]).toHaveLength(1);
+      expect(changes[1][0].index).toBe(0);
+      expect(changes[1][0].previousValue).toBe(0);
+      expect(changes[1][0].currentValue).toBe(10);
+      // Third call (label changed): only index 1
+      expect(changes[2]).toHaveLength(1);
+      expect(changes[2][0].index).toBe(1);
+      expect(changes[2][0].previousValue).toBe("start");
+      expect(changes[2][0].currentValue).toBe("end");
+    });
+  });
+
+  describe("with empty deps array", () => {
+    it("calls effect once on mount and not again on rerender", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      const { rerender } = renderHook(() => useTrackedEffect(effect, []));
+
+      rerender();
+      rerender();
+
+      expect(effect).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes empty changes array when deps array is empty", () => {
+      expect.hasAssertions();
+      const effect = vi.fn();
+      renderHook(() => useTrackedEffect(effect, []));
+
+      const [changes] = effect.mock.calls[0] as Parameters<typeof effect>;
+      expect(changes).toHaveLength(0);
+    });
+  });
+});

--- a/packages/rooks/src/hooks/useCookieState.ts
+++ b/packages/rooks/src/hooks/useCookieState.ts
@@ -1,0 +1,280 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useFreshRef } from "./useFreshRef";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function readCookieValue<T>(name: string): T | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const entries = document.cookie.split("; ");
+  for (const entry of entries) {
+    const eqIdx = entry.indexOf("=");
+    if (eqIdx === -1) continue;
+    if (decodeURIComponent(entry.slice(0, eqIdx)) === name) {
+      const raw = decodeURIComponent(entry.slice(eqIdx + 1));
+      try {
+        return JSON.parse(raw) as T;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function writeCookieValue<T>(
+  name: string,
+  value: T,
+  options: Omit<UseCookieStateOptions<T>, "defaultValue">
+): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const { expires, path = "/", domain, secure, sameSite } = options;
+
+  let str = `${encodeURIComponent(name)}=${encodeURIComponent(
+    JSON.stringify(value)
+  )}`;
+
+  if (expires !== undefined) {
+    const d =
+      typeof expires === "number"
+        ? new Date(Date.now() + expires * 864e5) // days → ms
+        : expires;
+    str += `; expires=${d.toUTCString()}`;
+  }
+
+  str += `; path=${path}`;
+  if (domain) str += `; domain=${domain}`;
+  if (secure) str += "; secure";
+  if (sameSite) str += `; samesite=${sameSite}`;
+
+  document.cookie = str;
+}
+
+function resolveInitialValue<T>(
+  cookieName: string,
+  defaultValue: T | (() => T) | undefined
+): T {
+  const cookieValue = readCookieValue<T>(cookieName);
+  if (cookieValue !== null) {
+    return cookieValue;
+  }
+  if (typeof defaultValue === "function") {
+    return (defaultValue as () => T)();
+  }
+  return defaultValue as T;
+}
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+/**
+ * Cookie attribute options for useCookieState.
+ */
+type UseCookieStateOptions<T> = {
+  /**
+   * Initial value when the cookie does not exist yet.
+   * Accepts a plain value or a zero-argument factory function.
+   */
+  defaultValue?: T | (() => T);
+  /**
+   * Expiry expressed as a number of days from now, or an explicit `Date`.
+   * Omit to create a session cookie.
+   */
+  expires?: number | Date;
+  /** Cookie `path` attribute. Defaults to `"/"`. */
+  path?: string;
+  /** Cookie `domain` attribute. */
+  domain?: string;
+  /** Whether to set the `Secure` attribute. */
+  secure?: boolean;
+  /** `SameSite` cookie attribute. */
+  sameSite?: "strict" | "lax" | "none";
+};
+
+type UseCookieStateReturnValue<T> = [T, Dispatch<SetStateAction<T>>];
+
+type BroadcastMessage<T> = { newValue: T };
+
+// ─── hook ────────────────────────────────────────────────────────────────────
+
+/**
+ * useCookieState
+ * @description Cookie-backed state with a useState-like API. Values are
+ * JSON-serialised and deserialised automatically. The hook is SSR-safe — on
+ * the server it returns the default value and a no-op setter. Changes are
+ * synced across same-origin tabs via the BroadcastChannel API (when
+ * available) and across multiple instances within the same document via a
+ * custom event.
+ *
+ * @param {string} cookieName - Name of the cookie to read from and write to
+ * @param {UseCookieStateOptions<T>} options - Cookie attributes and default value
+ * @returns {UseCookieStateReturnValue<T>} Tuple of [cookieValue, setCookieValue]
+ * @see https://rooks.vercel.app/docs/hooks/useCookieState
+ *
+ * @example
+ *
+ * const [theme, setTheme] = useCookieState("app-theme", {
+ *   defaultValue: "light",
+ *   expires: 30,
+ *   path: "/",
+ * });
+ *
+ * // Set a new value directly
+ * setTheme("dark");
+ *
+ * // Set via updater function (receives previous value)
+ * setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+ */
+function useCookieState<T>(
+  cookieName: string,
+  options: UseCookieStateOptions<T> = {}
+): UseCookieStateReturnValue<T> {
+  const { defaultValue, ...cookieOptions } = options;
+
+  const [value, setValue] = useState<T>(() =>
+    resolveInitialValue<T>(cookieName, defaultValue)
+  );
+
+  const isUpdateFromBroadcast = useRef(false);
+  const isUpdateFromWithinDocumentListener = useRef(false);
+
+  // Keep a fresh reference to the current value so the `set` callback
+  // does not need to include `value` in its dependency array.
+  const currentValueRef = useFreshRef(value, true);
+
+  // Keep a fresh reference to cookie options so they are always current
+  // inside effects without adding the options object to dependencies.
+  const cookieOptionsRef = useFreshRef(cookieOptions);
+
+  const customEventTypeName = useMemo(
+    () => `rooks-${cookieName}-cookie-update`,
+    [cookieName]
+  );
+
+  // Persist the current value to the cookie whenever it changes, unless the
+  // change originated from a cross-tab or within-document listener (those
+  // paths already have the cookie written or are reading from the cookie).
+  useEffect(() => {
+    if (
+      !isUpdateFromBroadcast.current &&
+      !isUpdateFromWithinDocumentListener.current
+    ) {
+      writeCookieValue(cookieName, value, cookieOptionsRef.current);
+    }
+    isUpdateFromBroadcast.current = false;
+    isUpdateFromWithinDocumentListener.current = false;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cookieName, value]);
+
+  // ── within-document listener (same tab, multiple hook instances) ──────────
+  const listenToCustomEventWithinDocument = useCallback(
+    (event: CustomEvent<BroadcastMessage<T>>) => {
+      try {
+        isUpdateFromWithinDocumentListener.current = true;
+        const { newValue } = event.detail;
+        if (value !== newValue) {
+          setValue(newValue);
+        }
+      } catch {
+        // ignore malformed events
+      }
+    },
+    [value]
+  );
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.addEventListener(
+        customEventTypeName,
+        listenToCustomEventWithinDocument as EventListener
+      );
+      return () => {
+        document.removeEventListener(
+          customEventTypeName,
+          listenToCustomEventWithinDocument as EventListener
+        );
+      };
+    } else {
+      console.warn("[useCookieState] document is undefined.");
+      return () => {};
+    }
+  }, [customEventTypeName, listenToCustomEventWithinDocument]);
+
+  const broadcastValueWithinDocument = useCallback(
+    (newValue: T) => {
+      if (typeof document !== "undefined") {
+        const event = new CustomEvent<BroadcastMessage<T>>(customEventTypeName, {
+          detail: { newValue },
+        });
+        document.dispatchEvent(event);
+      }
+    },
+    [customEventTypeName]
+  );
+
+  // ── cross-tab listener (BroadcastChannel) ────────────────────────────────
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") {
+      return () => {};
+    }
+
+    const channel = new BroadcastChannel(`rooks-cookie-${cookieName}`);
+
+    channel.onmessage = (event: MessageEvent<BroadcastMessage<T>>) => {
+      try {
+        isUpdateFromBroadcast.current = true;
+        const { newValue } = event.data;
+        if (value !== newValue) {
+          setValue(newValue);
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    };
+
+    return () => {
+      channel.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cookieName, value]);
+
+  // ── public setter ─────────────────────────────────────────────────────────
+  const set = useCallback(
+    (newValue: SetStateAction<T>) => {
+      const resolved =
+        typeof newValue === "function"
+          ? (newValue as (prev: T) => T)(currentValueRef.current)
+          : newValue;
+
+      isUpdateFromBroadcast.current = false;
+      isUpdateFromWithinDocumentListener.current = false;
+
+      // Write the cookie synchronously so callers see the update immediately
+      // (broadcastValueWithinDocument fires synchronously and would otherwise
+      // set isUpdateFromWithinDocumentListener before the effect runs).
+      writeCookieValue(cookieName, resolved, cookieOptionsRef.current);
+
+      setValue(resolved);
+      broadcastValueWithinDocument(resolved);
+
+      // Notify other tabs
+      if (
+        typeof window !== "undefined" &&
+        typeof BroadcastChannel !== "undefined"
+      ) {
+        const channel = new BroadcastChannel(`rooks-cookie-${cookieName}`);
+        channel.postMessage({ newValue: resolved } satisfies BroadcastMessage<T>);
+        channel.close();
+      }
+    },
+    [broadcastValueWithinDocument, cookieName, cookieOptionsRef, currentValueRef]
+  );
+
+  return [value, set];
+}
+
+export { useCookieState };
+export type { UseCookieStateOptions, UseCookieStateReturnValue };

--- a/packages/rooks/src/hooks/useCreation.ts
+++ b/packages/rooks/src/hooks/useCreation.ts
@@ -1,0 +1,77 @@
+import { useRef } from "react";
+
+type CreationCache<T> = {
+  deps: readonly unknown[];
+  value: T;
+};
+
+/**
+ * Compares two dependency arrays using Object.is for each element,
+ * mirroring the comparison React uses for useMemo/useEffect.
+ */
+function areDepsEqual(
+  prevDeps: readonly unknown[],
+  nextDeps: readonly unknown[]
+): boolean {
+  if (prevDeps.length !== nextDeps.length) return false;
+  return prevDeps.every((dep, i) => Object.is(dep, nextDeps[i]));
+}
+
+/**
+ * useCreation
+ *
+ * A stable alternative to `useMemo`. Unlike `useMemo`, React does **not**
+ * guarantee that it will preserve cached values — it may discard the memo
+ * cache to free memory (e.g. during concurrent rendering or future
+ * optimisations). `useCreation` uses a `useRef` to store the cached value,
+ * so React can never throw it away. The factory is only re-invoked when the
+ * dependency array changes (compared with `Object.is`, the same strategy
+ * React uses for hooks).
+ *
+ * Use this hook when:
+ * - The object/function you create must remain referentially stable.
+ * - Downstream hooks or components depend on reference equality and a silent
+ *   recompute from `useMemo` would cause subtle bugs or unnecessary work.
+ * - You are constructing expensive objects (e.g. class instances, parsers,
+ *   heavy data structures) whose recreation must be strictly controlled.
+ *
+ * For pure performance hints where occasional re-computation is acceptable,
+ * prefer the built-in `useMemo`.
+ *
+ * @template T - The type of value produced by the factory function.
+ * @param factory - A function that produces the value. Called once on mount,
+ *   then again only when `deps` change.
+ * @param deps - Dependency array. The factory is re-run whenever any element
+ *   changes (compared with `Object.is`).
+ * @returns The stable cached value of type `T`.
+ *
+ * @example
+ * ```tsx
+ * import { useCreation } from "rooks";
+ *
+ * function MyComponent({ config }: { config: Config }) {
+ *   // `parser` is guaranteed never to be silently recreated by React.
+ *   const parser = useCreation(() => new ExpensiveParser(config), [config]);
+ *   return <div>{parser.parse()}</div>;
+ * }
+ * ```
+ *
+ * @see https://rooks.vercel.app/docs/hooks/useCreation
+ */
+function useCreation<T>(factory: () => T, deps: readonly unknown[]): T {
+  const cacheRef = useRef<CreationCache<T> | null>(null);
+
+  if (
+    cacheRef.current === null ||
+    !areDepsEqual(cacheRef.current.deps, deps)
+  ) {
+    cacheRef.current = {
+      deps,
+      value: factory(),
+    };
+  }
+
+  return cacheRef.current.value;
+}
+
+export { useCreation };

--- a/packages/rooks/src/hooks/useLatest.ts
+++ b/packages/rooks/src/hooks/useLatest.ts
@@ -1,0 +1,41 @@
+import type { MutableRefObject } from "react";
+import { useRef } from "react";
+
+/**
+ * useLatest
+ *
+ * Returns a ref that always holds the latest value passed to it, solving
+ * the stale closure problem. Unlike useFreshRef, the ref is updated
+ * synchronously during render rather than in an effect, so it is always
+ * current—even during the same render cycle.
+ *
+ * @param value The value to keep fresh inside the ref
+ * @returns A MutableRefObject whose .current is always the latest value
+ * @see https://rooks.vercel.app/docs/hooks/useLatest
+ *
+ * @example
+ * // Solve stale closures in event listeners / intervals
+ * function SearchInput() {
+ *   const [query, setQuery] = useState("");
+ *   const latestQuery = useLatest(query);
+ *
+ *   useEffect(() => {
+ *     const id = setInterval(() => {
+ *       // latestQuery.current is always the latest query,
+ *       // even though the effect only ran once.
+ *       console.log("current query:", latestQuery.current);
+ *     }, 1000);
+ *     return () => clearInterval(id);
+ *   }, []); // empty deps — no stale closure
+ *
+ *   return <input value={query} onChange={(e) => setQuery(e.target.value)} />;
+ * }
+ */
+function useLatest<T>(value: T): MutableRefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+
+  return ref;
+}
+
+export { useLatest };

--- a/packages/rooks/src/hooks/useLockFn.ts
+++ b/packages/rooks/src/hooks/useLockFn.ts
@@ -1,0 +1,56 @@
+/**
+ * useLockFn
+ * @description Wraps an async function to prevent concurrent calls (anti-double-submit).
+ * While a call is in-flight, subsequent calls return undefined immediately without invoking fn.
+ * Uses a ref for the lock flag — no extra re-renders triggered.
+ * @see {@link https://rooks.vercel.app/docs/hooks/useLockFn}
+ */
+import { useCallback, useEffect, useRef } from "react";
+import { useFreshRef } from "./useFreshRef";
+
+/**
+ * useLockFn
+ *
+ * @param fn Async function to wrap with a concurrency lock
+ * @returns A wrapped async function with identical signature. While a call is in-flight,
+ * subsequent calls return undefined immediately without invoking fn again.
+ * @see https://rooks.vercel.app/docs/hooks/useLockFn
+ * @example
+ * ```jsx
+ * function SubmitButton() {
+ *   const handleSubmit = useLockFn(async () => {
+ *     await fetch('/api/submit', { method: 'POST' });
+ *   });
+ *   return <button onClick={handleSubmit}>Submit</button>;
+ * }
+ * ```
+ */
+function useLockFn<TParams extends unknown[], TResult>(
+  fn: (...args: TParams) => Promise<TResult>
+): (...args: TParams) => Promise<TResult | undefined> {
+  const lockRef = useRef<boolean>(false);
+  const fnRef = useFreshRef(fn);
+
+  useEffect(() => {
+    return () => {
+      lockRef.current = false;
+    };
+  }, []);
+
+  return useCallback(
+    async (...args: TParams): Promise<TResult | undefined> => {
+      if (lockRef.current) {
+        return undefined;
+      }
+      lockRef.current = true;
+      try {
+        return await fnRef.current(...args);
+      } finally {
+        lockRef.current = false;
+      }
+    },
+    [fnRef]
+  );
+}
+
+export { useLockFn };

--- a/packages/rooks/src/hooks/useTextSelection.ts
+++ b/packages/rooks/src/hooks/useTextSelection.ts
@@ -1,0 +1,186 @@
+import { useCallback, useRef, useSyncExternalStore } from "react";
+import type { RefObject } from "react";
+
+/**
+ * The shape of the text selection state returned by useTextSelection.
+ */
+type TextSelectionState = {
+  /** The selected text string. Empty string when nothing is selected. */
+  text: string;
+  /** Bounding DOMRect of the first selection range, or null when nothing is selected. */
+  rect: DOMRect | null;
+  /** Character offset within anchorNode where the selection starts. */
+  startOffset: number;
+  /** Character offset within focusNode where the selection ends. */
+  endOffset: number;
+  /** The node at which the selection begins, or null. */
+  anchorNode: Node | null;
+  /** The node at which the selection ends (the drag point), or null. */
+  focusNode: Node | null;
+};
+
+const initialSelectionState: TextSelectionState = {
+  text: "",
+  rect: null,
+  startOffset: 0,
+  endOffset: 0,
+  anchorNode: null,
+  focusNode: null,
+};
+
+/**
+ * Reads the current window.getSelection() and returns a TextSelectionState.
+ * If `targetElement` is provided, returns empty state when the selection
+ * falls outside that element.
+ */
+function readSelectionState(
+  targetElement: HTMLElement | null
+): TextSelectionState {
+  if (typeof window === "undefined" || !window.getSelection) {
+    return initialSelectionState;
+  }
+
+  const selection = window.getSelection();
+
+  if (!selection || selection.isCollapsed) {
+    return initialSelectionState;
+  }
+
+  const text = selection.toString();
+  if (!text) {
+    return initialSelectionState;
+  }
+
+  // When scoped to a target, ignore selections that stray outside it
+  if (targetElement) {
+    const { anchorNode, focusNode } = selection;
+    if (
+      !anchorNode ||
+      !focusNode ||
+      !targetElement.contains(anchorNode) ||
+      !targetElement.contains(focusNode)
+    ) {
+      return initialSelectionState;
+    }
+  }
+
+  let rect: DOMRect | null = null;
+  if (selection.rangeCount > 0) {
+    try {
+      rect = selection.getRangeAt(0).getBoundingClientRect();
+    } catch {
+      // getBoundingClientRect can throw in detached-document edge cases
+    }
+  }
+
+  return {
+    text,
+    rect,
+    startOffset: selection.anchorOffset,
+    endOffset: selection.focusOffset,
+    anchorNode: selection.anchorNode,
+    focusNode: selection.focusNode,
+  };
+}
+
+/**
+ * useTextSelection hook
+ *
+ * Tracks the currently selected text on the page or within a target element.
+ * Listens to the native `selectionchange` event on the document. Returns an
+ * empty selection state during SSR. When a `target` ref is provided the hook
+ * automatically clears the selection state when the user clicks outside of
+ * that element.
+ *
+ * @param target - Optional ref to an HTMLElement that scopes selection
+ *   tracking. Defaults to the entire document.
+ * @returns A tuple `[selectionState]` containing the current selection data.
+ *
+ * @example
+ * // Track selection anywhere on the page
+ * import { useTextSelection } from "rooks";
+ *
+ * export default function App() {
+ *   const [{ text, rect }] = useTextSelection();
+ *   return <p>You selected: {text}</p>;
+ * }
+ *
+ * @example
+ * // Scope tracking to a specific element
+ * import { useRef } from "react";
+ * import { useTextSelection } from "rooks";
+ *
+ * export default function Article() {
+ *   const ref = useRef<HTMLDivElement>(null);
+ *   const [{ text }] = useTextSelection(ref);
+ *   return (
+ *     <>
+ *       <div ref={ref}>Select text from this element only.</div>
+ *       <p>Selection: {text}</p>
+ *     </>
+ *   );
+ * }
+ *
+ * @see https://rooks.vercel.app/docs/hooks/useTextSelection
+ */
+function useTextSelection(
+  target?: RefObject<HTMLElement>
+): [TextSelectionState] {
+  const cacheRef = useRef<TextSelectionState>(initialSelectionState);
+
+  // Store target in a ref so the subscribe function stays stable across renders
+  const targetRef = useRef<RefObject<HTMLElement> | undefined>(target);
+  targetRef.current = target;
+
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    if (typeof document === "undefined") {
+      return () => {};
+    }
+
+    const handleSelectionChange = () => {
+      cacheRef.current = readSelectionState(
+        targetRef.current?.current ?? null
+      );
+      onStoreChange();
+    };
+
+    // When scoped to a target, clear state on mousedown outside that target
+    const handleMouseDown = (event: MouseEvent) => {
+      const targetElement = targetRef.current?.current;
+      if (
+        targetElement &&
+        !targetElement.contains(event.target as Node) &&
+        cacheRef.current.text !== ""
+      ) {
+        cacheRef.current = initialSelectionState;
+        onStoreChange();
+      }
+    };
+
+    document.addEventListener("selectionchange", handleSelectionChange);
+    document.addEventListener("mousedown", handleMouseDown);
+
+    return () => {
+      document.removeEventListener("selectionchange", handleSelectionChange);
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, []);
+
+  const getSnapshot = useCallback(() => cacheRef.current, []);
+
+  const getServerSnapshot = useCallback(
+    (): TextSelectionState => initialSelectionState,
+    []
+  );
+
+  const selectionState = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
+
+  return [selectionState];
+}
+
+export { useTextSelection };
+export type { TextSelectionState };

--- a/packages/rooks/src/hooks/useTrackedEffect.ts
+++ b/packages/rooks/src/hooks/useTrackedEffect.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Information about a single dependency that changed between renders.
+ */
+type DepChange = {
+  /** Zero-based position of this dependency in the deps array */
+  index: number;
+  /** Value of this dependency on the previous render (undefined on first run) */
+  previousValue: unknown;
+  /** Value of this dependency on the current render */
+  currentValue: unknown;
+};
+
+/**
+ * Callback signature for useTrackedEffect.
+ *
+ * @param changes      Every dependency that changed since the last run, in
+ *                     index order. On the initial mount every dependency is
+ *                     included because there is no prior run to compare with.
+ * @param previousDeps Full snapshot of the dependency array from the previous
+ *                     run. Empty array on the initial mount.
+ * @param currentDeps  Full snapshot of the dependency array for the current run.
+ */
+type TrackedEffectCallback = (
+  changes: Array<DepChange>,
+  previousDeps: readonly unknown[],
+  currentDeps: readonly unknown[]
+) => void | (() => void);
+
+/**
+ * useTrackedEffect hook
+ *
+ * @description Like useEffect, but the callback receives information about
+ * exactly which dependencies changed between renders — their index, previous
+ * value, and current value. Useful for debugging effects, writing conditional
+ * logic inside an effect, or understanding why an effect re-runs.
+ *
+ * SSR behaviour mirrors useEffect: the callback is not invoked on the server.
+ *
+ * @param {TrackedEffectCallback} effect Callback that receives change info,
+ *   previousDeps, and currentDeps. May return an optional cleanup function
+ *   just like a normal useEffect callback.
+ * @param {readonly unknown[]} deps The dependency array — same semantics as
+ *   the second argument of useEffect.
+ * @returns {void}
+ * @see https://rooks.vercel.app/docs/hooks/useTrackedEffect
+ *
+ * @example
+ *
+ * // Log which dependency triggered the effect
+ * useTrackedEffect(
+ *   (changes, previousDeps, currentDeps) => {
+ *     changes.forEach(({ index, previousValue, currentValue }) => {
+ *       console.log(`dep[${index}] changed:`, previousValue, "→", currentValue);
+ *     });
+ *   },
+ *   [userId, filter]
+ * );
+ *
+ * @example
+ *
+ * // Conditionally fetch only when a specific dep changes
+ * useTrackedEffect(
+ *   (changes) => {
+ *     const userChanged = changes.some((c) => c.index === 0);
+ *     if (userChanged) {
+ *       fetchUserData(userId);
+ *     }
+ *   },
+ *   [userId, pageSize]
+ * );
+ *
+ */
+function useTrackedEffect(
+  effect: TrackedEffectCallback,
+  deps: readonly unknown[]
+): void {
+  const previousDepsRef = useRef<readonly unknown[] | undefined>(undefined);
+
+  useEffect(() => {
+    const previousDeps = previousDepsRef.current;
+    const currentDeps = deps;
+
+    const changes = currentDeps.reduce<Array<DepChange>>((acc, dep, index) => {
+      if (previousDeps === undefined || !Object.is(dep, previousDeps[index])) {
+        acc.push({
+          index,
+          previousValue:
+            previousDeps !== undefined ? previousDeps[index] : undefined,
+          currentValue: dep,
+        });
+      }
+      return acc;
+    }, []);
+
+    previousDepsRef.current = currentDeps;
+
+    const cleanup = effect(changes, previousDeps ?? [], currentDeps);
+    if (typeof cleanup === "function") {
+      return cleanup;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps as unknown[]);
+}
+
+export { useTrackedEffect };
+export type { DepChange, TrackedEffectCallback };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -117,6 +117,8 @@ export { useTimeTravelState } from "./hooks/useTimeTravelState";
 export { useFetch } from "./hooks/useFetch";
 export { useThrottle } from "./hooks/useThrottle";
 export { useTimeoutWhen } from "./hooks/useTimeoutWhen";
+export { useTextSelection } from "./hooks/useTextSelection";
+export type { TextSelectionState } from "./hooks/useTextSelection";
 export { useToggle } from "./hooks/useToggle";
 export { useTrackedEffect } from "./hooks/useTrackedEffect";
 export type { DepChange, TrackedEffectCallback } from "./hooks/useTrackedEffect";

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -13,6 +13,7 @@ export { useCheckboxInputState } from "./hooks/useCheckboxInputState";
 export { useClipboard } from "./hooks/useClipboard";
 export { useCountdown } from "./hooks/useCountdown";
 export { useCounter } from "./hooks/useCounter";
+export { useCreation } from "./hooks/useCreation";
 export { useDebounce } from "./hooks/useDebounce";
 export { useDebounceFn } from "./hooks/useDebounceFn";
 export { useDebouncedAsyncEffect } from "./hooks/useDebouncedAsyncEffect";

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -11,6 +11,11 @@ export { useBoundingclientrectRef } from "./hooks/useBoundingclientrectRef";
 export { useBroadcastChannel } from "./hooks/useBroadcastChannel";
 export { useCheckboxInputState } from "./hooks/useCheckboxInputState";
 export { useClipboard } from "./hooks/useClipboard";
+export { useCookieState } from "./hooks/useCookieState";
+export type {
+  UseCookieStateOptions,
+  UseCookieStateReturnValue,
+} from "./hooks/useCookieState";
 export { useCountdown } from "./hooks/useCountdown";
 export { useCounter } from "./hooks/useCounter";
 export { useCreation } from "./hooks/useCreation";

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -61,6 +61,7 @@ export { useKeys } from "./hooks/useKeys";
 export { useLatest } from "./hooks/useLatest";
 export { useLifecycleLogger } from "./hooks/useLifecycleLogger";
 export { useLockBodyScroll } from "./hooks/useLockBodyScroll";
+export { useLockFn } from "./hooks/useLockFn";
 export { useLocalstorageState } from "./hooks/useLocalstorageState";
 export { useMapState };
 export { useNativeMapState } from "./hooks/useNativeMapState";

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -117,6 +117,8 @@ export { useFetch } from "./hooks/useFetch";
 export { useThrottle } from "./hooks/useThrottle";
 export { useTimeoutWhen } from "./hooks/useTimeoutWhen";
 export { useToggle } from "./hooks/useToggle";
+export { useTrackedEffect } from "./hooks/useTrackedEffect";
+export type { DepChange, TrackedEffectCallback } from "./hooks/useTrackedEffect";
 export { useUndoState } from "./hooks/useUndoState";
 export { useTween } from "./hooks/useTween";
 export { useUndoRedoState } from "./hooks/useUndoRedoState";

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -58,6 +58,7 @@ export { useKey } from "./hooks/useKey";
 export { useKeyBindings } from "./hooks/useKeyBindings";
 export { useKeyRef } from "./hooks/useKeyRef";
 export { useKeys } from "./hooks/useKeys";
+export { useLatest } from "./hooks/useLatest";
 export { useLifecycleLogger } from "./hooks/useLifecycleLogger";
 export { useLockBodyScroll } from "./hooks/useLockBodyScroll";
 export { useLocalstorageState } from "./hooks/useLocalstorageState";


### PR DESCRIPTION
## Summary

- Adds `useCookieState` — cookie-backed state with a `useState`-like API
- JSON serialises/deserialises values automatically via `document.cookie`
- No external cookie library; native `document.cookie` only
- SSR-safe: returns `[defaultValue, noop]` when `document` is undefined
- Syncs across same-origin tabs via **BroadcastChannel**
- Syncs across multiple hook instances in the same document via a custom event
- Exports `UseCookieStateOptions` and `UseCookieStateReturnValue` types

## New files

| File | Purpose |
|------|---------|
| `packages/rooks/src/hooks/useCookieState.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useCookieState.spec.tsx` | 14 vitest tests (all passing) |
| `apps/website/content/docs/hooks/(state)/useCookieState.mdx` | MDX documentation |

## API

\`\`\`ts
const [value, setValue] = useCookieState("cookie-name", {
  defaultValue: "light",   // T | (() => T)
  expires: 30,             // days from now, or a Date
  path: "/",
  domain: "example.com",
  secure: true,
  sameSite: "lax",
});

setValue("dark");                           // direct value
setValue((prev) => prev === "dark" ? "light" : "dark"); // updater fn
\`\`\`

## Test plan

- [x] `useCookieState should be defined`
- [x] Initialises with default value when cookie is absent
- [x] Initialises with factory `defaultValue`
- [x] Reads an existing cookie on mount (prefers cookie over default)
- [x] Reads numeric and object cookie values
- [x] Sets a new value
- [x] Sets a new value via updater function
- [x] Setter is stable across re-renders (memo)
- [x] Writes to `document.cookie` on init
- [x] Writes new value to `document.cookie` when setValue is called
- [x] Includes `path` attribute in the cookie string
- [x] React component integration (renders, toggles value)
- [x] Syncs value across two hook instances in the same document
- [x] Full test suite: 138/140 files pass (2 were pre-existing skips), 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)