### PR TITLE
feat: add useCreation hook

### DIFF
--- a/apps/website/content/docs/hooks/(performance)/useCreation.mdx
+++ b/apps/website/content/docs/hooks/(performance)/useCreation.mdx
@@ -1,0 +1,71 @@
+---
+id: useCreation
+title: useCreation
+sidebar_label: useCreation
+---
+
+## About
+
+A stable alternative to `useMemo` backed by `useRef`. React is allowed to discard memoized values from `useMemo` and recompute them for performance reasons, which can break object identity. `useCreation` guarantees the factory function is called exactly once on mount and only re-runs when the dependency array actually changes — making it safe for expensive object or class instance creation.
+
+[//]: # "Main"
+
+## Examples
+
+### Create a stable class instance
+
+```jsx
+import { useCreation } from "rooks";
+
+class AudioEngine {
+  constructor(sampleRate) {
+    this.sampleRate = sampleRate;
+    this.buffer = new Float32Array(sampleRate);
+  }
+}
+
+export default function Player({ sampleRate }) {
+  const engine = useCreation(() => new AudioEngine(sampleRate), [sampleRate]);
+
+  return <div>Engine buffer length: {engine.buffer.length}</div>;
+}
+```
+
+### Stable object reference that only recreates on dependency change
+
+```jsx
+import { useState } from "react";
+import { useCreation } from "rooks";
+
+export default function App() {
+  const [userId, setUserId] = useState(1);
+
+  const config = useCreation(
+    () => ({
+      endpoint: `/api/users/${userId}`,
+      headers: { "X-User-Id": String(userId) },
+    }),
+    [userId]
+  );
+
+  return (
+    <div>
+      <p>Endpoint: {config.endpoint}</p>
+      <button onClick={() => setUserId((id) => id + 1)}>Next user</button>
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument | Type            | Description                                                     | Default value |
+| -------- | --------------- | --------------------------------------------------------------- | ------------- |
+| factory  | () => T         | Factory function that produces the value to memoize             | undefined     |
+| deps     | DependencyList  | Dependency array — factory re-runs only when a dep changes      | undefined     |
+
+### Return Value
+
+| Type | Description                                        |
+| ---- | -------------------------------------------------- |
+| T    | The stable memoized value returned by the factory  |

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -61,6 +61,11 @@
       "category": "state"
     },
     {
+      "name": "useCreation",
+      "description": "A stable alternative to useMemo backed by useRef, guaranteeing the factory is only called when deps change.",
+      "category": "performance"
+    },
+    {
       "name": "useDebounce",
       "description": "Debounce hook for react",
       "category": "performance"

--- a/packages/rooks/src/__tests__/useCreation.spec.tsx
+++ b/packages/rooks/src/__tests__/useCreation.spec.tsx
@@ -1,0 +1,188 @@
+import { renderHook } from "@testing-library/react";
+import { useState } from "react";
+import { useCreation } from "@/hooks/useCreation";
+
+describe("useCreation", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useCreation).toBeDefined();
+  });
+
+  it("calls factory on initialization and returns value", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({ id: 1 }));
+    const { result } = renderHook(() => useCreation(factory, []));
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({ id: 1 });
+  });
+
+  it("does NOT call factory again on rerender when deps are unchanged", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({ id: 1 }));
+    const { result, rerender } = renderHook(() => useCreation(factory, []));
+
+    const firstValue = result.current;
+    rerender();
+    rerender();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(firstValue);
+  });
+
+  it("returns a stable reference across rerenders when deps do not change", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({ stable: true }));
+    const { result, rerender } = renderHook(() => useCreation(factory, [42]));
+
+    const ref1 = result.current;
+    rerender();
+    const ref2 = result.current;
+
+    expect(ref1).toBe(ref2);
+  });
+
+  it("calls factory again when a dep changes", () => {
+    expect.hasAssertions();
+    let dep = 1;
+    const factory = vi.fn(() => ({ dep }));
+    const { result, rerender } = renderHook(() => useCreation(factory, [dep]));
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({ dep: 1 });
+
+    dep = 2;
+    rerender();
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({ dep: 2 });
+  });
+
+  it("returns a new reference when deps change", () => {
+    expect.hasAssertions();
+    let dep = "a";
+    const { result, rerender } = renderHook(() =>
+      useCreation(() => ({ value: dep }), [dep])
+    );
+
+    const first = result.current;
+    dep = "b";
+    rerender();
+
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual({ value: "b" });
+  });
+
+  it("supports class instance creation and keeps same instance while deps unchanged", () => {
+    expect.hasAssertions();
+
+    class Counter {
+      count = 0;
+      increment() {
+        this.count++;
+      }
+    }
+
+    const { result, rerender } = renderHook(() =>
+      useCreation(() => new Counter(), [])
+    );
+
+    const instance = result.current;
+    instance.increment();
+    rerender();
+
+    expect(result.current).toBe(instance);
+    expect(result.current.count).toBe(1);
+  });
+
+  it("creates a fresh class instance when deps change", () => {
+    expect.hasAssertions();
+
+    class Greeter {
+      constructor(public name: string) {}
+    }
+
+    let name = "Alice";
+    const { result, rerender } = renderHook(() =>
+      useCreation(() => new Greeter(name), [name])
+    );
+
+    const first = result.current;
+    expect(first.name).toBe("Alice");
+
+    name = "Bob";
+    rerender();
+
+    expect(result.current).not.toBe(first);
+    expect(result.current.name).toBe("Bob");
+  });
+
+  it("works with multiple deps — only recreates when one of them changes", () => {
+    expect.hasAssertions();
+    let a = 1;
+    let b = 2;
+    const factory = vi.fn(() => a + b);
+    const { result, rerender } = renderHook(() =>
+      useCreation(factory, [a, b])
+    );
+
+    expect(result.current).toBe(3);
+    rerender();
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    a = 10;
+    rerender();
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe(12);
+  });
+
+  it("works with state changes that affect deps", () => {
+    expect.hasAssertions();
+
+    const factory = vi.fn((v: number) => ({ value: v }));
+
+    const { result } = renderHook(() => {
+      const [count, setCount] = useState(0);
+      const created = useCreation(() => factory(count), [count]);
+      return { count, setCount, created };
+    });
+
+    expect(result.current.created).toEqual({ value: 0 });
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    const { act } = require("@testing-library/react");
+    act(() => {
+      result.current.setCount(5);
+    });
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(result.current.created).toEqual({ value: 5 });
+  });
+
+  it("handles empty deps array — factory called exactly once", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => Symbol("unique"));
+    const { result, rerender } = renderHook(() => useCreation(factory, []));
+
+    const sym = result.current;
+    rerender();
+    rerender();
+    rerender();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(sym);
+  });
+
+  it("uses Object.is semantics for dep comparison (NaN equals NaN)", () => {
+    expect.hasAssertions();
+    const factory = vi.fn(() => ({}));
+    // NaN === NaN is false but Object.is(NaN, NaN) is true
+    const { rerender } = renderHook(() => useCreation(factory, [NaN]));
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    rerender();
+
+    // NaN dep has not changed per Object.is, so factory should NOT be called again
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/rooks/src/hooks/useCreation.ts
+++ b/packages/rooks/src/hooks/useCreation.ts
@@ -1,0 +1,45 @@
+import { useRef } from "react";
+import type { DependencyList } from "react";
+
+function depsHaveChanged(
+  prevDeps: DependencyList,
+  nextDeps: DependencyList
+): boolean {
+  if (prevDeps.length !== nextDeps.length) return true;
+  return nextDeps.some((dep, i) => !Object.is(dep, prevDeps[i]));
+}
+
+/**
+ * useCreation hook
+ *
+ * @description A more reliable version of useMemo backed by useRef. Unlike
+ * useMemo, React does not discard cached values between renders for performance
+ * — useCreation guarantees the factory function is only called once on mount
+ * and again only when deps actually change.
+ *
+ * @param {Function} factory A factory function that returns the value to memoize
+ * @param {DependencyList} deps Dependency array — factory re-runs when any dep changes
+ * @returns {T} The stable memoized value
+ * @see https://rooks.vercel.app/docs/hooks/useCreation
+ */
+function useCreation<T>(factory: () => T, deps: DependencyList): T {
+  const ref = useRef<{
+    deps: DependencyList;
+    value: T;
+    initialized: boolean;
+  }>({
+    deps,
+    value: undefined as unknown as T,
+    initialized: false,
+  });
+
+  if (!ref.current.initialized || depsHaveChanged(ref.current.deps, deps)) {
+    ref.current.value = factory();
+    ref.current.deps = deps;
+    ref.current.initialized = true;
+  }
+
+  return ref.current.value;
+}
+
+export { useCreation };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -13,6 +13,7 @@ export { useCheckboxInputState } from "./hooks/useCheckboxInputState";
 export { useClipboard } from "./hooks/useClipboard";
 export { useCountdown } from "./hooks/useCountdown";
 export { useCounter } from "./hooks/useCounter";
+export { useCreation } from "./hooks/useCreation";
 export { useDebounce } from "./hooks/useDebounce";
 export { useDebounceFn } from "./hooks/useDebounceFn";
 export { useDebouncedAsyncEffect } from "./hooks/useDebouncedAsyncEffect";


### PR DESCRIPTION
## Summary

- Adds `useCreation`, a stable alternative to `useMemo` backed by `useRef`
- Unlike `useMemo`, React may discard cached values for performance; `useCreation` guarantees the factory is called exactly once on mount and only re-runs when deps actually change (using `Object.is` semantics)
- Safe for expensive object or class instance creation where identity stability matters

## Files changed

| File | Description |
|------|-------------|
| `packages/rooks/src/hooks/useCreation.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useCreation.spec.tsx` | 12 tests covering all behaviour |
| `apps/website/content/docs/hooks/(performance)/useCreation.mdx` | Docs page in the Performance category |
| `packages/rooks/src/index.ts` | Export added alphabetically after `useCounter` |

## Test plan

- [x] Factory called exactly once on mount
- [x] Factory NOT called again on rerender when deps are unchanged
- [x] Stable reference returned across rerenders (no dep change)
- [x] Factory re-runs when a dep changes
- [x] New reference returned when deps change
- [x] Class instance kept alive across rerenders (identity stable)
- [x] Fresh class instance created when deps change
- [x] Multiple deps — only recreates when one of them changes
- [x] Works with state changes that affect deps
- [x] Empty deps array — factory called exactly once
- [x] `Object.is` semantics (`NaN === NaN` treated as same dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)