### PR TITLE
feat: add useInfiniteScroll hook

### DIFF
--- a/apps/website/content/docs/hooks/(ui)/useInfiniteScroll.mdx
+++ b/apps/website/content/docs/hooks/(ui)/useInfiniteScroll.mdx
@@ -1,0 +1,196 @@
+---
+id: useInfiniteScroll
+title: useInfiniteScroll
+sidebar_label: useInfiniteScroll
+---
+
+## About
+
+`useInfiniteScroll` manages paginated / infinite-scroll data loading. It calls
+a `service` function on mount and accumulates pages of data as the user scrolls.
+When a `target` element is provided the hook wires up an
+[IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+so that the next page loads automatically the moment the sentinel element enters
+the viewport. SSR-safe — no `window` or `document` access at module level.
+
+[//]: # "Main"
+
+## Examples
+
+### Basic example — manual load more
+
+```jsx
+import { useInfiniteScroll } from "rooks";
+
+async function fetchUsers({ page, pageSize }) {
+  const res = await fetch(`/api/users?page=${page}&pageSize=${pageSize}`);
+  return res.json(); // { list: User[], total: number }
+}
+
+export default function UserList() {
+  const [data, { loading, loadingMore, noMore, loadMore, reload }] =
+    useInfiniteScroll(
+      async (prev) => {
+        const page = Math.floor((prev?.list.length ?? 0) / 10) + 1;
+        const result = await fetchUsers({ page, pageSize: 10 });
+        return {
+          list: [...(prev?.list ?? []), ...result.list],
+          total: result.total,
+        };
+      },
+      {
+        isNoMore: (d) => (d?.list.length ?? 0) >= (d?.total ?? 0),
+      }
+    );
+
+  if (loading) return <p>Loading…</p>;
+
+  return (
+    <div>
+      {data?.list.map((user) => (
+        <div key={user.id}>{user.name}</div>
+      ))}
+
+      {!noMore && (
+        <button onClick={loadMore} disabled={loadingMore}>
+          {loadingMore ? "Loading…" : "Load more"}
+        </button>
+      )}
+      {noMore && <p>No more users.</p>}
+
+      <button onClick={reload}>Reload</button>
+    </div>
+  );
+}
+```
+
+### Automatic scroll detection with IntersectionObserver
+
+Attach a `target` ref to a sentinel element at the bottom of the list. The hook
+observes it and calls `loadMore` automatically when it scrolls into view.
+
+```jsx
+import { useRef } from "react";
+import { useInfiniteScroll } from "rooks";
+
+export default function AutoScrollList() {
+  const sentinelRef = useRef(null);
+
+  const [data, { loading, loadingMore, noMore }] = useInfiniteScroll(
+    async (prev) => {
+      const page = Math.floor((prev?.list.length ?? 0) / 20) + 1;
+      const res = await fetch(`/api/items?page=${page}`);
+      const json = await res.json();
+      return { list: [...(prev?.list ?? []), ...json.items], total: json.total };
+    },
+    {
+      target: sentinelRef,
+      isNoMore: (d) => (d?.list.length ?? 0) >= (d?.total ?? 0),
+      threshold: 0.1,
+    }
+  );
+
+  if (loading) return <p>Loading…</p>;
+
+  return (
+    <div>
+      {data?.list.map((item) => (
+        <div key={item.id}>{item.title}</div>
+      ))}
+
+      {/* Sentinel — entering the viewport triggers the next load */}
+      <div ref={sentinelRef}>
+        {loadingMore && <p>Loading more…</p>}
+        {noMore && <p>You've reached the end!</p>}
+      </div>
+    </div>
+  );
+}
+```
+
+### Manual mode with reloadDeps
+
+Skip the initial fetch and drive loading yourself. Use `reloadDeps` to reset the
+list whenever a search query changes.
+
+```jsx
+import { useState } from "react";
+import { useInfiniteScroll } from "rooks";
+
+export default function SearchableList() {
+  const [query, setQuery] = useState("");
+
+  const [data, { loading, loadingMore, noMore, loadMore }] = useInfiniteScroll(
+    async (prev) => {
+      const page = Math.floor((prev?.list.length ?? 0) / 10) + 1;
+      const res = await fetch(`/api/search?q=${query}&page=${page}`);
+      const json = await res.json();
+      return { list: [...(prev?.list ?? []), ...json.results], total: json.total };
+    },
+    {
+      // Reset list whenever `query` changes; don't fetch on mount.
+      reloadDeps: [query],
+      isNoMore: (d) => (d?.list.length ?? 0) >= (d?.total ?? 0),
+    }
+  );
+
+  return (
+    <div>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search…"
+      />
+
+      {loading && <p>Searching…</p>}
+
+      {data?.list.map((item) => (
+        <div key={item.id}>{item.title}</div>
+      ))}
+
+      {!noMore && !loading && (
+        <button onClick={loadMore} disabled={loadingMore}>
+          {loadingMore ? "Loading…" : "Load more"}
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument  | Type                                        | Description                                         | Default value | Required |
+| --------- | ------------------------------------------- | --------------------------------------------------- | ------------- | -------- |
+| `service` | `(data?: TData) => Promise<TData>`          | Async loader; receives previous accumulation        | —             | yes      |
+| `options` | `UseInfiniteScrollOptions<TData>`           | Configuration (see Options table below)             | `{}`          | no       |
+
+#### Options
+
+| Option        | Type                                | Description                                                                   | Default   |
+| ------------- | ----------------------------------- | ----------------------------------------------------------------------------- | --------- |
+| `target`      | `RefObject<Element \| null> \| Element \| null` | Element (or ref) to observe; triggers `loadMore` on intersection | `null`    |
+| `isNoMore`    | `(data?: TData) => boolean`         | Returns `true` when there are no more pages to load                           | —         |
+| `threshold`   | `number`                            | IntersectionObserver threshold (0–1)                                          | `0.1`     |
+| `manual`      | `boolean`                           | Skip automatic load on mount                                                  | `false`   |
+| `reloadDeps`  | `DependencyList`                    | Reload all data when any of these values change                               | `[]`      |
+| `onBefore`    | `() => void`                        | Called before each service invocation                                         | —         |
+| `onSuccess`   | `(data: TData) => void`             | Called when service resolves                                                  | —         |
+| `onError`     | `(error: Error) => void`            | Called when service rejects                                                   | —         |
+| `onFinally`   | `() => void`                        | Called after service, regardless of outcome                                   | —         |
+
+### Return
+
+Returns a tuple `[data, controls]`.
+
+| Return value         | Type                             | Description                                                              | Default value |
+| -------------------- | -------------------------------- | ------------------------------------------------------------------------ | ------------- |
+| `data`               | `TData \| undefined`             | Current accumulated data                                                 | `undefined`   |
+| `controls.loading`   | `boolean`                        | `true` during the initial / reload fetch                                 | `true`        |
+| `controls.loadingMore` | `boolean`                      | `true` while an incremental "load more" fetch is in flight               | `false`       |
+| `controls.noMore`    | `boolean`                        | `true` when `isNoMore` returns `true` for current data                   | `false`       |
+| `controls.loadMore`  | `() => void`                     | Fire-and-forget: fetch the next page                                     | —             |
+| `controls.loadMoreAsync` | `() => Promise<TData \| undefined>` | Fetch the next page and return the updated data                   | —             |
+| `controls.reload`    | `() => Promise<void>`            | Clear data and re-fetch from the first page                              | —             |
+| `controls.cancel`    | `() => void`                     | Abandon the current in-flight fetch                                      | —             |
+| `controls.mutate`    | `(data?: TData) => void`         | Directly replace the accumulated data                                    | —             |

--- a/packages/rooks/src/__tests__/useInfiniteScroll.spec.tsx
+++ b/packages/rooks/src/__tests__/useInfiniteScroll.spec.tsx
@@ -1,0 +1,624 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React, { useRef } from "react";
+import { render, screen } from "@testing-library/react";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+
+// ---------------------------------------------------------------------------
+// IntersectionObserver mock
+// ---------------------------------------------------------------------------
+
+const mockObserver = {
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+};
+const mockObserverCtor = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface Page {
+  list: string[];
+  total: number;
+}
+
+const makeService =
+  (
+    items: string[],
+    pageSize = 3,
+    delay = 0
+  ): ((prev?: Page) => Promise<Page>) =>
+  async (prev) => {
+    if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+    const loaded = prev?.list ?? [];
+    const next = items.slice(loaded.length, loaded.length + pageSize);
+    return { list: [...loaded, ...next], total: items.length };
+  };
+
+const ALL_ITEMS = ["a", "b", "c", "d", "e", "f", "g"];
+
+// ---------------------------------------------------------------------------
+
+describe("useInfiniteScroll", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Must use a regular function (not arrow) to be usable as a `new` constructor.
+    mockObserverCtor.mockImplementation(function () {
+      return mockObserver;
+    });
+    global.IntersectionObserver = mockObserverCtor as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic
+  // -------------------------------------------------------------------------
+
+  describe("Basic", () => {
+    it("is defined", () => {
+      expect(useInfiniteScroll).toBeDefined();
+    });
+
+    it("returns a tuple [data, controls]", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), { manual: true })
+      );
+      const [data, controls] = result.current;
+      expect(data).toBeUndefined();
+      expect(controls).toMatchObject({
+        loading: expect.any(Boolean),
+        loadingMore: expect.any(Boolean),
+        noMore: expect.any(Boolean),
+        loadMore: expect.any(Function),
+        loadMoreAsync: expect.any(Function),
+        reload: expect.any(Function),
+        cancel: expect.any(Function),
+        mutate: expect.any(Function),
+      });
+    });
+
+    it("loads initial data on mount when manual is false", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      // loading starts true
+      expect(result.current[1].loading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current[1].loading).toBe(false);
+      });
+
+      expect(service).toHaveBeenCalledTimes(1);
+      expect(service).toHaveBeenCalledWith(undefined);
+      expect(result.current[0]?.list).toEqual(["a", "b", "c"]);
+    });
+
+    it("does not load on mount when manual is true", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result } = renderHook(() =>
+        useInfiniteScroll(service, { manual: true })
+      );
+
+      // Give effects time to fire
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+      });
+
+      expect(service).not.toHaveBeenCalled();
+      expect(result.current[1].loading).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // loadMore / loadMoreAsync
+  // -------------------------------------------------------------------------
+
+  describe("loadMore / loadMoreAsync", () => {
+    it("appends the next page via loadMoreAsync", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(result.current[0]?.list).toEqual(["a", "b", "c"]);
+
+      await act(async () => {
+        await result.current[1].loadMoreAsync();
+      });
+
+      expect(result.current[0]?.list).toEqual(["a", "b", "c", "d", "e", "f"]);
+      expect(service).toHaveBeenCalledTimes(2);
+    });
+
+    it("sets loadingMore to true while fetching, false after", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS, 3, 50));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      let loadingMoreDuringFetch = false;
+      act(() => {
+        result.current[1].loadMore();
+        loadingMoreDuringFetch = result.current[1].loadingMore;
+      });
+
+      // Because loadingMore state update is async, wait until it turns true
+      await waitFor(() => expect(result.current[1].loadingMore).toBe(true));
+
+      await waitFor(() => expect(result.current[1].loadingMore).toBe(false));
+    });
+
+    it("ignores concurrent loadMore calls while already loading", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS, 3, 30));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      // Fire two loadMore calls simultaneously
+      act(() => {
+        result.current[1].loadMore();
+        result.current[1].loadMore(); // should be ignored
+      });
+
+      await waitFor(() => expect(result.current[1].loadingMore).toBe(false));
+
+      // Service should only have been called once for "load more"
+      expect(service).toHaveBeenCalledTimes(2); // 1 initial + 1 loadMore
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reload
+  // -------------------------------------------------------------------------
+
+  describe("reload", () => {
+    it("clears data and re-fetches from scratch", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      await act(async () => { await result.current[1].loadMoreAsync(); });
+      expect(result.current[0]?.list).toHaveLength(6);
+
+      await act(async () => { await result.current[1].reload(); });
+
+      // After reload, back to first page
+      expect(result.current[0]?.list).toHaveLength(3);
+      expect(service).toHaveBeenCalledTimes(3); // initial + loadMore + reload
+    });
+
+    it("calls service with undefined on reload", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      await act(async () => { await result.current[1].reload(); });
+
+      const calls = service.mock.calls;
+      // Both initial call and reload call should pass undefined
+      expect(calls[0][0]).toBeUndefined();
+      expect(calls[1][0]).toBeUndefined();
+    });
+
+    it("sets loading true during reload, false after", async () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS, 3, 30))
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      act(() => { void result.current[1].reload(); });
+      await waitFor(() => expect(result.current[1].loading).toBe(true));
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // noMore
+  // -------------------------------------------------------------------------
+
+  describe("noMore", () => {
+    it("is false when isNoMore is not provided", async () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useInfiniteScroll(makeService(ALL_ITEMS)));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(result.current[1].noMore).toBe(false);
+    });
+
+    it("becomes true when isNoMore returns true", async () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), {
+          isNoMore: (d) => (d?.list.length ?? 0) >= ALL_ITEMS.length,
+        })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(result.current[1].noMore).toBe(false);
+
+      // Load remaining pages
+      await act(async () => { await result.current[1].loadMoreAsync(); });
+      await act(async () => { await result.current[1].loadMoreAsync(); });
+
+      expect(result.current[0]?.list).toHaveLength(ALL_ITEMS.length);
+      expect(result.current[1].noMore).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cancel
+  // -------------------------------------------------------------------------
+
+  describe("cancel", () => {
+    it("stops the loading state immediately", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS, 3, 100));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      // Should start loading
+      await waitFor(() => expect(result.current[1].loading).toBe(true));
+
+      act(() => { result.current[1].cancel(); });
+
+      expect(result.current[1].loading).toBe(false);
+      expect(result.current[1].loadingMore).toBe(false);
+    });
+
+    it("discards result of cancelled call", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS, 3, 50));
+      const { result } = renderHook(() => useInfiniteScroll(service));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(true));
+
+      // Cancel mid-flight
+      act(() => { result.current[1].cancel(); });
+
+      // Data should remain undefined (initial load was cancelled)
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 100));
+      });
+      expect(result.current[0]).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // mutate
+  // -------------------------------------------------------------------------
+
+  describe("mutate", () => {
+    it("directly replaces current data", async () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useInfiniteScroll<Page>(makeService(ALL_ITEMS)));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      act(() => {
+        result.current[1].mutate({ list: ["x", "y"], total: 2 });
+      });
+
+      expect(result.current[0]?.list).toEqual(["x", "y"]);
+    });
+
+    it("can reset data to undefined", async () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useInfiniteScroll<Page>(makeService(ALL_ITEMS)));
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(result.current[0]).toBeDefined();
+
+      act(() => { result.current[1].mutate(undefined); });
+      expect(result.current[0]).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Callbacks
+  // -------------------------------------------------------------------------
+
+  describe("Callbacks", () => {
+    it("calls onBefore before service", async () => {
+      expect.hasAssertions();
+      const onBefore = vi.fn();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result } = renderHook(() =>
+        useInfiniteScroll(service, { onBefore })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(onBefore).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onSuccess with resolved data", async () => {
+      expect.hasAssertions();
+      const onSuccess = vi.fn();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), { onSuccess })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(onSuccess).toHaveBeenCalledOnce();
+      expect(onSuccess.mock.calls[0][0].list).toEqual(["a", "b", "c"]);
+    });
+
+    it("calls onError when service rejects", async () => {
+      expect.hasAssertions();
+      const onError = vi.fn();
+      const failingService = vi.fn(async () => {
+        throw new Error("boom");
+      });
+      const { result } = renderHook(() =>
+        useInfiniteScroll(failingService, { onError })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError.mock.calls[0][0].message).toBe("boom");
+    });
+
+    it("calls onFinally after success", async () => {
+      expect.hasAssertions();
+      const onFinally = vi.fn();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), { onFinally })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(onFinally).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onFinally after error", async () => {
+      expect.hasAssertions();
+      const onFinally = vi.fn();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(async () => { throw new Error("err"); }, { onFinally })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(onFinally).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // reloadDeps
+  // -------------------------------------------------------------------------
+
+  describe("reloadDeps", () => {
+    it("reloads when a dependency changes", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result, rerender } = renderHook(
+        ({ dep }: { dep: number }) =>
+          useInfiniteScroll(service, { reloadDeps: [dep] }),
+        { initialProps: { dep: 0 } }
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(service).toHaveBeenCalledTimes(1);
+
+      rerender({ dep: 1 });
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(service).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not reload on re-render without dep change", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const { result, rerender } = renderHook(
+        ({ dep }: { dep: number }) =>
+          useInfiniteScroll(service, { reloadDeps: [dep] }),
+        { initialProps: { dep: 0 } }
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      rerender({ dep: 0 });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+      });
+      // Still only called once
+      expect(service).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // IntersectionObserver target
+  // -------------------------------------------------------------------------
+
+  describe("IntersectionObserver target", () => {
+    it("creates an observer when a target element is provided", async () => {
+      expect.hasAssertions();
+      const element = document.createElement("div");
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), { target: element })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      expect(mockObserverCtor).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ threshold: 0.1 })
+      );
+      expect(mockObserver.observe).toHaveBeenCalledWith(element);
+    });
+
+    it("disconnects observer on unmount", async () => {
+      expect.hasAssertions();
+      const element = document.createElement("div");
+      const { result, unmount } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), { target: element })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      unmount();
+
+      expect(mockObserver.disconnect).toHaveBeenCalled();
+    });
+
+    it("uses custom threshold", async () => {
+      expect.hasAssertions();
+      const element = document.createElement("div");
+      renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), { target: element, threshold: 0.5 })
+      );
+
+      await waitFor(() => expect(mockObserverCtor).toHaveBeenCalled());
+
+      expect(mockObserverCtor).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ threshold: 0.5 })
+      );
+    });
+
+    it("triggers loadMore when target intersects", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const element = document.createElement("div");
+      const { result } = renderHook(() =>
+        useInfiniteScroll(service, { target: element })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      const observerCallback = mockObserverCtor.mock.calls[0][0] as IntersectionObserverCallback;
+
+      await act(async () => {
+        observerCallback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          mockObserver as unknown as IntersectionObserver
+        );
+      });
+
+      await waitFor(() => expect(result.current[1].loadingMore).toBe(false));
+
+      // Initial load + 1 auto-triggered load more
+      expect(service).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not trigger loadMore when isIntersecting is false", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(makeService(ALL_ITEMS));
+      const element = document.createElement("div");
+      const { result } = renderHook(() =>
+        useInfiniteScroll(service, { target: element })
+      );
+
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+
+      const observerCallback = mockObserverCtor.mock.calls[0][0] as IntersectionObserverCallback;
+
+      act(() => {
+        observerCallback(
+          [{ isIntersecting: false } as IntersectionObserverEntry],
+          mockObserver as unknown as IntersectionObserver
+        );
+      });
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+      });
+
+      // Still only the initial load
+      expect(service).toHaveBeenCalledTimes(1);
+    });
+
+    it("accepts a React RefObject as target", async () => {
+      expect.hasAssertions();
+
+      const TestComponent = () => {
+        const ref = useRef<HTMLDivElement>(null);
+        const [, controls] = useInfiniteScroll(makeService(ALL_ITEMS), {
+          target: ref,
+        });
+        return (
+          <div>
+            <div ref={ref} data-testid="sentinel" />
+            <div data-testid="loading">{String(controls.loading)}</div>
+          </div>
+        );
+      };
+
+      render(<TestComponent />);
+      await waitFor(() =>
+        expect(screen.getByTestId("loading")).toHaveTextContent("false")
+      );
+
+      // Observer should have been created and set up for the div element
+      expect(mockObserverCtor).toHaveBeenCalled();
+      expect(mockObserver.observe).toHaveBeenCalledWith(
+        screen.getByTestId("sentinel")
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SSR / no-target path
+  // -------------------------------------------------------------------------
+
+  describe("SSR safety", () => {
+    it("does not throw when target is null", async () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS), { target: null })
+      );
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(mockObserverCtor).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when target is undefined", async () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() =>
+        useInfiniteScroll(makeService(ALL_ITEMS))
+      );
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(mockObserverCtor).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration
+  // -------------------------------------------------------------------------
+
+  describe("Integration", () => {
+    it("full lifecycle: load → loadMore → noMore → reload", async () => {
+      expect.hasAssertions();
+      const items = ["a", "b", "c", "d"];
+      const service = vi.fn(makeService(items, 2));
+      const { result } = renderHook(() =>
+        useInfiniteScroll(service, {
+          isNoMore: (d) => (d?.list.length ?? 0) >= items.length,
+        })
+      );
+
+      // Phase 1: initial load
+      await waitFor(() => expect(result.current[1].loading).toBe(false));
+      expect(result.current[0]?.list).toEqual(["a", "b"]);
+      expect(result.current[1].noMore).toBe(false);
+
+      // Phase 2: loadMore
+      await act(async () => { await result.current[1].loadMoreAsync(); });
+      expect(result.current[0]?.list).toEqual(["a", "b", "c", "d"]);
+      expect(result.current[1].noMore).toBe(true);
+
+      // Phase 3: reload resets noMore
+      await act(async () => { await result.current[1].reload(); });
+      expect(result.current[0]?.list).toEqual(["a", "b"]);
+      expect(result.current[1].noMore).toBe(false);
+    });
+  });
+});

--- a/packages/rooks/src/hooks/useInfiniteScroll.ts
+++ b/packages/rooks/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,394 @@
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type DependencyList,
+  type RefObject,
+} from "react";
+import { noop } from "@/utils/noop";
+
+/**
+ * Data shape required by useInfiniteScroll.
+ * TData must contain a `list` array to indicate paginated results.
+ */
+type InfiniteScrollData = {
+  list: unknown[];
+};
+
+/**
+ * Options for the useInfiniteScroll hook.
+ */
+interface UseInfiniteScrollOptions<TData extends InfiniteScrollData> {
+  /**
+   * A DOM element or React ref to observe with IntersectionObserver.
+   * When this element enters the viewport, `loadMore` is triggered automatically.
+   */
+  target?: RefObject<Element | null> | Element | null;
+  /**
+   * Returns `true` when there are no more items to load.
+   * Prevents further auto-loading and sets `noMore` to `true`.
+   */
+  isNoMore?: (data?: TData) => boolean;
+  /**
+   * IntersectionObserver threshold (0–1). Defaults to `0.1`.
+   */
+  threshold?: number;
+  /**
+   * When `true`, the hook does not fetch automatically on mount.
+   * Call `reload()` or `loadMore()` manually. Defaults to `false`.
+   */
+  manual?: boolean;
+  /**
+   * Reload all data from scratch when any of these dependencies change.
+   */
+  reloadDeps?: DependencyList;
+  /** Called before each service invocation. */
+  onBefore?: () => void;
+  /** Called when the service resolves successfully. */
+  onSuccess?: (data: TData) => void;
+  /** Called when the service rejects. */
+  onError?: (error: Error) => void;
+  /** Called after the service call, regardless of outcome. */
+  onFinally?: () => void;
+}
+
+/**
+ * Controls returned as the second element of the useInfiniteScroll tuple.
+ */
+interface UseInfiniteScrollControls<TData extends InfiniteScrollData> {
+  /** `true` during the initial or reload fetch. */
+  loading: boolean;
+  /** `true` while an incremental "load more" fetch is in progress. */
+  loadingMore: boolean;
+  /** `true` when `isNoMore` returns `true` for the current data. */
+  noMore: boolean;
+  /** Fire-and-forget wrapper around `loadMoreAsync`. */
+  loadMore: () => void;
+  /** Append the next page and return the updated data. */
+  loadMoreAsync: () => Promise<TData | undefined>;
+  /** Clear data and re-fetch from scratch. */
+  reload: () => Promise<void>;
+  /** Abandon the current in-flight service call. */
+  cancel: () => void;
+  /** Directly replace the accumulated data. */
+  mutate: (data?: TData) => void;
+}
+
+/**
+ * useInfiniteScroll
+ *
+ * Manages infinite-scroll data loading. Calls `service` on mount (unless
+ * `manual` is `true`) and again whenever `loadMore` / `reload` are invoked.
+ * Optionally observes a DOM element via IntersectionObserver and triggers
+ * `loadMore` automatically when it enters the viewport.
+ *
+ * The `service` function receives the current accumulated data (or `undefined`
+ * on the first / reload call) and must return the next snapshot, typically
+ * by appending new items to `data.list`.
+ *
+ * @param service - Async function that loads data, receiving the previous
+ *   accumulation so it can determine the next page.
+ * @param options - Configuration options (target, isNoMore, threshold, …).
+ * @returns A tuple `[data, controls]`.
+ *
+ * @example
+ * ```tsx
+ * interface UserPage {
+ *   list: User[];
+ *   total: number;
+ * }
+ *
+ * function UserList() {
+ *   const sentinelRef = useRef<HTMLDivElement>(null);
+ *
+ *   const [data, { loading, loadingMore, noMore, reload }] = useInfiniteScroll<UserPage>(
+ *     async (prev) => {
+ *       const page = Math.floor((prev?.list.length ?? 0) / 10) + 1;
+ *       const res = await fetchUsers({ page, pageSize: 10 });
+ *       return { list: [...(prev?.list ?? []), ...res.list], total: res.total };
+ *     },
+ *     {
+ *       target: sentinelRef,
+ *       isNoMore: (d) => (d?.list.length ?? 0) >= (d?.total ?? 0),
+ *     }
+ *   );
+ *
+ *   if (loading) return <p>Loading…</p>;
+ *   return (
+ *     <>
+ *       {data?.list.map((u) => <div key={u.id}>{u.name}</div>)}
+ *       <div ref={sentinelRef}>{loadingMore ? "Loading more…" : noMore ? "No more" : null}</div>
+ *       <button onClick={reload}>Reload</button>
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+function useInfiniteScroll<TData extends InfiniteScrollData>(
+  service: (data?: TData) => Promise<TData>,
+  options: UseInfiniteScrollOptions<TData> = {}
+): [TData | undefined, UseInfiniteScrollControls<TData>] {
+  const {
+    target = null,
+    isNoMore,
+    threshold = 0.1,
+    manual = false,
+    reloadDeps = [],
+    onBefore,
+    onSuccess,
+    onError,
+    onFinally,
+  } = options;
+
+  const [data, setData] = useState<TData | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(!manual);
+  const [loadingMore, setLoadingMore] = useState<boolean>(false);
+
+  // Refs that mirror mutable state — allow stable callbacks to read current
+  // values without adding them to dependency arrays and causing re-creation.
+  const dataRef = useRef<TData | undefined>(undefined);
+  const loadingRef = useRef<boolean>(!manual);
+  const loadingMoreRef = useRef<boolean>(false);
+  const mountedRef = useRef<boolean>(true);
+
+  // Increment this to cancel any in-flight call: a completed call whose
+  // generation no longer matches requestIdRef.current is silently discarded.
+  const requestIdRef = useRef<number>(0);
+
+  // Keep user-supplied callbacks in refs so that reload / loadMoreAsync
+  // can remain stable (useCallback([]) deps) even when the caller recreates them.
+  const serviceRef = useRef(service);
+  useEffect(() => {
+    serviceRef.current = service;
+  });
+  const onBeforeRef = useRef(onBefore);
+  useEffect(() => {
+    onBeforeRef.current = onBefore;
+  });
+  const onSuccessRef = useRef(onSuccess);
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+  });
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onErrorRef.current = onError;
+  });
+  const onFinallyRef = useRef(onFinally);
+  useEffect(() => {
+    onFinallyRef.current = onFinally;
+  });
+
+  // ------------------------------------------------------------------
+  // Helpers that sync both the ref and the React state together
+  // ------------------------------------------------------------------
+
+  const syncData = useCallback((next: TData | undefined) => {
+    dataRef.current = next;
+    setData(next);
+  }, []);
+
+  const syncLoading = useCallback((next: boolean) => {
+    loadingRef.current = next;
+    setLoading(next);
+  }, []);
+
+  const syncLoadingMore = useCallback((next: boolean) => {
+    loadingMoreRef.current = next;
+    setLoadingMore(next);
+  }, []);
+
+  // ------------------------------------------------------------------
+  // cancel — abandons the current in-flight call
+  // ------------------------------------------------------------------
+
+  const cancel = useCallback(() => {
+    requestIdRef.current++;
+    syncLoading(false);
+    syncLoadingMore(false);
+  }, [syncLoading, syncLoadingMore]);
+
+  // ------------------------------------------------------------------
+  // mutate — directly replace the accumulated data
+  // ------------------------------------------------------------------
+
+  const mutate = useCallback(
+    (next?: TData) => {
+      syncData(next);
+    },
+    [syncData]
+  );
+
+  // ------------------------------------------------------------------
+  // loadMoreAsync — append the next page; returns updated data
+  // ------------------------------------------------------------------
+
+  const loadMoreAsync = useCallback(async (): Promise<TData | undefined> => {
+    if (loadingRef.current || loadingMoreRef.current) return undefined;
+
+    const id = ++requestIdRef.current;
+    syncLoadingMore(true);
+    onBeforeRef.current?.();
+
+    try {
+      const result = await serviceRef.current(dataRef.current);
+
+      if (!mountedRef.current || id !== requestIdRef.current) return undefined;
+
+      syncData(result);
+      onSuccessRef.current?.(result);
+      return result;
+    } catch (err) {
+      if (!mountedRef.current || id !== requestIdRef.current) return undefined;
+
+      const error = err instanceof Error ? err : new Error(String(err));
+      onErrorRef.current?.(error);
+      return undefined;
+    } finally {
+      if (mountedRef.current && id === requestIdRef.current) {
+        syncLoadingMore(false);
+        onFinallyRef.current?.();
+      }
+    }
+  }, [syncData, syncLoadingMore]);
+
+  // ------------------------------------------------------------------
+  // loadMore — fire-and-forget wrapper
+  // ------------------------------------------------------------------
+
+  const loadMore = useCallback(() => {
+    void loadMoreAsync();
+  }, [loadMoreAsync]);
+
+  // ------------------------------------------------------------------
+  // reload — reset data and re-fetch from page 1
+  // ------------------------------------------------------------------
+
+  const reload = useCallback(async (): Promise<void> => {
+    const id = ++requestIdRef.current;
+    syncData(undefined);
+    syncLoading(true);
+    onBeforeRef.current?.();
+
+    try {
+      const result = await serviceRef.current(undefined);
+
+      if (!mountedRef.current || id !== requestIdRef.current) return;
+
+      syncData(result);
+      onSuccessRef.current?.(result);
+    } catch (err) {
+      if (!mountedRef.current || id !== requestIdRef.current) return;
+
+      const error = err instanceof Error ? err : new Error(String(err));
+      onErrorRef.current?.(error);
+    } finally {
+      if (mountedRef.current && id === requestIdRef.current) {
+        syncLoading(false);
+        onFinallyRef.current?.();
+      }
+    }
+  }, [syncData, syncLoading]);
+
+  // ------------------------------------------------------------------
+  // Initial load on mount
+  // ------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!manual) {
+      void reload();
+    }
+    // Intentionally empty deps: only run once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ------------------------------------------------------------------
+  // Reload when reloadDeps change (skip mount — handled above)
+  // ------------------------------------------------------------------
+
+  const reloadDepsInitialized = useRef(false);
+  useEffect(() => {
+    if (!reloadDepsInitialized.current) {
+      reloadDepsInitialized.current = true;
+      return;
+    }
+    void reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, reloadDeps);
+
+  // ------------------------------------------------------------------
+  // IntersectionObserver — auto-trigger loadMore when target is visible
+  // ------------------------------------------------------------------
+
+  useEffect(() => {
+    if (typeof window === "undefined") return noop;
+
+    // Resolve the element inside the effect (after the commit phase) so that
+    // RefObjects are already populated with their DOM node before we read them.
+    const element =
+      target == null
+        ? null
+        : target instanceof Element
+        ? target
+        : (target as RefObject<Element | null>).current;
+
+    if (!element) return noop;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (
+          entry?.isIntersecting &&
+          !loadingRef.current &&
+          !loadingMoreRef.current
+        ) {
+          void loadMoreAsync();
+        }
+      },
+      { threshold }
+    );
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [target, threshold, loadMoreAsync]);
+
+  // ------------------------------------------------------------------
+  // Cleanup on unmount
+  // ------------------------------------------------------------------
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // ------------------------------------------------------------------
+  // noMore — derived from latest data on every render
+  // ------------------------------------------------------------------
+
+  const noMore = isNoMore ? isNoMore(data) : false;
+
+  return [
+    data,
+    {
+      loading,
+      loadingMore,
+      noMore,
+      loadMore,
+      loadMoreAsync,
+      reload,
+      cancel,
+      mutate,
+    },
+  ];
+}
+
+export { useInfiniteScroll };
+export type {
+  UseInfiniteScrollOptions,
+  UseInfiniteScrollControls,
+  InfiniteScrollData,
+};

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -51,6 +51,12 @@ export { useInput } from "./hooks/useInput";
 export { useMeasure } from "./hooks/useMeasure";
 export { useIntervalWhen } from "./hooks/useIntervalWhen";
 export { useIntersectionObserverRef } from "./hooks/useIntersectionObserverRef";
