### PR TITLE
feat: add useTrackedEffect hook

### DIFF
--- a/apps/website/content/docs/hooks/(lifecycle)/useTrackedEffect.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useTrackedEffect.mdx
@@ -1,0 +1,81 @@
+---
+id: useTrackedEffect
+title: useTrackedEffect
+sidebar_label: useTrackedEffect
+---
+
+## About
+
+A useEffect hook that tracks which dependencies changed between renders. The effect callback receives an array of indices indicating which dependencies changed. On the initial render the callback is invoked with an empty array.
+
+## Examples
+
+### Log which dependency triggered an effect
+
+```jsx
+import React, { useState } from "react";
+import { useTrackedEffect } from "rooks";
+
+export default function App() {
+  const [a, setA] = useState(0);
+  const [b, setB] = useState(0);
+
+  useTrackedEffect(
+    (changedIndices) => {
+      if (changedIndices.includes(0)) {
+        console.log("a changed to", a);
+      }
+      if (changedIndices.includes(1)) {
+        console.log("b changed to", b);
+      }
+    },
+    [a, b]
+  );
+
+  return (
+    <div>
+      <button onClick={() => setA((v) => v + 1)}>Increment a ({a})</button>
+      <button onClick={() => setB((v) => v + 1)}>Increment b ({b})</button>
+    </div>
+  );
+}
+```
+
+### Run different logic depending on which dep changed
+
+```jsx
+import React, { useState } from "react";
+import { useTrackedEffect } from "rooks";
+
+export default function SmartSync() {
+  const [userId, setUserId] = useState(1);
+  const [filter, setFilter] = useState("all");
+
+  useTrackedEffect(
+    (changedIndices) => {
+      if (changedIndices.length === 0) {
+        // Initial mount — fetch everything
+        console.log("Initial load");
+        return;
+      }
+      if (changedIndices.includes(0)) {
+        console.log("User changed, re-fetching profile and data");
+      } else if (changedIndices.includes(1)) {
+        console.log("Filter changed, re-fetching filtered data only");
+      }
+    },
+    [userId, filter]
+  );
+
+  return (
+    <div>
+      <button onClick={() => setUserId((id) => id + 1)}>
+        Switch user (current: {userId})
+      </button>
+      <button onClick={() => setFilter(filter === "all" ? "active" : "all")}>
+        Toggle filter (current: {filter})
+      </button>
+    </div>
+  );
+}
+```

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -586,6 +586,11 @@
       "category": "state-history"
     },
     {
+      "name": "useTrackedEffect",
+      "description": "A useEffect hook that tracks which dependencies changed between renders and passes their indices to the effect callback",
+      "category": "lifecycle"
+    },
+    {
       "name": "useTween",
       "description": "Tween animation hook for React",
       "category": "animation"

--- a/packages/rooks/src/__tests__/useTrackedEffect.spec.tsx
+++ b/packages/rooks/src/__tests__/useTrackedEffect.spec.tsx
@@ -1,0 +1,213 @@
+import { vi } from "vitest";
+import { render, cleanup, fireEvent, act } from "@testing-library/react";
+import React, { useState } from "react";
+import { useTrackedEffect } from "@/hooks/useTrackedEffect";
+
+describe("useTrackedEffect", () => {
+  afterEach(cleanup);
+
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useTrackedEffect).toBeDefined();
+  });
+
+  it("calls callback on mount with empty changedIndices", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const App = () => {
+      const [count] = useState(0);
+      useTrackedEffect(callback, [count]);
+      return <div />;
+    };
+    render(<App />);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith([]);
+  });
+
+  it("passes changed index when a single dep changes", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const App = () => {
+      const [count, setCount] = useState(0);
+      useTrackedEffect(callback, [count]);
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => setCount((c) => c + 1)}
+          type="button"
+        >
+          inc
+        </button>
+      );
+    };
+    const { getByTestId } = render(<App />);
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenLastCalledWith([0]);
+  });
+
+  it("passes correct changed indices when multiple deps change", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const App = () => {
+      const [a, setA] = useState(0);
+      const [b, setB] = useState(0);
+      const [c, setC] = useState(0);
+      useTrackedEffect(callback, [a, b, c]);
+      return (
+        <div>
+          <button
+            data-testid="btn-ab"
+            onClick={() => {
+              setA((v) => v + 1);
+              setB((v) => v + 1);
+            }}
+            type="button"
+          >
+            inc a and b
+          </button>
+        </div>
+      );
+    };
+    render(<App />);
+    callback.mockClear();
+    act(() => {
+      fireEvent.click(document.querySelector("[data-testid='btn-ab']")!);
+    });
+    // Both a (index 0) and b (index 1) changed; c (index 2) did not
+    expect(callback).toHaveBeenLastCalledWith([0, 1]);
+  });
+
+  it("passes only the index of the dep that actually changed", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const App = () => {
+      const [a, setA] = useState(0);
+      const [b] = useState(0);
+      useTrackedEffect(callback, [a, b]);
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => setA((v) => v + 1)}
+          type="button"
+        >
+          inc a
+        </button>
+      );
+    };
+    const { getByTestId } = render(<App />);
+    callback.mockClear();
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(callback).toHaveBeenLastCalledWith([0]);
+  });
+
+  it("does not call callback when deps do not change", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const App = () => {
+      const [, forceRender] = useState(0);
+      const stableValue = 42;
+      useTrackedEffect(callback, [stableValue]);
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => forceRender((v) => v + 1)}
+          type="button"
+        >
+          force
+        </button>
+      );
+    };
+    const { getByTestId } = render(<App />);
+    const initialCallCount = callback.mock.calls.length;
+    // Clicking re-renders the component but stableValue doesn't change,
+    // so useEffect won't re-run (deps unchanged)
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(callback).toHaveBeenCalledTimes(initialCallCount);
+  });
+
+  it("runs the cleanup returned by the callback", () => {
+    expect.hasAssertions();
+    const cleanup = vi.fn();
+    const App = () => {
+      const [count, setCount] = useState(0);
+      useTrackedEffect(() => cleanup, [count]);
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => setCount((c) => c + 1)}
+          type="button"
+        >
+          inc
+        </button>
+      );
+    };
+    const { getByTestId, unmount } = render(<App />);
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    // cleanup should have been called once (from the first render's effect cleanup)
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    unmount();
+    // cleanup should have been called again on unmount
+    expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+
+  it("works with no deps (runs on every render)", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const App = () => {
+      const [count, setCount] = useState(0);
+      useTrackedEffect(callback);
+      return (
+        <div>
+          <span data-testid="count">{count}</span>
+          <button
+            data-testid="btn"
+            onClick={() => setCount((c) => c + 1)}
+            type="button"
+          >
+            inc
+          </button>
+        </div>
+      );
+    };
+    const { getByTestId } = render(<App />);
+    expect(callback).toHaveBeenCalledTimes(1);
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the correct index when the second dep changes and the first stays the same", () => {
+    expect.hasAssertions();
+    const callback = vi.fn();
+    const App = () => {
+      const [a] = useState("stable");
+      const [b, setB] = useState(0);
+      useTrackedEffect(callback, [a, b]);
+      return (
+        <button
+          data-testid="btn"
+          onClick={() => setB((v) => v + 1)}
+          type="button"
+        >
+          inc b
+        </button>
+      );
+    };
+    const { getByTestId } = render(<App />);
+    callback.mockClear();
+    act(() => {
+      fireEvent.click(getByTestId("btn"));
+    });
+    expect(callback).toHaveBeenLastCalledWith([1]);
+  });
+});

