### PR TITLE
feat: add useLatest hook

### DIFF
--- a/apps/website/content/docs/hooks/(utilities)/useLatest.mdx
+++ b/apps/website/content/docs/hooks/(utilities)/useLatest.mdx
@@ -1,0 +1,83 @@
+---
+id: useLatest
+title: useLatest
+sidebar_label: useLatest
+---
+
+## About
+
+Returns a ref that always holds the latest value of the argument. Useful for reading the most recent value of a prop or state inside an async callback, event handler, or interval without causing the effect to re-run.
+
+[//]: # "Main"
+
+## Examples
+
+### Read latest state value inside an interval
+
+```jsx
+import { useState, useEffect } from "react";
+import { useLatest } from "rooks";
+
+export default function App() {
+  const [count, setCount] = useState(0);
+  const latestCount = useLatest(count);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      // Always reads the current count without adding it to deps
+      console.log("latest count:", latestCount.current);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount((c) => c + 1)}>Increment</button>
+    </div>
+  );
+}
+```
+
+### Avoid stale closures in event handlers
+
+```jsx
+import { useState } from "react";
+import { useLatest } from "rooks";
+
+export default function App() {
+  const [value, setValue] = useState("");
+  const latestValue = useLatest(value);
+
+  function handleSubmit() {
+    // latestValue.current is always up-to-date even if this function
+    // was created in a render where value was different
+    alert(`Submitted: ${latestValue.current}`);
+  }
+
+  return (
+    <div>
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Type something"
+      />
+      <button onClick={handleSubmit}>Submit</button>
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument | Type | Description                             |
+| -------- | ---- | --------------------------------------- |
+| value    | T    | The value to keep up-to-date in the ref |
+
+### Returns
+
+| Return value | Type                    | Description                                           |
+| ------------ | ----------------------- | ----------------------------------------------------- |
+| ref          | MutableRefObject&lt;T&gt; | A ref whose `.current` always equals the latest value |
+
+---

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -256,6 +256,11 @@
       "category": "keyboard"
     },
     {
+      "name": "useLatest",
+      "description": "Returns a ref whose current value is always up-to-date with the latest value passed in, useful for avoiding stale closures in callbacks and effects.",
+      "category": "utilities"
+    },
+    {
       "name": "useLifecycleLogger",
       "description": "A react hook that console logs parameters as component transitions through lifecycles.",
       "category": "lifecycle"

--- a/packages/rooks/src/__tests__/useLatest.spec.tsx
+++ b/packages/rooks/src/__tests__/useLatest.spec.tsx
@@ -1,0 +1,266 @@
+import { render, cleanup, fireEvent, act } from "@testing-library/react";
+import React, { useState, useEffect, useRef } from "react";
+import { useLatest } from "@/hooks/useLatest";
+
+describe("useLatest", () => {
+  afterEach(cleanup);
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useLatest).toBeDefined();
+  });
+
+  it("returns a ref with the initial value on first render", () => {
+    expect.hasAssertions();
+    function App() {
+      const ref = useLatest(42);
+      return <span data-testid="value">{ref.current}</span>;
+    }
+
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("value").textContent).toBe("42");
+  });
+
+  it("ref.current always reflects the latest value after state updates", () => {
+    expect.hasAssertions();
+    function App() {
+      const [count, setCount] = useState(0);
+      const latestCount = useLatest(count);
+
+      return (
+        <div>
+          <button
+            data-testid="btn"
+            onClick={() => setCount((c) => c + 1)}
+            type="button"
+          >
+            increment
+          </button>
+          <span data-testid="ref-value">{latestCount.current}</span>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("ref-value").textContent).toBe("0");
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(getByTestId("ref-value").textContent).toBe("1");
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(getByTestId("ref-value").textContent).toBe("2");
+  });
+
+  it("returns the same ref object across re-renders", () => {
+    expect.hasAssertions();
+    const capturedRefs: React.MutableRefObject<number>[] = [];
+
+    function App() {
+      const [count, setCount] = useState(0);
+      const latestRef = useLatest(count);
+      capturedRefs.push(latestRef);
+
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => setCount((c) => c + 1)}
+          type="button"
+        >
+          click
+        </button>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+
+    // All renders should share the same ref object identity
+    expect(capturedRefs.length).toBeGreaterThanOrEqual(3);
+    const first = capturedRefs[0];
+    for (const ref of capturedRefs) {
+      expect(ref).toBe(first);
+    }
+  });
+
+  it("works with string values", () => {
+    expect.hasAssertions();
+    function App() {
+      const [text, setText] = useState("hello");
+      const latestText = useLatest(text);
+
+      return (
+        <div>
+          <button
+            data-testid="btn"
+            onClick={() => setText("world")}
+            type="button"
+          >
+            change
+          </button>
+          <span data-testid="ref-value">{latestText.current}</span>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("ref-value").textContent).toBe("hello");
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(getByTestId("ref-value").textContent).toBe("world");
+  });
+
+  it("works with object values", () => {
+    expect.hasAssertions();
+    const obj1 = { x: 1 };
+    const obj2 = { x: 2 };
+
+    function App() {
+      const [obj, setObj] = useState(obj1);
+      const latestObj = useLatest(obj);
+
+      return (
+        <div>
+          <button
+            data-testid="btn"
+            onClick={() => setObj(obj2)}
+            type="button"
+          >
+            change
+          </button>
+          <span data-testid="ref-value">{latestObj.current.x}</span>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("ref-value").textContent).toBe("1");
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(getByTestId("ref-value").textContent).toBe("2");
+  });
+
+  it("provides latest value inside async callbacks without stale closure issues", () => {
+    expect.hasAssertions();
+    let capturedValue: number | null = null;
+
+    function App() {
+      const [count, setCount] = useState(0);
+      const latestCount = useLatest(count);
+      const callbackRef = useRef<() => void>(() => {});
+
+      // Simulate a callback registered once that reads the latest value
+      useEffect(() => {
+        callbackRef.current = () => {
+          capturedValue = latestCount.current;
+        };
+      });
+
+      return (
+        <div>
+          <button
+            data-testid="increment"
+            onClick={() => setCount((c) => c + 1)}
+            type="button"
+          >
+            increment
+          </button>
+          <button
+            data-testid="read"
+            onClick={() => callbackRef.current()}
+            type="button"
+          >
+            read latest
+          </button>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+
+    act(() => {
+      fireEvent.click(getByTestId("increment"));
+    });
+    act(() => {
+      fireEvent.click(getByTestId("increment"));
+    });
+    act(() => {
+      fireEvent.click(getByTestId("increment"));
+    });
+    act(() => {
+      fireEvent.click(getByTestId("read"));
+    });
+
+    expect(capturedValue).toBe(3);
+  });
+
+  it("works with undefined value", () => {
+    expect.hasAssertions();
+    function App() {
+      const ref = useLatest<string | undefined>(undefined);
+      return (
+        <span data-testid="value">{String(ref.current)}</span>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("value").textContent).toBe("undefined");
+  });
+
+  it("works with null value", () => {
+    expect.hasAssertions();
+    function App() {
+      const ref = useLatest<string | null>(null);
+      return (
+        <span data-testid="value">{String(ref.current)}</span>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("value").textContent).toBe("null");
+  });
+
+  it("works with function values", () => {
+    expect.hasAssertions();
+    const fn1 = () => "fn1";
+    const fn2 = () => "fn2";
+
+    function App() {
+      const [fn, setFn] = useState<() => string>(() => fn1);
+      const latestFn = useLatest(fn);
+
+      return (
+        <div>
+          <button
+            data-testid="btn"
+            onClick={() => setFn(() => fn2)}
+            type="button"
+          >
+            change
+          </button>
+          <span data-testid="ref-value">{latestFn.current()}</span>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<App />);
+    expect(getByTestId("ref-value").textContent).toBe("fn1");
+
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(getByTestId("ref-value").textContent).toBe("fn2");
+  });
+});

--- a/packages/rooks/src/hooks/useLatest.ts
+++ b/packages/rooks/src/hooks/useLatest.ts
@@ -1,0 +1,22 @@
+import type { MutableRefObject } from "react";
+import { useRef } from "react";
+
+/**
+ * useLatest
+ *
+ * Returns a ref that always holds the latest value of the argument.
+ * Useful for reading the most recent value of a prop or state inside an
+ * async callback or event handler without causing the callback to re-run.
+ *
+ * @param value The value to keep up-to-date in the ref
+ * @returns A mutable ref whose `.current` always equals the latest `value`
+ * @see https://rooks.vercel.app/docs/hooks/useLatest
+ */
+function useLatest<T>(value: T): MutableRefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+
+  return ref;
+}
+
+export { useLatest };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -58,6 +58,7 @@ export { useKey } from "./hooks/useKey";
 export { useKeyBindings } from "./hooks/useKeyBindings";
 export { useKeyRef } from "./hooks/useKeyRef";
 export { useKeys } from "./hooks/useKeys";
+export { useLatest } from "./hooks/useLatest";
 export { useLifecycleLogger } from "./hooks/useLifecycleLogger";
 export { useLockBodyScroll } from "./hooks/useLockBodyScroll";
 export { useLocalstorageState } from "./hooks/useLocalstorageState";


### PR DESCRIPTION
## Summary

- Adds `useLatest<T>(value: T): MutableRefObject<T>` hook that returns a ref whose `.current` is synchronously updated to the latest value on every render
- Hook implementation at `packages/rooks/src/hooks/useLatest.ts`
- 10 thorough tests in `packages/rooks/src/__tests__/useLatest.spec.tsx`
- Docs page at `apps/website/content/docs/hooks/(utilities)/useLatest.mdx`
- Export added to `packages/rooks/src/index.ts` in alphabetical order

## How it works

`ref.current` is assigned synchronously during render (not inside `useEffect`), ensuring the ref is always up-to-date before any paint or effect runs — the standard pattern for "latest value" refs.

## Test plan

- [x] Returns ref with correct initial value
- [x] `ref.current` reflects latest value after state updates
- [x] Returns the same ref object identity across re-renders
- [x] Works with string, object, function, undefined, and null values
- [x] Provides latest value inside simulated async callback (no stale closure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)