### PR TITLE
feat: add useWebSocket hook

### DIFF
--- a/apps/website/content/docs/hooks/(browser)/useWebSocket.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useWebSocket.mdx
@@ -1,0 +1,247 @@
+---
+id: useWebSocket
+title: useWebSocket
+sidebar_label: useWebSocket
+---
+
+## About
+
+A React hook that manages a WebSocket connection with auto-reconnect, message handling, ready state tracking, and manual connect/disconnect control. Provides a clean interface to the WebSocket API with exponential backoff reconnection, SSR safety, and TypeScript support.
+
+[//]: # "Main"
+
+## Examples
+
+### Basic real-time chat
+
+```jsx
+import { useWebSocket } from "rooks";
+import { useState } from "react";
+
+export default function Chat() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState("");
+
+  const { readyState, lastMessage, send } = useWebSocket("wss://echo.websocket.org", {
+    onMessage: (event) => {
+      setMessages((prev) => [...prev, event.data]);
+    },
+    onOpen: () => console.log("Connected"),
+    onClose: () => console.log("Disconnected"),
+  });
+
+  const handleSend = () => {
+    if (input.trim()) {
+      send(input);
+      setInput("");
+    }
+  };
+
+  const statusLabels = {
+    0: "Connecting…",
+    1: "Connected",
+    2: "Closing…",
+    3: "Disconnected",
+  };
+
+  return (
+    <div style={{ padding: "20px", maxWidth: "500px" }}>
+      <h3>WebSocket Chat</h3>
+      <p>Status: <strong>{statusLabels[readyState]}</strong></p>
+
+      <div
+        style={{
+          height: "200px",
+          overflowY: "auto",
+          border: "1px solid #ccc",
+          padding: "10px",
+          marginBottom: "10px",
+        }}
+      >
+        {messages.map((msg, i) => (
+          <div key={i}>{msg}</div>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: "10px" }}>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSend()}
+          placeholder="Type a message…"
+          style={{ flex: 1, padding: "5px" }}
+          disabled={readyState !== 1}
+        />
+        <button onClick={handleSend} disabled={readyState !== 1}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+### Auto-reconnect with status display
+
+```jsx
+import { useWebSocket } from "rooks";
+
+export default function AutoReconnect() {
+  const { readyState, lastMessage, disconnect, connect } = useWebSocket(
+    "wss://example.com/ws",
+    {
+      reconnect: true,
+      reconnectInterval: 1000,
+      reconnectAttempts: 5,
+      onOpen: () => console.log("Connected!"),
+      onClose: (event) => console.log("Closed:", event.code),
+      onError: (event) => console.error("Error:", event),
+    }
+  );
+
+  const statusColor = {
+    0: "orange",
+    1: "green",
+    2: "orange",
+    3: "red",
+  };
+
+  const statusLabel = {
+    0: "CONNECTING",
+    1: "OPEN",
+    2: "CLOSING",
+    3: "CLOSED",
+  };
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <h3>Auto-Reconnect Demo</h3>
+      <p>
+        Status:{" "}
+        <span style={{ color: statusColor[readyState], fontWeight: "bold" }}>
+          {statusLabel[readyState]}
+        </span>
+      </p>
+      <p>Last message: {lastMessage?.data ?? "none"}</p>
+      <div style={{ display: "flex", gap: "10px" }}>
+        <button onClick={connect}>Reconnect</button>
+        <button onClick={disconnect}>Disconnect</button>
+      </div>
+    </div>
+  );
+}
+```
+
+### Binary data with subprotocols
+
+```jsx
+import { useWebSocket } from "rooks";
+
+export default function BinaryExample() {
+  const { readyState, send, lastMessage } = useWebSocket(
+    "wss://example.com/binary",
+    {
+      protocols: ["binary", "base64"],
+      onMessage: (event) => {
+        if (event.data instanceof Blob) {
+          event.data.arrayBuffer().then((buffer) => {
+            console.log("Received binary buffer:", buffer.byteLength, "bytes");
+          });
+        }
+      },
+    }
+  );
+
+  const sendBinary = () => {
+    const buffer = new ArrayBuffer(4);
+    const view = new Uint8Array(buffer);
+    view.set([1, 2, 3, 4]);
+    send(buffer);
+  };
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <h3>Binary WebSocket</h3>
+      <p>Ready state: {readyState}</p>
+      <button onClick={sendBinary} disabled={readyState !== 1}>
+        Send Binary
+      </button>
+    </div>
+  );
+}
+```
+
+### Arguments
+
+| Argument | Type                    | Description                                         | Default |
+| -------- | ----------------------- | --------------------------------------------------- | ------- |
+| url      | `string \| null`        | WebSocket URL to connect to, or null to skip        | -       |
+| options  | `UseWebSocketOptions`   | Optional configuration object                       | `{}`    |
+
+### Options
+
+| Option             | Type                            | Description                                                          | Default |
+| ------------------ | ------------------------------- | -------------------------------------------------------------------- | ------- |
+| onOpen             | `(event: Event) => void`        | Callback fired when the connection opens                             | -       |
+| onMessage          | `(event: MessageEvent) => void` | Callback fired when a message is received                            | -       |
+| onClose            | `(event: CloseEvent) => void`   | Callback fired when the connection closes                            | -       |
+| onError            | `(event: Event) => void`        | Callback fired when a socket error occurs                            | -       |
+| reconnect          | `boolean`                       | Whether to automatically reconnect on connection loss                | `false` |
+| reconnectInterval  | `number`                        | Base interval in ms between reconnection attempts (exponential backoff) | `1000` |
+| reconnectAttempts  | `number`                        | Maximum number of reconnection attempts                              | `3`     |
+| protocols          | `string \| string[]`            | WebSocket sub-protocol(s) to use                                     | -       |
+
+### Returns
+
+Returns an object with the following properties:
+
+| Return value | Type                                                        | Description                                              |
+| ------------ | ----------------------------------------------------------- | -------------------------------------------------------- |
+| readyState   | `0 \| 1 \| 2 \| 3`                                         | Current WebSocket state (CONNECTING/OPEN/CLOSING/CLOSED) |
+| lastMessage  | `MessageEvent \| null`                                      | The most recently received message event                 |
+| send         | `(data: string \| ArrayBufferLike \| Blob \| ArrayBufferView) => void` | Send data through the open connection     |
+| connect      | `() => void`                                                | Manually (re-)establish the connection                   |
+| disconnect   | `() => void`                                                | Manually close and disable auto-reconnect                |
+| isSupported  | `boolean`                                                   | Whether the WebSocket API is supported                   |
+
+### TypeScript Support
+
+```typescript
+import { useWebSocket } from "rooks";
+import type { UseWebSocketOptions, UseWebSocketReturn, WebSocketReadyState } from "rooks";
+
+const { readyState, lastMessage, send, connect, disconnect, isSupported } =
+  useWebSocket("wss://example.com/ws", {
+    onMessage: (event: MessageEvent) => {
+      const data = JSON.parse(event.data);
+      console.log(data);
+    },
+    reconnect: true,
+  });
+```
+
+### Ready State Values
+
+| Value | Constant             | Meaning                                   |
+| ----- | -------------------- | ----------------------------------------- |
+| `0`   | `WebSocket.CONNECTING` | Connection is being established           |
+| `1`   | `WebSocket.OPEN`       | Connection is open and ready              |
+| `2`   | `WebSocket.CLOSING`    | Connection is in the process of closing   |
+| `3`   | `WebSocket.CLOSED`     | Connection is closed or could not be opened |
+
+### Browser Support
+
+- Chrome: 4+
+- Firefox: 4+
+- Safari: 5+
+- Edge: 12+
+
+The hook includes built-in support detection and will set `isSupported` to `false` in environments without the WebSocket API (e.g., server-side rendering).
+
+### Notes
+
+- Passing `null` as the URL prevents any connection from being established — useful for conditional connections.
+- Auto-reconnect uses **exponential backoff**: the delay between attempts doubles each time (`reconnectInterval * 2^attempt`).
+- Calling `disconnect()` permanently stops auto-reconnect until `connect()` is called manually.
+- All callbacks are kept fresh via refs, so you can safely pass inline functions without causing reconnects.
+- The hook cleans up the WebSocket connection automatically when the component unmounts.

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -361,6 +361,11 @@
       "category": "browser"
     },
     {
+      "name": "useWebSocket",
+      "description": "Manages a WebSocket connection with auto-reconnect, message handling, ready state tracking, and manual connect/disconnect control",
+      "category": "browser"
+    },
+    {
       "name": "useOnClickRef",
       "description": "Callback on click/tap events",
       "category": "events"

--- a/packages/rooks/src/__tests__/useWebSocket.spec.tsx
+++ b/packages/rooks/src/__tests__/useWebSocket.spec.tsx
@@ -1,0 +1,733 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWebSocket } from "@/hooks/useWebSocket";
+
+// ─── Mock WebSocket ───────────────────────────────────────────────────────────
+
+type WebSocketEventListener = (event: any) => void;
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  public readyState: number = MockWebSocket.CONNECTING;
+  public url: string;
+  public protocol: string | string[];
+
+  private listeners: Map<string, Set<WebSocketEventListener>> = new Map();
+
+  // Track all instances so tests can control them
+  static instances: MockWebSocket[] = [];
+
+  constructor(url: string, protocol?: string | string[]) {
+    this.url = url;
+    this.protocol = protocol ?? "";
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: WebSocketEventListener): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type)!.add(listener);
+  }
+
+  removeEventListener(type: string, listener: WebSocketEventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(_data: any): void {
+    // No-op by default; can be overridden in specific tests
+  }
+
+  close(): void {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.readyState = MockWebSocket.CLOSED;
+    this._emit("close", new CloseEvent("close", { wasClean: true, code: 1000 }));
+  }
+
+  // ── Test helpers ──────────────────────────────────────────────────────────
+
+  /** Simulate the server accepting the connection */
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this._emit("open", new Event("open"));
+  }
+
+  /** Simulate an incoming message */
+  simulateMessage(data: any): void {
+    this._emit("message", new MessageEvent("message", { data }));
+  }
+
+  /** Simulate an error event */
+  simulateError(): void {
+    this._emit("error", new Event("error"));
+  }
+
+  /** Simulate the server closing the connection */
+  simulateClose(code = 1006, wasClean = false): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this._emit("close", new CloseEvent("close", { wasClean, code }));
+  }
+
+  private _emit(type: string, event: Event): void {
+    this.listeners.get(type)?.forEach((listener) => listener(event));
+  }
+}
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+const OriginalWebSocket = (global as any).WebSocket;
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  (global as any).WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  (global as any).WebSocket = OriginalWebSocket;
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+function latestInstance(): MockWebSocket {
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("useWebSocket", () => {
+  it("should be defined", () => {
+    expect.hasAssertions();
+    expect(useWebSocket).toBeDefined();
+  });
+
+  // ── Initial state ──────────────────────────────────────────────────────────
+
+  describe("Initial state", () => {
+    it("should start with readyState CLOSED (3) when no url is provided", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket(null));
+      expect(result.current.readyState).toBe(3);
+    });
+
+    it("should start with lastMessage null", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket(null));
+      expect(result.current.lastMessage).toBeNull();
+    });
+
+    it("should expose send, connect, and disconnect as functions", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket(null));
+      expect(result.current.send).toBeInstanceOf(Function);
+      expect(result.current.connect).toBeInstanceOf(Function);
+      expect(result.current.disconnect).toBeInstanceOf(Function);
+    });
+
+    it("should report isSupported true when WebSocket is available", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket(null));
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it("should report isSupported false when WebSocket is unavailable", () => {
+      expect.hasAssertions();
+      (global as any).WebSocket = undefined;
+      const { result } = renderHook(() => useWebSocket(null));
+      expect(result.current.isSupported).toBe(false);
+    });
+  });
+
+  // ── Connection lifecycle ───────────────────────────────────────────────────
+
+  describe("Connection lifecycle", () => {
+    it("should create a WebSocket when url is provided", () => {
+      expect.hasAssertions();
+      renderHook(() => useWebSocket("ws://localhost:8080"));
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(latestInstance().url).toBe("ws://localhost:8080");
+    });
+
+    it("should set readyState to CONNECTING (0) immediately after connecting", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+      expect(result.current.readyState).toBe(0);
+    });
+
+    it("should transition readyState to OPEN (1) when connection opens", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      expect(result.current.readyState).toBe(1);
+    });
+
+    it("should transition readyState to CLOSED (3) when connection closes", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      act(() => {
+        latestInstance().simulateClose();
+      });
+
+      expect(result.current.readyState).toBe(3);
+    });
+
+    it("should not create a WebSocket when url is null", () => {
+      expect.hasAssertions();
+      renderHook(() => useWebSocket(null));
+      expect(MockWebSocket.instances).toHaveLength(0);
+    });
+
+    it("should pass protocols to WebSocket constructor when provided", () => {
+      expect.hasAssertions();
+      renderHook(() =>
+        useWebSocket("ws://localhost:8080", { protocols: ["chat", "superchat"] })
+      );
+      expect(latestInstance().protocol).toEqual(["chat", "superchat"]);
+    });
+
+    it("should reconnect with a new WebSocket when url changes", () => {
+      expect.hasAssertions();
+      const { rerender } = renderHook(
+        ({ url }: { url: string }) => useWebSocket(url),
+        { initialProps: { url: "ws://localhost:8080" } }
+      );
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      rerender({ url: "ws://localhost:9090" });
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+      expect(latestInstance().url).toBe("ws://localhost:9090");
+    });
+
+    it("should close the WebSocket on unmount", () => {
+      expect.hasAssertions();
+      const { unmount } = renderHook(() => useWebSocket("ws://localhost:8080"));
+      const ws = latestInstance();
+      const closeSpy = vi.spyOn(ws, "close");
+
+      unmount();
+
+      expect(closeSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ── Callbacks ─────────────────────────────────────────────────────────────
+
+  describe("Callbacks", () => {
+    it("should call onOpen when connection opens", () => {
+      expect.hasAssertions();
+      const onOpen = vi.fn();
+      renderHook(() => useWebSocket("ws://localhost:8080", { onOpen }));
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      expect(onOpen).toHaveBeenCalledOnce();
+      expect(onOpen).toHaveBeenCalledWith(expect.any(Event));
+    });
+
+    it("should call onMessage when a message arrives", () => {
+      expect.hasAssertions();
+      const onMessage = vi.fn();
+      renderHook(() => useWebSocket("ws://localhost:8080", { onMessage }));
+
+      act(() => {
+        latestInstance().simulateOpen();
+        latestInstance().simulateMessage("hello");
+      });
+
+      expect(onMessage).toHaveBeenCalledOnce();
+      expect(onMessage).toHaveBeenCalledWith(expect.any(MessageEvent));
+    });
+
+    it("should call onClose when connection closes", () => {
+      expect.hasAssertions();
+      const onClose = vi.fn();
+      renderHook(() => useWebSocket("ws://localhost:8080", { onClose }));
+
+      act(() => {
+        latestInstance().simulateOpen();
+        latestInstance().simulateClose();
+      });
+
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(onClose).toHaveBeenCalledWith(expect.any(CloseEvent));
+    });
+
+    it("should call onError when a socket error occurs", () => {
+      expect.hasAssertions();
+      const onError = vi.fn();
+      renderHook(() => useWebSocket("ws://localhost:8080", { onError }));
+
+      act(() => {
+        latestInstance().simulateError();
+      });
+
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError).toHaveBeenCalledWith(expect.any(Event));
+    });
+  });
+
+  // ── lastMessage ───────────────────────────────────────────────────────────
+
+  describe("lastMessage", () => {
+    it("should update lastMessage when a message is received", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        latestInstance().simulateOpen();
+        latestInstance().simulateMessage("world");
+      });
+
+      expect(result.current.lastMessage).toBeInstanceOf(MessageEvent);
+      expect(result.current.lastMessage?.data).toBe("world");
+    });
+
+    it("should update lastMessage for each new message", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        latestInstance().simulateOpen();
+        latestInstance().simulateMessage("first");
+      });
+
+      expect(result.current.lastMessage?.data).toBe("first");
+
+      act(() => {
+        latestInstance().simulateMessage("second");
+      });
+
+      expect(result.current.lastMessage?.data).toBe("second");
+    });
+  });
+
+  // ── send ──────────────────────────────────────────────────────────────────
+
+  describe("send", () => {
+    it("should send data when socket is open", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+      const ws = latestInstance();
+      const sendSpy = vi.spyOn(ws, "send");
+
+      act(() => {
+        ws.simulateOpen();
+      });
+
+      act(() => {
+        result.current.send("test message");
+      });
+
+      expect(sendSpy).toHaveBeenCalledWith("test message");
+    });
+
+    it("should warn and not send when socket is not open", () => {
+      expect.hasAssertions();
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        result.current.send("test message");
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith("useWebSocket: WebSocket is not open");
+      consoleSpy.mockRestore();
+    });
+
+    it("should warn when attempting to send without a connection", () => {
+      expect.hasAssertions();
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { result } = renderHook(() => useWebSocket(null));
+
+      act(() => {
+        result.current.send("test");
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith("useWebSocket: WebSocket is not open");
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── Manual connect / disconnect ───────────────────────────────────────────
+
+  describe("Manual connect / disconnect", () => {
+    it("should allow manual connect after being initialized with null url", () => {
+      expect.hasAssertions();
+      const { result, rerender } = renderHook(
+        ({ url }: { url: string | null }) => useWebSocket(url),
+        { initialProps: { url: null as string | null } }
+      );
+
+      // Now provide a url and call connect
+      rerender({ url: "ws://localhost:8080" });
+
+      act(() => {
+        result.current.connect();
+      });
+
+      // Should have two instances: one from rerender, one from connect()
+      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should create a new connection when connect() is called", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      act(() => {
+        result.current.connect();
+      });
+
+      // A new WebSocket should have been created
+      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should close connection and prevent reconnect when disconnect() is called", () => {
+      expect.hasAssertions();
+      const { result } = renderHook(() =>
+        useWebSocket("ws://localhost:8080", { reconnect: true, reconnectAttempts: 3 })
+      );
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      act(() => {
+        result.current.disconnect();
+      });
+
+      expect(result.current.readyState).toBe(3);
+    });
+
+    it("should not auto-reconnect after manual disconnect()", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+
+      const { result } = renderHook(() =>
+        useWebSocket("ws://localhost:8080", {
+          reconnect: true,
+          reconnectAttempts: 5,
+          reconnectInterval: 100,
+        })
+      );
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      const instancesBefore = MockWebSocket.instances.length;
+
+      act(() => {
+        result.current.disconnect();
+      });
+
+      // Advance timers significantly
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      // No new instances should have been created
+      expect(MockWebSocket.instances.length).toBe(instancesBefore);
+    });
+  });
+
+  // ── Auto-reconnect ────────────────────────────────────────────────────────
+
+  describe("Auto-reconnect", () => {
+    it("should not attempt reconnect by default when connection drops", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+
+      renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        latestInstance().simulateOpen();
+        latestInstance().simulateClose(1006);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      // Only one WebSocket should have been created (no reconnect)
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    it("should attempt reconnect when reconnect option is true", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+
+      renderHook(() =>
+        useWebSocket("ws://localhost:8080", {
+          reconnect: true,
+          reconnectInterval: 100,
+          reconnectAttempts: 2,
+        })
+      );
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      // First reconnect after 100ms (interval * 2^0)
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("should use exponential backoff for reconnect delays", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+
+      renderHook(() =>
+        useWebSocket("ws://localhost:8080", {
+          reconnect: true,
+          reconnectInterval: 100,
+          reconnectAttempts: 3,
+        })
+      );
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      // First drop -> reconnect after 100ms (100 * 2^0)
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+
+      // Second drop -> reconnect after 200ms (100 * 2^1)
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      // Only 100ms has passed — not yet time for second reconnect
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+
+      // Now the additional 100ms completes the 200ms window
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(MockWebSocket.instances).toHaveLength(3);
+    });
+
+    it("should stop reconnecting after reconnectAttempts is exhausted", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+
+      renderHook(() =>
+        useWebSocket("ws://localhost:8080", {
+          reconnect: true,
+          reconnectInterval: 100,
+          reconnectAttempts: 2,
+        })
+      );
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      // First drop
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      // Second drop (attempt #2 = last)
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      // Third drop — no more reconnect allowed
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(10000);
+      });
+
+      // Should not have created more than original + 2 reconnect instances
+      expect(MockWebSocket.instances.length).toBeLessThanOrEqual(3);
+    });
+
+    it("should reset reconnect count after successful connection", () => {
+      expect.hasAssertions();
+      vi.useFakeTimers();
+
+      renderHook(() =>
+        useWebSocket("ws://localhost:8080", {
+          reconnect: true,
+          reconnectInterval: 100,
+          reconnectAttempts: 1,
+        })
+      );
+
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      // Drop and reconnect
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      // Reconnected instance opens successfully — resets counter
+      act(() => {
+        latestInstance().simulateOpen();
+      });
+
+      // Drop again — should be allowed to reconnect (counter reset)
+      act(() => {
+        latestInstance().simulateClose(1006);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      // Should have at least 3 WebSocket instances (original + 2 reconnects)
+      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  // ── isSupported guard ──────────────────────────────────────────────────────
+
+  describe("When WebSocket is not supported", () => {
+    it("should not create a WebSocket when unsupported", () => {
+      expect.hasAssertions();
+      (global as any).WebSocket = undefined;
+      renderHook(() => useWebSocket("ws://localhost:8080"));
+      expect(MockWebSocket.instances).toHaveLength(0);
+    });
+
+    it("should warn when send is called and not supported", () => {
+      expect.hasAssertions();
+      (global as any).WebSocket = undefined;
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { result } = renderHook(() => useWebSocket("ws://localhost:8080"));
+
+      act(() => {
+        result.current.send("data");
+      });
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── Callback stability ────────────────────────────────────────────────────
+
+  describe("Callback stability", () => {
+    it("should maintain stable send reference across renders", () => {
+      expect.hasAssertions();
+      const { result, rerender } = renderHook(() =>
+        useWebSocket("ws://localhost:8080")
+      );
+
+      const firstSend = result.current.send;
+      rerender();
+      expect(result.current.send).toBe(firstSend);
+    });
+
+    it("should maintain stable disconnect reference across renders", () => {
+      expect.hasAssertions();
+      const { result, rerender } = renderHook(() =>
+        useWebSocket("ws://localhost:8080")
+      );
+
+      const firstDisconnect = result.current.disconnect;
+      rerender();
+      expect(result.current.disconnect).toBe(firstDisconnect);
+    });
+  });
+
+  // ── TypeScript generics (runtime data-type coverage) ─────────────────────
+
+  describe("Various message data types", () => {
+    it("should handle string messages", () => {
+      expect.hasAssertions();
+      const onMessage = vi.fn();
+      renderHook(() => useWebSocket("ws://localhost:8080", { onMessage }));
+
+      act(() => {
+        latestInstance().simulateOpen();
+        latestInstance().simulateMessage("hello string");
+      });
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ data: "hello string" })
+      );
+    });
+
+    it("should handle object messages", () => {
+      expect.hasAssertions();
+      const onMessage = vi.fn();
+      const payload = { type: "update", value: 42 };
+      renderHook(() => useWebSocket("ws://localhost:8080", { onMessage }));
+
+      act(() => {
+        latestInstance().simulateOpen();
+        latestInstance().simulateMessage(payload);
+      });
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ data: payload })
+      );
+    });
+  });
+});

--- a/packages/rooks/src/hooks/useWebSocket.ts
+++ b/packages/rooks/src/hooks/useWebSocket.ts
@@ -1,0 +1,275 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * WebSocket ready state values matching the WebSocket API specification
+ */
+type WebSocketReadyState = 0 | 1 | 2 | 3;
+
+/**
+ * Options for the useWebSocket hook
+ */
+type UseWebSocketOptions = {
+  /**
+   * Callback fired when the WebSocket connection opens
+   */
+  onOpen?: (event: Event) => void;
+
+  /**
+   * Callback fired when a message is received
+   */
+  onMessage?: (event: MessageEvent) => void;
+
+  /**
+   * Callback fired when the WebSocket connection closes
+   */
+  onClose?: (event: CloseEvent) => void;
+
+  /**
+   * Callback fired when a WebSocket error occurs
+   */
+  onError?: (event: Event) => void;
+
+  /**
+   * Whether to automatically reconnect on connection loss
+   * @default false
+   */
+  reconnect?: boolean;
+
+  /**
+   * Base interval in milliseconds between reconnection attempts (uses exponential backoff)
+   * @default 1000
+   */
+  reconnectInterval?: number;
+
+  /**
+   * Maximum number of reconnection attempts
+   * @default 3
+   */
+  reconnectAttempts?: number;
+
+  /**
+   * Optional WebSocket sub-protocol(s) to use
+   */
+  protocols?: string | string[];
+};
+
+/**
+ * Return type for the useWebSocket hook
+ */
+type UseWebSocketReturn = {
+  /**
+   * Current WebSocket ready state: 0=CONNECTING, 1=OPEN, 2=CLOSING, 3=CLOSED
+   */
+  readyState: WebSocketReadyState;
+
+  /**
+   * The most recently received MessageEvent, or null if no message received yet
+   */
+  lastMessage: MessageEvent | null;
+
+  /**
+   * Send data through the WebSocket connection
+   */
+  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
+
+  /**
+   * Manually initiate or re-establish the WebSocket connection
+   */
+  connect: () => void;
+
+  /**
+   * Manually close the WebSocket connection and disable auto-reconnect
+   */
+  disconnect: () => void;
+
+  /**
+   * Whether the WebSocket API is supported in the current environment
+   */
+  isSupported: boolean;
+};
+
+/**
+ * useWebSocket
+ *
+ * @description A React hook that manages a WebSocket connection with auto-reconnect,
+ * message handling, ready state tracking, and manual connect/disconnect control.
+ * @param url - The WebSocket URL to connect to, or null to skip connecting
+ * @param options - Configuration options for callbacks, reconnect behavior, and protocols
+ * @returns Object with readyState, lastMessage, send, connect, disconnect, and isSupported
+ * @see {@link https://rooks.vercel.app/docs/hooks/useWebSocket}
+ */
+function useWebSocket(
+  url: string | null,
+  options: UseWebSocketOptions = {}
+): UseWebSocketReturn {
+  // Check WebSocket API support
+  const isSupported = useMemo(() => {
+    return typeof window !== "undefined" && typeof WebSocket !== "undefined";
+  }, []);
+
+  // Refs for the socket instance and reconnect timer
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectCountRef = useRef(0);
+  const manualDisconnectRef = useRef(false);
+
+  // Keep fresh references to url and options without triggering re-connections
+  const urlRef = useRef(url);
+  const optionsRef = useRef(options);
+
+  useEffect(() => {
+    urlRef.current = url;
+  }, [url]);
+
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+
+  const [readyState, setReadyState] = useState<WebSocketReadyState>(3); // WebSocket.CLOSED
+  const [lastMessage, setLastMessage] = useState<MessageEvent | null>(null);
+
+  // Internal function to create and wire up a new WebSocket connection
+  const createConnection = useCallback(
+    (wsUrl: string) => {
+      if (!isSupported) return;
+
+      try {
+        const { protocols } = optionsRef.current;
+        const ws = protocols
+          ? new WebSocket(wsUrl, protocols)
+          : new WebSocket(wsUrl);
+
+        wsRef.current = ws;
+        setReadyState(0); // WebSocket.CONNECTING
+
+        ws.addEventListener("open", (event) => {
+          reconnectCountRef.current = 0;
+          setReadyState(1); // WebSocket.OPEN
+          optionsRef.current.onOpen?.(event);
+        });
+
+        ws.addEventListener("message", (event: MessageEvent) => {
+          setLastMessage(event);
+          optionsRef.current.onMessage?.(event);
+        });
+
+        ws.addEventListener("close", (event: CloseEvent) => {
+          setReadyState(3); // WebSocket.CLOSED
+          optionsRef.current.onClose?.(event);
+
+          // Attempt auto-reconnect if enabled and not manually disconnected
+          const {
+            reconnect = false,
+            reconnectInterval = 1000,
+            reconnectAttempts = 3,
+          } = optionsRef.current;
+
+          if (
+            !manualDisconnectRef.current &&
+            reconnect &&
+            reconnectCountRef.current < reconnectAttempts
+          ) {
+            const delay =
+              reconnectInterval * Math.pow(2, reconnectCountRef.current);
+            reconnectCountRef.current += 1;
+            reconnectTimerRef.current = setTimeout(() => {
+              if (!manualDisconnectRef.current && urlRef.current) {
+                createConnection(urlRef.current);
+              }
+            }, delay);
+          }
+        });
+
+        ws.addEventListener("error", (event) => {
+          setReadyState(ws.readyState as WebSocketReadyState);
+          optionsRef.current.onError?.(event);
+        });
+      } catch (error) {
+        console.error("useWebSocket: Failed to create WebSocket connection", error);
+      }
+    },
+    [isSupported]
+  );
+
+  // Manually initiate or re-establish the connection
+  const connect = useCallback(() => {
+    if (!isSupported || !urlRef.current) return;
+
+    manualDisconnectRef.current = false;
+    reconnectCountRef.current = 0;
+
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    createConnection(urlRef.current);
+  }, [isSupported, createConnection]);
+
+  // Manually close and prevent auto-reconnect
+  const disconnect = useCallback(() => {
+    manualDisconnectRef.current = true;
+    reconnectCountRef.current = 0;
+
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    setReadyState(3); // WebSocket.CLOSED
+  }, []);
+
+  // Send data through the open WebSocket
+  const send = useCallback(
+    (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+      if (!wsRef.current || wsRef.current.readyState !== 1 /* WebSocket.OPEN */) {
+        console.warn("useWebSocket: WebSocket is not open");
+        return;
+      }
+      wsRef.current.send(data);
+    },
+    []
+  );
+
+  // Auto-connect when url is provided; re-connect when url changes
+  useEffect(() => {
+    if (!isSupported || !url) return;
+
+    manualDisconnectRef.current = false;
+    createConnection(url);
+
+    return () => {
+      manualDisconnectRef.current = true;
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [url, isSupported, createConnection]);
+
+  return {
+    readyState,
+    lastMessage,
+    send,
+    connect,
+    disconnect,
+    isSupported,
+  };
+}
+
+export { useWebSocket };
+export type { UseWebSocketOptions, UseWebSocketReturn, WebSocketReadyState };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -124,6 +124,12 @@ export { useUndoRedoState } from "./hooks/useUndoRedoState";
 export { useVibrate } from "./hooks/useVibrate";
 export { useVideo } from "./hooks/useVideo";
 export { useWebLocksApi } from "./hooks/useWebLocksApi";
+export { useWebSocket } from "./hooks/useWebSocket";
+export type {
+  UseWebSocketOptions,
+  UseWebSocketReturn,
+  WebSocketReadyState,
+} from "./hooks/useWebSocket";
 export { useWebWorker } from "./hooks/useWebWorker";
 export { useWhyDidYouUpdate } from "./hooks/useWhyDidYouUpdate";
 export { useWillUnmount } from "./hooks/useWillUnmount";


### PR DESCRIPTION
## Summary

- Adds `useWebSocket` hook to `packages/rooks/src/hooks/useWebSocket.ts`
- Manages WebSocket connections with auto-reconnect (exponential backoff), message handling, ready state tracking, and manual connect/disconnect
- Exports `useWebSocket`, `UseWebSocketOptions`, `UseWebSocketReturn`, and `WebSocketReadyState` from the package index
- Adds 38 tests covering all major behaviors
- Adds docs page at `apps/website/content/docs/hooks/(browser)/useWebSocket.mdx`

## Features

- `readyState` tracking (0=CONNECTING, 1=OPEN, 2=CLOSING, 3=CLOSED)
- `lastMessage` — the most recent `MessageEvent`
- `send(data)` — sends data when socket is open, warns otherwise
- `connect()` — manually initiate or re-establish the connection
- `disconnect()` — close and suppress auto-reconnect
- `reconnect` option with **exponential backoff** (`interval * 2^attempt`)
- `protocols` support for WebSocket sub-protocols
- SSR-safe (`isSupported` flag, no-ops when `WebSocket` is undefined)
- Callbacks (`onOpen`, `onMessage`, `onClose`, `onError`) kept fresh via refs — safe to pass inline functions without causing reconnects

## Test plan

- [x] All 38 new tests pass
- [x] Full existing test suite (140 files / 1535 tests) still passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)