### PR TITLE
feat: add useCookieState hook

### DIFF
--- a/apps/website/content/docs/hooks/(state)/useCookieState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useCookieState.mdx
@@ -1,0 +1,137 @@
+---
+id: useCookieState
+title: useCookieState
+sidebar_label: useCookieState
+---
+
+## About
+
+useState but auto updates values to browser cookies. Supports cookie options like `expires`, `path`, `domain`, `secure`, and `sameSite`.
+
+[//]: # "Main"
+
+## Examples
+
+### Basic example
+
+```jsx
+import React from "react";
+import { useCookieState } from "rooks";
+
+export default function App() {
+  const [username, setUsername, removeUsername] = useCookieState("app:username", "");
+
+  return (
+    <div>
+      <h1>useCookieState</h1>
+      <input
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="Enter username"
+      />
+      <button onClick={() => removeUsername()}>Clear</button>
+      <p>Stored username: {username}</p>
+    </div>
+  );
+}
+```
+
+### With expiry (7 days)
+
+```jsx
+import React from "react";
+import { useCookieState } from "rooks";
+
+export default function App() {
+  const [token, setToken, removeToken] = useCookieState(
+    "app:auth-token",
+    null,
+    { expires: 7 }
+  );
+
+  return (
+    <div>
+      <button onClick={() => setToken("my-secret-token")}>Login</button>
+      <button onClick={() => removeToken()}>Logout</button>
+      <p>Token: {token ?? "not set"}</p>
+    </div>
+  );
+}
+```
+
+### With all cookie options
+
+```jsx
+import React from "react";
+import { useCookieState } from "rooks";
+
+export default function App() {
+  const [preferences, setPreferences] = useCookieState(
+    "app:preferences",
+    { theme: "light", lang: "en" },
+    {
+      expires: 365,
+      path: "/",
+      domain: "example.com",
+      secure: true,
+      sameSite: "Lax",
+    }
+  );
+
+  return (
+    <div>
+      <p>Theme: {preferences.theme}</p>
+      <button onClick={() => setPreferences({ ...preferences, theme: "dark" })}>
+        Switch to dark
+      </button>
+    </div>
+  );
+}
+```
+
+### Using a function setter (like useState)
+
+```jsx
+import React from "react";
+import { useCookieState } from "rooks";
+
+export default function App() {
+  const [count, setCount] = useCookieState("app:count", 0, { expires: 1 });
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount((prev) => prev + 1)}>Increment</button>
+      <button onClick={() => setCount(0)}>Reset</button>
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument     | Type                  | Description                                        | Default   |
+| ------------ | --------------------- | -------------------------------------------------- | --------- |
+| key          | string                | Name of the cookie                                 | undefined |
+| initialState | any \| (() => any)    | Default initial value (or a function returning it) | undefined |
+| options      | CookieOptions         | Cookie attributes (see below)                      | `{}`      |
+
+### CookieOptions
+
+| Option    | Type                         | Description                                                  | Default     |
+| --------- | ---------------------------- | ------------------------------------------------------------ | ----------- |
+| expires   | number \| Date               | Days until expiry (number) or exact expiry date (Date)       | session     |
+| path      | string                       | Cookie path                                                  | `"/"`       |
+| domain    | string                       | Cookie domain                                                | undefined   |
+| secure    | boolean                      | Send only over HTTPS                                         | `false`     |
+| sameSite  | `"Strict"` \| `"Lax"` \| `"None"` | SameSite policy                                        | undefined   |
+
+### Returns
+
+Returns an array of the following items:
+
+| Return value | Type     | Description                       |
+| ------------ | -------- | --------------------------------- |
+| value        | any      | Current value stored in cookie    |
+| set          | Function | Set a new value for the cookie    |
+| remove       | Function | Remove the cookie                 |

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -51,6 +51,11 @@
       "category": "browser"
     },
     {
+      "name": "useCookieState",
+      "description": "useState but auto updates values to browser cookies, with support for expires, path, domain, secure, and sameSite options",
+      "category": "state"
+    },
+    {
       "name": "useCountdown",
       "description": "Count down to a target timestamp and call callbacks every second (or provided peried)",
       "category": "state"

--- a/packages/rooks/src/__tests__/useCookieState.spec.tsx
+++ b/packages/rooks/src/__tests__/useCookieState.spec.tsx
@@ -1,0 +1,427 @@
+import { vi } from "vitest";
+import React from "react";
+import {
+  render,
+  cleanup,
+  getByTestId,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+
+import { useCookieState } from "@/hooks/useCookieState";
+
+// Helper to clear all cookies between tests
+function clearAllCookies() {
+  document.cookie.split(";").forEach((cookie) => {
+    const eqPos = cookie.indexOf("=");
+    const name = eqPos > -1 ? cookie.substring(0, eqPos).trim() : cookie.trim();
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+  });
+}
+
+describe("useCookieState defined", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useCookieState).toBeDefined();
+  });
+});
+
+describe("useCookieState basic", () => {
+  let App = () => <div />;
+
+  beforeEach(() => {
+    clearAllCookies();
+    App = () => {
+      const [value, set, remove] = useCookieState("test-cookie", "hello");
+
+      return (
+        <div data-testid="container">
+          <p data-testid="value">{String(value)}</p>
+          <button
+            data-testid="new-value"
+            onClick={() => {
+              set("new value");
+            }}
+            type="button"
+          >
+            Set to new value
+          </button>
+          <button data-testid="remove-value" onClick={remove} type="button">
+            Remove the cookie
+          </button>
+        </div>
+      );
+    };
+  });
+
+  afterEach(() => {
+    clearAllCookies();
+    cleanup();
+  });
+
+  it("initializes with default value when no cookie exists", () => {
+    expect.hasAssertions();
+    const { container } = render(<App />);
+    const valueElement = getByTestId(container as HTMLElement, "value");
+    expect(valueElement.innerHTML).toBe("hello");
+  });
+
+  it("initializes from existing cookie value", () => {
+    expect.hasAssertions();
+    document.cookie = `test-cookie=${encodeURIComponent(JSON.stringify("pre-existing"))}; path=/`;
+    const { result } = renderHook(() => useCookieState("test-cookie", "default"));
+    expect(result.current[0]).toBe("pre-existing");
+  });
+
+  it("initializes correctly with a function initializer", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("test-fn-init", () => "from-function")
+    );
+    expect(result.current[0]).toBe("from-function");
+  });
+
+  it("sets a new value", async () => {
+    expect.hasAssertions();
+    const { container } = render(<App />);
+    const setButton = getByTestId(container as HTMLElement, "new-value");
+    act(() => {
+      fireEvent.click(setButton);
+    });
+    const valueElement = getByTestId(container as HTMLElement, "value");
+    await waitFor(() => expect(valueElement.innerHTML).toBe("new value"));
+  });
+
+  it("removes the cookie value", async () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("test-remove-cookie", "initial")
+    );
+    expect(result.current[0]).toBe("initial");
+    act(() => {
+      result.current[2]();
+    });
+    await waitFor(() => expect(result.current[0]).toBeUndefined());
+  });
+
+  it("set and remove functions are stable across re-renders", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(() =>
+      useCookieState("test-stable", "value")
+    );
+    const setBefore = result.current[1];
+    const removeBefore = result.current[2];
+    rerender();
+    expect(result.current[1]).toBe(setBefore);
+    expect(result.current[2]).toBe(removeBefore);
+  });
+
+  it("set and remove functions are stable after a set call", () => {
+    expect.hasAssertions();
+    const { result, rerender } = renderHook(() =>
+      useCookieState("test-stable-set", "value")
+    );
+    const setBefore = result.current[1];
+    const removeBefore = result.current[2];
+    act(() => {
+      setBefore("updated");
+    });
+    rerender();
+    expect(result.current[1]).toBe(setBefore);
+    expect(result.current[2]).toBe(removeBefore);
+  });
+});
+
+describe("useCookieState cookie interactions", () => {
+  beforeEach(() => {
+    clearAllCookies();
+  });
+
+  afterEach(() => {
+    clearAllCookies();
+    vi.restoreAllMocks();
+  });
+
+  it("writes value to document.cookie on initialization", () => {
+    expect.hasAssertions();
+    renderHook(() => useCookieState("write-test", "hello"));
+    expect(document.cookie).toContain("write-test");
+  });
+
+  it("writes updated value to document.cookie", async () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("update-test", "initial")
+    );
+    act(() => {
+      result.current[1]("updated");
+    });
+    await waitFor(() => expect(result.current[0]).toBe("updated"));
+    expect(document.cookie).toContain(encodeURIComponent(JSON.stringify("updated")));
+  });
+
+  it("supports function setter form", async () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useCookieState("fn-setter", 5));
+    act(() => {
+      result.current[1]((prev) => prev + 1);
+    });
+    await waitFor(() => expect(result.current[0]).toBe(6));
+  });
+
+  it("handles object values via JSON serialization", async () => {
+    expect.hasAssertions();
+    const initial = { name: "Alice", age: 30 };
+    const { result } = renderHook(() =>
+      useCookieState("object-cookie", initial)
+    );
+    expect(result.current[0]).toEqual(initial);
+    const updated = { name: "Bob", age: 25 };
+    act(() => {
+      result.current[1](updated);
+    });
+    await waitFor(() => expect(result.current[0]).toEqual(updated));
+  });
+
+  it("handles array values", async () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState<number[]>("array-cookie", [1, 2, 3])
+    );
+    expect(result.current[0]).toEqual([1, 2, 3]);
+    act(() => {
+      result.current[1]([4, 5, 6]);
+    });
+    await waitFor(() => expect(result.current[0]).toEqual([4, 5, 6]));
+  });
+
+  it("handles boolean values", async () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("bool-cookie", false)
+    );
+    expect(result.current[0]).toBe(false);
+    act(() => {
+      result.current[1](true);
+    });
+    await waitFor(() => expect(result.current[0]).toBe(true));
+  });
+
+  it("handles numeric values", async () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("num-cookie", 42)
+    );
+    expect(result.current[0]).toBe(42);
+    act(() => {
+      result.current[1](100);
+    });
+    await waitFor(() => expect(result.current[0]).toBe(100));
+  });
+
+  it("reads existing numeric cookie on mount", () => {
+    expect.hasAssertions();
+    document.cookie = `num-init-cookie=${encodeURIComponent(JSON.stringify(99))}; path=/`;
+    const { result } = renderHook(() =>
+      useCookieState("num-init-cookie", 0)
+    );
+    expect(result.current[0]).toBe(99);
+  });
+
+  it("reads existing object cookie on mount", () => {
+    expect.hasAssertions();
+    const obj = { x: 1, y: 2 };
+    document.cookie = `obj-init-cookie=${encodeURIComponent(JSON.stringify(obj))}; path=/`;
+    const { result } = renderHook(() =>
+      useCookieState("obj-init-cookie", {})
+    );
+    expect(result.current[0]).toEqual(obj);
+  });
+});
+
+describe("useCookieState with cookie options", () => {
+  beforeEach(() => {
+    clearAllCookies();
+    vi.spyOn(document, "cookie", "set").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    clearAllCookies();
+    vi.restoreAllMocks();
+  });
+
+  it("includes expires in cookie string when expires is a number (days)", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    renderHook(() =>
+      useCookieState("expires-num", "value", { expires: 7 })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const hasCookieWithExpires = calls.some(
+        (c) => c.includes("expires-num") && c.includes("expires=")
+      );
+      expect(hasCookieWithExpires).toBe(true);
+    });
+  });
+
+  it("includes expires in cookie string when expires is a Date", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    renderHook(() =>
+      useCookieState("expires-date", "value", { expires: futureDate })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const hasCookieWithExpires = calls.some(
+        (c) =>
+          c.includes("expires-date") &&
+          c.includes(`expires=${futureDate.toUTCString()}`)
+      );
+      expect(hasCookieWithExpires).toBe(true);
+    });
+  });
+
+  it("includes path in cookie string", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    renderHook(() =>
+      useCookieState("path-cookie", "value", { path: "/app" })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const hasPath = calls.some(
+        (c) => c.includes("path-cookie") && c.includes("path=/app")
+      );
+      expect(hasPath).toBe(true);
+    });
+  });
+
+  it("includes domain in cookie string", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    renderHook(() =>
+      useCookieState("domain-cookie", "value", { domain: "example.com" })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const hasDomain = calls.some(
+        (c) => c.includes("domain-cookie") && c.includes("domain=example.com")
+      );
+      expect(hasDomain).toBe(true);
+    });
+  });
+
+  it("includes Secure flag in cookie string", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    renderHook(() =>
+      useCookieState("secure-cookie", "value", { secure: true })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const hasSecure = calls.some(
+        (c) => c.includes("secure-cookie") && c.includes("Secure")
+      );
+      expect(hasSecure).toBe(true);
+    });
+  });
+
+  it("includes SameSite in cookie string", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    renderHook(() =>
+      useCookieState("samesite-cookie", "value", { sameSite: "Lax" })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const hasSameSite = calls.some(
+        (c) => c.includes("samesite-cookie") && c.includes("SameSite=Lax")
+      );
+      expect(hasSameSite).toBe(true);
+    });
+  });
+
+  it("includes SameSite=Strict in cookie string", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    renderHook(() =>
+      useCookieState("samesite-strict", "value", { sameSite: "Strict" })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const hasStrict = calls.some(
+        (c) => c.includes("samesite-strict") && c.includes("SameSite=Strict")
+      );
+      expect(hasStrict).toBe(true);
+    });
+  });
+
+  it("uses all options together", async () => {
+    expect.hasAssertions();
+    const cookieSetter = vi.spyOn(document, "cookie", "set");
+    renderHook(() =>
+      useCookieState("full-options", "value", {
+        expires: 30,
+        path: "/",
+        domain: "example.com",
+        secure: true,
+        sameSite: "None",
+      })
+    );
+    await waitFor(() => {
+      const calls = cookieSetter.mock.calls.map((c) => c[0]);
+      const fullOptionsCookie = calls.find((c) => c.includes("full-options"));
+      expect(fullOptionsCookie).toBeDefined();
+      expect(fullOptionsCookie).toContain("expires=");
+      expect(fullOptionsCookie).toContain("path=/");
+      expect(fullOptionsCookie).toContain("domain=example.com");
+      expect(fullOptionsCookie).toContain("Secure");
+      expect(fullOptionsCookie).toContain("SameSite=None");
+    });
+  });
+});
+
+describe("useCookieState edge cases", () => {
+  beforeEach(() => {
+    clearAllCookies();
+  });
+
+  afterEach(() => {
+    clearAllCookies();
+    vi.restoreAllMocks();
+  });
+
+  it("handles undefined initial value", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState<string | undefined>("undef-cookie")
+    );
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it("handles keys with special characters", async () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useCookieState("special key", "value")
+    );
+    expect(result.current[0]).toBe("value");
+    act(() => {
+      result.current[1]("updated");
+    });
+    await waitFor(() => expect(result.current[0]).toBe("updated"));
+  });
+
+  it("returns tuple with value, set, remove", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useCookieState("tuple-test", "hello"));
+    expect(Array.isArray(result.current)).toBe(true);
+    expect(result.current).toHaveLength(3);
+    expect(typeof result.current[0]).toBe("string");
+    expect(typeof result.current[1]).toBe("function");
+    expect(typeof result.current[2]).toBe("function");
+  });
+});

--- a/packages/rooks/src/hooks/useCookieState.ts
+++ b/packages/rooks/src/hooks/useCookieState.ts
@@ -1,0 +1,172 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { useFreshRef } from "./useFreshRef";
+
+type SameSite = "Strict" | "Lax" | "None";
+
+interface CookieOptions {
+  /**
+   * Number of days until the cookie expires, or a specific Date object.
+   * If not set, creates a session cookie.
+   */
+  expires?: number | Date;
+  /** Path for the cookie. Defaults to '/' */
+  path?: string;
+  /** Domain for the cookie */
+  domain?: string;
+  /** Whether the cookie is only sent over HTTPS */
+  secure?: boolean;
+  /** SameSite policy for the cookie */
+  sameSite?: SameSite;
+}
+
+function serializeCookieValue(value: unknown): string {
+  return encodeURIComponent(JSON.stringify(value));
+}
+
+function serializeCookie(
+  name: string,
+  value: unknown,
+  options: CookieOptions = {}
+): string {
+  const { expires, path = "/", domain, secure, sameSite } = options;
+
+  let cookieString = `${encodeURIComponent(name)}=${serializeCookieValue(value)}`;
+
+  if (expires !== undefined) {
+    let expiresDate: Date;
+    if (typeof expires === "number") {
+      expiresDate = new Date();
+      expiresDate.setTime(expiresDate.getTime() + expires * 24 * 60 * 60 * 1000);
+    } else {
+      expiresDate = expires;
+    }
+    cookieString += `; expires=${expiresDate.toUTCString()}`;
+  }
+
+  if (path) {
+    cookieString += `; path=${path}`;
+  }
+
+  if (domain) {
+    cookieString += `; domain=${domain}`;
+  }
+
+  if (secure) {
+    cookieString += "; Secure";
+  }
+
+  if (sameSite) {
+    cookieString += `; SameSite=${sameSite}`;
+  }
+
+  return cookieString;
+}
+
+function getCookieValue<S>(name: string): S | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const encodedName = encodeURIComponent(name);
+  const cookies = document.cookie.split(";");
+
+  for (const cookie of cookies) {
+    const trimmed = cookie.trim();
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex === -1) continue;
+    const cookieName = trimmed.substring(0, eqIndex);
+    if (cookieName === encodedName) {
+      const cookieValue = trimmed.substring(eqIndex + 1);
+      try {
+        return JSON.parse(decodeURIComponent(cookieValue)) as S;
+      } catch {
+        return decodeURIComponent(cookieValue) as unknown as S;
+      }
+    }
+  }
+
+  return null;
+}
+
+function removeCookie(
+  name: string,
+  options: Pick<CookieOptions, "path" | "domain"> = {}
+): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.cookie = serializeCookie(name, "", {
+    ...options,
+    expires: new Date(0),
+  });
+}
+
+type UseCookieStateReturnValue<S> = [S, Dispatch<SetStateAction<S>>, () => void];
+
+/**
+ * useCookieState hook
+ * Manages browser cookie state with a useState-like API
+ *
+ * @param {string} key - Name of the cookie
+ * @param {any} initialState - Default initial value
+ * @param {CookieOptions} options - Cookie options (expires, path, domain, secure, sameSite)
+ * @see https://rooks.vercel.app/docs/hooks/useCookieState
+ */
+function useCookieState<S>(
+  key: string,
+  initialState?: S | (() => S),
+  options: CookieOptions = {}
+): UseCookieStateReturnValue<S> {
+  const [value, setValue] = useState<S>(() => {
+    const valueFromCookie = getCookieValue<S>(key);
+    if (valueFromCookie !== null) {
+      return valueFromCookie;
+    }
+    return typeof initialState === "function"
+      ? (initialState as () => S)()
+      : (initialState as S);
+  });
+
+  const optionsRef = useFreshRef(options);
+  const currentValue = useFreshRef(value, true);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    if (value === undefined) {
+      removeCookie(key, {
+        path: optionsRef.current.path,
+        domain: optionsRef.current.domain,
+      });
+    } else {
+      document.cookie = serializeCookie(key, value, optionsRef.current);
+    }
+  }, [key, value, optionsRef]);
+
+  const set = useCallback(
+    (newValue: SetStateAction<S>) => {
+      const resolvedNewValue =
+        typeof newValue === "function"
+          ? (newValue as (prevState: S) => S)(currentValue.current)
+          : newValue;
+      setValue(resolvedNewValue);
+    },
+    [currentValue]
+  );
+
+  const remove = useCallback(() => {
+    removeCookie(key, {
+      path: optionsRef.current.path,
+      domain: optionsRef.current.domain,
+    });
+    setValue(undefined as unknown as S);
+  }, [key, optionsRef]);
+
+  return [value, set, remove];
+}
+
+export { useCookieState };
+export type { CookieOptions };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -11,6 +11,8 @@ export { useBoundingclientrectRef } from "./hooks/useBoundingclientrectRef";
 export { useBroadcastChannel } from "./hooks/useBroadcastChannel";
 export { useCheckboxInputState } from "./hooks/useCheckboxInputState";
 export { useClipboard } from "./hooks/useClipboard";
+export { useCookieState } from "./hooks/useCookieState";
+export type { CookieOptions } from "./hooks/useCookieState";
 export { useCountdown } from "./hooks/useCountdown";
 export { useCounter } from "./hooks/useCounter";
 export { useDebounce } from "./hooks/useDebounce";


### PR DESCRIPTION
## Summary

- Adds `useCookieState` hook — a `useState`-like API that persists state to browser cookies
- Returns a `[value, set, remove]` tuple matching the `useLocalstorageState` pattern
- Supports all standard cookie attributes: `expires` (days or `Date`), `path`, `domain`, `secure`, `sameSite`
- Handles JSON serialization/deserialization for all value types (strings, numbers, booleans, objects, arrays)
- Exports `CookieOptions` type for consumers

## Files changed

- `packages/rooks/src/hooks/useCookieState.ts` — hook implementation
- `packages/rooks/src/__tests__/useCookieState.spec.tsx` — 28 tests across 5 describe blocks
- `apps/website/content/docs/hooks/(state)/useCookieState.mdx` — documentation with examples
- `packages/rooks/src/index.ts` — export added alphabetically

## Test plan

- [x] `useCookieState` is defined
- [x] Initializes from default value when no cookie exists
- [x] Initializes from existing cookie value on mount
- [x] Supports function initializer form
- [x] Sets new values and updates `document.cookie`
- [x] Supports function setter form (like `useState`)
- [x] Removes cookie on `remove()` call
- [x] `set` and `remove` functions are referentially stable across re-renders
- [x] Handles strings, numbers, booleans, objects, and arrays
- [x] `expires` option (number of days and Date)
- [x] `path`, `domain`, `secure`, `sameSite` options
- [x] All options used together
- [x] Edge cases: undefined initial value, keys with special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)