+export { useInfiniteScroll } from "./hooks/useInfiniteScroll";
+export type {
+  UseInfiniteScrollOptions,
+  UseInfiniteScrollControls,
+  InfiniteScrollData,
+} from "./hooks/useInfiniteScroll";
 export { useInViewRef } from "./hooks/useInViewRef";
 export { useIsDroppingFiles } from "./hooks/useIsDroppingFiles";
 export { useIsomorphicEffect } from "./hooks/useIsomorphicEffect";


### PR DESCRIPTION
## Summary

- New hook `useInfiniteScroll<TData>` for infinite-scroll / paginated data loading
- Accepts a `service: (prev?: TData) => Promise<TData>` and optional config
- Returns a tuple `[data, controls]` where controls expose `loading`, `loadingMore`, `noMore`, `loadMore`, `loadMoreAsync`, `reload`, `cancel`, `mutate`
- SSR-safe: `IntersectionObserver` is only constructed inside a `useEffect` behind a `typeof window` guard

## What's included

| File | Purpose |
|------|---------|
| `packages/rooks/src/hooks/useInfiniteScroll.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useInfiniteScroll.spec.tsx` | 32 vitest tests (all passing) |
| `apps/website/content/docs/hooks/(ui)/useInfiniteScroll.mdx` | MDX docs with 3 examples |
| `packages/rooks/src/index.ts` | Public export + re-exported types |

## Key design decisions

- **Tuple return** `[data, controls]` consistent with `useInViewRef` and other rooks hooks
- **Ref-based callbacks** (`serviceRef`, `onBeforeRef`, …) keep `reload` / `loadMoreAsync` stable across renders without listing user callbacks in `useCallback` deps
- **Generation counter** (`requestIdRef`) for cancellation — stale async completions are silently discarded
- **Target resolution inside effect** — reading `ref.current` inside `useEffect` (post-commit) ensures RefObjects are already populated
- **`reloadDeps` skips mount** via `reloadDepsInitialized` ref so the initial load and dep-change reload aren't duplicated

## Test plan

- [x] `pnpm typecheck` — no errors
- [x] `pnpm test` — 138/138 test files pass, 1496 tests pass, 21 skipped (no regressions)
- [x] All 32 new tests pass including IntersectionObserver, cancellation, callbacks, noMore, reloadDeps, RefObject target

🤖 Generated with [Claude Code](https://claude.com/claude-code)