--- a/packages/rooks/src/hooks/useTrackedEffect.ts
+++ b/packages/rooks/src/hooks/useTrackedEffect.ts
@@ -1,0 +1,36 @@
+import { type DependencyList, useEffect, useRef } from "react";
+
+/**
+ * useTrackedEffect hook
+ * @description A useEffect hook that tracks which dependencies changed between renders.
+ * The callback receives an array of indices indicating which dependencies changed.
+ * On the initial render, the callback is called with an empty array.
+ * @param {Function} callback Effect callback that receives an array of changed dependency indices
+ * @param {DependencyList} deps Dependency list to track
+ * @see https://rooks.vercel.app/docs/hooks/useTrackedEffect
+ */
+function useTrackedEffect(
+  callback: (changedIndices: number[]) => void | (() => void),
+  deps?: DependencyList
+): void {
+  const prevDepsRef = useRef<DependencyList | undefined>(undefined);
+
+  useEffect(() => {
+    const changedIndices: number[] = [];
+
+    if (prevDepsRef.current !== undefined && deps !== undefined) {
+      deps.forEach((dep, index) => {
+        if (!Object.is(dep, prevDepsRef.current![index])) {
+          changedIndices.push(index);
+        }
+      });
+    }
+
+    prevDepsRef.current = deps;
+
+    return callback(changedIndices);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}
+
+export { useTrackedEffect };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -115,6 +115,7 @@ export { useTimeTravelState } from "./hooks/useTimeTravelState";
 export { useFetch } from "./hooks/useFetch";
 export { useThrottle } from "./hooks/useThrottle";
 export { useTimeoutWhen } from "./hooks/useTimeoutWhen";
+export { useTrackedEffect } from "./hooks/useTrackedEffect";
 export { useTextSelection } from "./hooks/useTextSelection";
 export type { TextSelectionState } from "./hooks/useTextSelection";
 export { useToggle } from "./hooks/useToggle";


### PR DESCRIPTION
## Summary

- Adds `useTrackedEffect` hook — a `useEffect` variant whose callback receives an array of **changed dependency indices** between renders
- On initial mount the callback is invoked with `[]`; on subsequent renders it reports which positions in the `deps` array actually changed (using `Object.is` comparison, matching React's own semantics)
- Follows all existing repo patterns: hook in `packages/rooks/src/hooks/`, tests in `packages/rooks/src/__tests__/`, docs page in `apps/website/content/docs/hooks/(lifecycle)/`, export in `packages/rooks/src/index.ts`

## Files changed

| File | Description |
|------|-------------|
| `packages/rooks/src/hooks/useTrackedEffect.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useTrackedEffect.spec.tsx` | 9 test cases |
| `apps/website/content/docs/hooks/(lifecycle)/useTrackedEffect.mdx` | Docs page with two examples |
| `packages/rooks/src/index.ts` | Re-export added |

## Test plan

- [x] `useTrackedEffect` is defined
- [x] Calls callback on mount with empty `changedIndices`
- [x] Passes changed index when a single dep changes
- [x] Passes correct changed indices when multiple deps change simultaneously
- [x] Passes only the index of the dep that actually changed (not unchanged ones)
- [x] Does not call callback when deps do not change
- [x] Cleanup function returned by callback is executed correctly
- [x] Works with no deps (runs on every render)
- [x] Reports the correct index when second dep changes and first stays the same
- [x] All 140 existing test files still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)