### PR TITLE
feat: add useRequest hook

### DIFF
--- a/apps/website/content/docs/hooks/(state)/useRequest.mdx
+++ b/apps/website/content/docs/hooks/(state)/useRequest.mdx
@@ -1,0 +1,239 @@
+---
+title: useRequest
+description: Async data-fetching hook with loading/error/data states, manual and auto triggers, caching, polling, debounce, and retry
+---
+
+# useRequest
+
+A hook that manages async service calls with loading, error, and data states. Supports automatic and manual triggers, in-memory caching, polling, debounce, and automatic retry on failure.
+
+## Usage
+
+### Automatic fetch on mount
+
+```tsx
+import { useRequest } from "rooks";
+
+async function fetchUser(id: number) {
+  const res = await fetch(`/api/users/${id}`);
+  return res.json();
+}
+
+export default function UserProfile({ id }: { id: number }) {
+  const { data, loading, error } = useRequest(() => fetchUser(id));
+
+  if (loading) return <div>Loading…</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return <div>{data?.name}</div>;
+}
+```
+
+### Manual trigger
+
+```tsx
+import { useRequest } from "rooks";
+
+export default function SaveButton() {
+  const { loading, run } = useRequest(
+    () => fetch("/api/save", { method: "POST" }),
+    { manual: true }
+  );
+
+  return (
+    <button onClick={() => run()} disabled={loading}>
+      {loading ? "Saving…" : "Save"}
+    </button>
+  );
+}
+```
+
+### With parameters
+
+```tsx
+import { useRequest } from "rooks";
+
+async function searchUsers(query: string, page: number) {
+  const res = await fetch(`/api/users?q=${query}&page=${page}`);
+  return res.json();
+}
+
+export default function Search() {
+  const { data, loading, run } = useRequest(searchUsers, { manual: true });
+
+  return (
+    <div>
+      <button onClick={() => run("alice", 1)}>Search</button>
+      {loading && <span>Searching…</span>}
+      {data?.users.map((u) => <div key={u.id}>{u.name}</div>)}
+    </div>
+  );
+}
+```
+
+### Polling
+
+```tsx
+import { useRequest } from "rooks";
+
+export default function LivePrice({ symbol }: { symbol: string }) {
+  const { data } = useRequest(() => fetchPrice(symbol), {
+    pollingInterval: 5000, // re-fetch every 5 seconds
+  });
+
+  return <div>Price: {data?.price}</div>;
+}
+```
+
+### Debounce
+
+```tsx
+import { useRequest } from "rooks";
+
+export default function AutoComplete({ query }: { query: string }) {
+  const { data, loading, run } = useRequest(fetchSuggestions, {
+    manual: true,
+    debounceWait: 300,
+  });
+
+  // Rapid calls are batched; only the last fires after 300 ms
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    run(e.target.value);
+  };
+
+  return (
+    <div>
+      <input onChange={handleChange} />
+      {loading && <span>Loading…</span>}
+      {data?.map((s) => <div key={s}>{s}</div>)}
+    </div>
+  );
+}
+```
+
+### Retry on error
+
+```tsx
+import { useRequest } from "rooks";
+
+export default function ReliableFetch() {
+  const { data, error, loading } = useRequest(fetchData, {
+    retryCount: 3,      // retry up to 3 times
+    retryInterval: 500, // wait 500 ms between retries
+  });
+
+  if (loading) return <div>Loading (with retries)…</div>;
+  if (error) return <div>Failed after retries: {error.message}</div>;
+  return <div>{JSON.stringify(data)}</div>;
+}
+```
+
+### Caching
+
+```tsx
+import { useRequest } from "rooks";
+
+// Both components share the same cached response for 30 seconds
+function ComponentA() {
+  const { data } = useRequest(fetchConfig, {
+    cacheKey: "app-config",
+    staleTime: 30_000,
+  });
+  return <pre>{JSON.stringify(data)}</pre>;
+}
+
+function ComponentB() {
+  const { data } = useRequest(fetchConfig, {
+    cacheKey: "app-config",
+    staleTime: 30_000,
+  });
+  return <pre>{JSON.stringify(data)}</pre>;
+}
+```
+
+### Cancel
+
+```tsx
+import { useRequest } from "rooks";
+
+export default function CancellableFetch() {
+  const { data, loading, run, cancel } = useRequest(fetchLargeDataset, {
+    manual: true,
+  });
+
+  return (
+    <div>
+      <button onClick={() => run()}>Fetch</button>
+      <button onClick={cancel} disabled={!loading}>
+        Cancel
+      </button>
+      {loading && <span>Loading…</span>}
+      {data && <pre>{JSON.stringify(data)}</pre>}
+    </div>
+  );
+}
+```
+
+### Mutate (optimistic update)
+
+```tsx
+import { useRequest } from "rooks";
+
+export default function Counter() {
+  const { data, mutate, run } = useRequest(fetchCount);
+
+  const increment = () => {
+    mutate((current = 0) => current + 1); // optimistic
+    run(); // sync with server in background
+  };
+
+  return <button onClick={increment}>Count: {data}</button>;
+}
+```
+
+## API Reference
+
+### Parameters
+
+| Parameter | Type                                                 | Required | Description                        |
+| --------- | ---------------------------------------------------- | -------- | ---------------------------------- |
+| `service` | `(...params: TParams) => Promise<TData>`             | Yes      | Async function that fetches data   |
+| `options` | [`UseRequestOptions<TData, TParams>`](#options)      | No       | Configuration options              |
+
+### Options
+
+| Option            | Type                                                    | Default       | Description                                                                     |
+| ----------------- | ------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------- |
+| `manual`          | `boolean`                                               | `false`       | When true, the request is not triggered automatically on mount                  |
+| `defaultParams`   | `TParams`                                               | `[]`          | Parameters forwarded to `service` on the initial auto-trigger                   |
+| `onSuccess`       | `(data: TData, params: TParams) => void`                | —             | Called after a successful response                                              |
+| `onError`         | `(error: Error, params: TParams) => void`               | —             | Called after all retry attempts are exhausted                                   |
+| `onFinally`       | `(params: TParams, data?: TData, error?: Error) => void`| —             | Called when the request settles regardless of outcome                           |
+| `cacheKey`        | `string`                                                | —             | When provided, successful responses are stored in a global in-memory cache      |
+| `cacheTime`       | `number`                                                | `300000`      | Duration (ms) before a cache entry is evicted                                   |
+| `staleTime`       | `number`                                                | `0`           | Duration (ms) a cached response is considered fresh (0 = always refetch)        |
+| `pollingInterval` | `number`                                                | —             | Automatically re-runs the request at this interval (ms). Omit to disable        |
+| `debounceWait`    | `number`                                                | —             | Debounce delay (ms) for `run()`. Omit or set 0 to disable                       |
+| `retryCount`      | `number`                                                | `0`           | Number of extra attempts after a failure                                        |
+| `retryInterval`   | `number`                                                | `1000`        | Delay (ms) between consecutive retry attempts                                   |
+
+### Return Value
+
+| Property       | Type                                                                      | Description                                                      |
+| -------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `loading`      | `boolean`                                                                 | True while a request (including retries) is in-flight            |
+| `data`         | `TData \| undefined`                                                      | The most recent successful response                              |
+| `error`        | `Error \| undefined`                                                      | Error from the most recent failure (cleared when the next run starts) |
+| `params`       | `TParams \| undefined`                                                    | Parameters from the most recent invocation                       |
+| `run`          | `(...params: TParams) => void`                                            | Trigger the request (fire-and-forget). Respects `debounceWait`   |
+| `runAsync`     | `(...params: TParams) => Promise<TData>`                                  | Trigger the request and return the promise                       |
+| `refresh`      | `() => void`                                                              | Re-trigger using the last-used parameters                        |
+| `refreshAsync` | `() => Promise<TData>`                                                    | Re-trigger using the last-used parameters, returns a promise     |
+| `mutate`       | `(data: TData \| ((current: TData \| undefined) => TData \| undefined)) => void` | Directly set the data without making a request           |
+| `cancel`       | `() => void`                                                              | Cancel the in-flight request and clear pending debounce/retry    |
+
+## Related Hooks
+
+- [`usePromise`](/docs/hooks/usePromise) — lightweight promise state without extra features
+- [`useFetch`](/docs/hooks/useFetch) — fetch-specific hook for simple URL fetching
+- [`useIntervalWhen`](/docs/hooks/useIntervalWhen) — conditional interval primitive used internally by polling

--- a/data/hooks-list.json
+++ b/data/hooks-list.json
@@ -446,6 +446,11 @@
       "category": "state"
     },
     {
+      "name": "useRequest",
+      "description": "Async data-fetching hook with loading, error, and data states, supporting manual and automatic triggers, caching, polling, debounce, and retry",
+      "category": "state"
+    },
+    {
       "name": "useRaf",
       "description": "A continuously running requestAnimationFrame hook for React",
       "category": "animation"

--- a/packages/rooks/src/__tests__/useRequest.spec.tsx
+++ b/packages/rooks/src/__tests__/useRequest.spec.tsx
@@ -1,0 +1,727 @@
+import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useRequest } from "@/hooks/useRequest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeService<T>(value: T, delayMs = 0) {
+  return vi.fn(
+    (): Promise<T> =>
+      new Promise((resolve) => {
+        if (delayMs > 0) {
+          setTimeout(() => resolve(value), delayMs);
+        } else {
+          resolve(value);
+        }
+      })
+  );
+}
+
+function makeErrorService(message = "request failed", delayMs = 0) {
+  return vi.fn(
+    (): Promise<never> =>
+      new Promise((_, reject) => {
+        if (delayMs > 0) {
+          setTimeout(() => reject(new Error(message)), delayMs);
+        } else {
+          reject(new Error(message));
+        }
+      })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useRequest", () => {
+  it("is defined", () => {
+    expect.hasAssertions();
+    expect(useRequest).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auto-trigger
+  // -------------------------------------------------------------------------
+
+  describe("auto-trigger (manual=false)", () => {
+    it("starts with loading=true", () => {
+      expect.hasAssertions();
+      const service = makeService("data", 100);
+      const { result } = renderHook(() => useRequest(service));
+      expect(result.current.loading).toBe(true);
+    });
+
+    it("resolves data and clears loading on success", async () => {
+      expect.hasAssertions();
+      const service = makeService("hello");
+      const { result } = renderHook(() => useRequest(service));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data).toBe("hello");
+      expect(result.current.error).toBeUndefined();
+      expect(service).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets error and clears loading on failure", async () => {
+      expect.hasAssertions();
+      const service = makeErrorService("boom");
+      const { result } = renderHook(() => useRequest(service));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.error?.message).toBe("boom");
+    });
+
+    it("passes defaultParams to the service", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(
+        (id: number): Promise<string> => Promise.resolve(`user-${id}`)
+      );
+      const { result } = renderHook(() =>
+        useRequest(service, { defaultParams: [42] })
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(service).toHaveBeenCalledWith(42);
+      expect(result.current.data).toBe("user-42");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Manual mode
+  // -------------------------------------------------------------------------
+
+  describe("manual=true", () => {
+    it("does not fetch on mount", () => {
+      expect.hasAssertions();
+      const service = makeService("data");
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(service).not.toHaveBeenCalled();
+    });
+
+    it("fetches when run() is called", async () => {
+      expect.hasAssertions();
+      const service = makeService("manual-data");
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      act(() => {
+        result.current.run();
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.data).toBe("manual-data");
+    });
+
+    it("fetches when runAsync() is called", async () => {
+      expect.hasAssertions();
+      const service = makeService(99);
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      let resolved: number | undefined;
+      await act(async () => {
+        resolved = await result.current.runAsync();
+      });
+
+      expect(resolved).toBe(99);
+      expect(result.current.data).toBe(99);
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // run() with params
+  // -------------------------------------------------------------------------
+
+  describe("run() with params", () => {
+    it("passes params to the service", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(
+        (a: string, b: number): Promise<string> =>
+          Promise.resolve(`${a}-${b}`)
+      );
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      act(() => {
+        result.current.run("foo", 7);
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(service).toHaveBeenCalledWith("foo", 7);
+      expect(result.current.data).toBe("foo-7");
+      expect(result.current.params).toEqual(["foo", 7]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Callbacks
+  // -------------------------------------------------------------------------
+
+  describe("callbacks", () => {
+    it("calls onSuccess with data and params", async () => {
+      expect.hasAssertions();
+      const onSuccess = vi.fn();
+      const service = vi.fn((x: number) => Promise.resolve(x * 2));
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true, onSuccess })
+      );
+
+      act(() => {
+        result.current.run(5);
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(onSuccess).toHaveBeenCalledWith(10, [5]);
+    });
+
+    it("calls onError with error and params", async () => {
+      expect.hasAssertions();
+      const onError = vi.fn();
+      const service = vi.fn((_x: number) =>
+        Promise.reject(new Error("oops"))
+      );
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true, onError })
+      );
+
+      act(() => {
+        result.current.run(3);
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(onError).toHaveBeenCalledWith(expect.any(Error), [3]);
+      expect(onError.mock.calls[0]?.[0].message).toBe("oops");
+    });
+
+    it("calls onFinally on success", async () => {
+      expect.hasAssertions();
+      const onFinally = vi.fn();
+      const service = makeService("done");
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true, onFinally })
+      );
+
+      act(() => result.current.run());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(onFinally).toHaveBeenCalledTimes(1);
+      expect(onFinally).toHaveBeenCalledWith([], "done", undefined);
+    });
+
+    it("calls onFinally on error", async () => {
+      expect.hasAssertions();
+      const onFinally = vi.fn();
+      const service = makeErrorService("fail");
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true, onFinally })
+      );
+
+      act(() => result.current.run());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(onFinally).toHaveBeenCalledTimes(1);
+      expect(onFinally).toHaveBeenCalledWith(
+        [],
+        undefined,
+        expect.any(Error)
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refresh / refreshAsync
+  // -------------------------------------------------------------------------
+
+  describe("refresh", () => {
+    it("re-runs with last params", async () => {
+      expect.hasAssertions();
+      const service = vi.fn((x: number) => Promise.resolve(x + 1));
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      act(() => result.current.run(10));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data).toBe(11);
+      expect(service).toHaveBeenCalledTimes(1);
+
+      act(() => result.current.refresh());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(service).toHaveBeenCalledTimes(2);
+      expect(service).toHaveBeenLastCalledWith(10);
+    });
+
+    it("refreshAsync returns a promise that resolves with new data", async () => {
+      expect.hasAssertions();
+      let counter = 0;
+      const service = vi.fn((): Promise<number> => Promise.resolve(++counter));
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      act(() => result.current.run());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data).toBe(1);
+
+      let refreshed: number | undefined;
+      await act(async () => {
+        refreshed = await result.current.refreshAsync();
+      });
+      expect(refreshed).toBe(2);
+      expect(result.current.data).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // mutate
+  // -------------------------------------------------------------------------
+
+  describe("mutate", () => {
+    it("sets data directly to a new value", async () => {
+      expect.hasAssertions();
+      const service = makeService("original");
+      const { result } = renderHook(() => useRequest(service));
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.data).toBe("original");
+
+      act(() => result.current.mutate("overridden"));
+      expect(result.current.data).toBe("overridden");
+    });
+
+    it("accepts an updater function", async () => {
+      expect.hasAssertions();
+      const service = makeService(5);
+      const { result } = renderHook(() => useRequest(service));
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => result.current.mutate((old) => (old ?? 0) * 10));
+      expect(result.current.data).toBe(50);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cancel
+  // -------------------------------------------------------------------------
+
+  describe("cancel", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("sets loading=false immediately", async () => {
+      expect.hasAssertions();
+      const service = makeService("late", 500);
+      const { result } = renderHook(() => useRequest(service));
+
+      // loading starts true
+      expect(result.current.loading).toBe(true);
+
+      act(() => result.current.cancel());
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("does not update data after cancel", async () => {
+      expect.hasAssertions();
+      const service = makeService("should-not-arrive", 200);
+      const { result } = renderHook(() => useRequest(service));
+
+      act(() => result.current.cancel());
+      expect(result.current.data).toBeUndefined();
+
+      // Advance past the service delay to make sure nothing arrives
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(result.current.data).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Retry
+  // -------------------------------------------------------------------------
+
+  describe("retryCount", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("retries the specified number of times before failing", async () => {
+      expect.hasAssertions();
+      const service = makeErrorService("transient");
+
+      const { result } = renderHook(() =>
+        useRequest(service, {
+          manual: true,
+          retryCount: 2,
+          retryInterval: 100,
+        })
+      );
+
+      act(() => result.current.run());
+
+      // Flush first failure (synchronous rejection, resolved via microtask)
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Advance through first retry interval and flush
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      // Advance through second retry interval and flush
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      expect(service).toHaveBeenCalledTimes(3); // 1 original + 2 retries
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error?.message).toBe("transient");
+    });
+
+    it("succeeds on a later retry", async () => {
+      expect.hasAssertions();
+      let attempts = 0;
+      const service = vi.fn((): Promise<string> => {
+        attempts++;
+        if (attempts < 3) return Promise.reject(new Error("not yet"));
+        return Promise.resolve("success-on-retry");
+      });
+
+      const { result } = renderHook(() =>
+        useRequest(service, {
+          manual: true,
+          retryCount: 3,
+          retryInterval: 50,
+        })
+      );
+
+      act(() => result.current.run());
+
+      // Flush first failure
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Advance through first retry
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+
+      // Advance through second retry (this one succeeds)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+
+      expect(service).toHaveBeenCalledTimes(3);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.data).toBe("success-on-retry");
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Debounce
+  // -------------------------------------------------------------------------
+
+  describe("debounceWait", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("coalesces rapid calls into one request", async () => {
+      expect.hasAssertions();
+      const service = makeService("debounced");
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true, debounceWait: 200 })
+      );
+
+      act(() => {
+        result.current.run();
+        result.current.run();
+        result.current.run();
+      });
+
+      // No call yet — still within debounce window
+      expect(service).not.toHaveBeenCalled();
+
+      // Advance past the debounce window and flush promises
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+
+      expect(service).toHaveBeenCalledTimes(1);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("uses the last params when debouncing multiple calls", async () => {
+      expect.hasAssertions();
+      const service = vi.fn((x: number) => Promise.resolve(x));
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true, debounceWait: 150 })
+      );
+
+      act(() => {
+        result.current.run(1);
+        result.current.run(2);
+        result.current.run(3);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(150);
+      });
+
+      expect(service).toHaveBeenCalledTimes(1);
+      expect(service).toHaveBeenCalledWith(3);
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Polling
+  // -------------------------------------------------------------------------
+
+  describe("pollingInterval", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("re-triggers the request at the specified interval", async () => {
+      expect.hasAssertions();
+      const service = makeService("poll");
+
+      renderHook(() => useRequest(service, { pollingInterval: 1000 }));
+
+      // Flush the initial auto-trigger (runs via useEffect + Promise microtask)
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(service).toHaveBeenCalledTimes(1);
+
+      // Advance one polling interval
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(service).toHaveBeenCalledTimes(2);
+
+      // Advance another polling interval
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(service).toHaveBeenCalledTimes(3);
+    });
+
+    it("stops polling on unmount", async () => {
+      expect.hasAssertions();
+      const service = makeService("poll");
+
+      const { unmount } = renderHook(() =>
+        useRequest(service, { pollingInterval: 500 })
+      );
+
+      // Flush initial auto-trigger
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(service).toHaveBeenCalledTimes(1);
+
+      unmount();
+      const countAfterUnmount = service.mock.calls.length;
+
+      // Advance well past several polling intervals
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(service).toHaveBeenCalledTimes(countAfterUnmount);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Caching
+  // -------------------------------------------------------------------------
+
+  describe("cacheKey + staleTime", () => {
+    it("returns cached data without re-fetching within staleTime", async () => {
+      expect.hasAssertions();
+      const service = makeService("cached-value");
+      const key = `test-cache-${Date.now()}`;
+
+      // First hook instance — triggers a real request
+      const { result: first } = renderHook(() =>
+        useRequest(service, { cacheKey: key, staleTime: 60_000 })
+      );
+      await waitFor(() => expect(first.current.loading).toBe(false));
+      expect(first.current.data).toBe("cached-value");
+      expect(service).toHaveBeenCalledTimes(1);
+
+      // Second hook instance — should hit the in-memory cache
+      const { result: second } = renderHook(() =>
+        useRequest(service, { cacheKey: key, staleTime: 60_000 })
+      );
+
+      // Data should be available immediately, loading should be false
+      expect(second.current.data).toBe("cached-value");
+      expect(second.current.loading).toBe(false);
+
+      // Service should still have been called only once (cache hit)
+      expect(service).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-fetches when staleTime=0 (default)", async () => {
+      expect.hasAssertions();
+      const service = makeService("fresh");
+      const key = `test-no-cache-${Date.now()}`;
+
+      const { result: first } = renderHook(() =>
+        useRequest(service, { cacheKey: key, staleTime: 0 })
+      );
+      await waitFor(() => expect(first.current.loading).toBe(false));
+
+      const { result: second } = renderHook(() =>
+        useRequest(service, { cacheKey: key, staleTime: 0 })
+      );
+      await waitFor(() => expect(second.current.loading).toBe(false));
+
+      // Both instances should have triggered a fetch
+      expect(service).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cleanup on unmount
+  // -------------------------------------------------------------------------
+
+  describe("cleanup", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("does not update state after unmount", async () => {
+      expect.hasAssertions();
+      const service = makeService("late-data", 300);
+      const { result, unmount } = renderHook(() => useRequest(service));
+
+      expect(result.current.loading).toBe(true);
+      unmount();
+
+      // Advancing past service delay should not cause errors
+      await act(async () => vi.advanceTimersByTime(400));
+      // No assertion — absence of act() warnings / exceptions is the goal
+    });
+
+    it("clears pending retry timers on unmount", async () => {
+      expect.hasAssertions();
+      const service = makeErrorService("persistent");
+
+      const { result, unmount } = renderHook(() =>
+        useRequest(service, {
+          manual: true,
+          retryCount: 5,
+          retryInterval: 1000,
+        })
+      );
+
+      act(() => result.current.run());
+
+      // Let the first attempt fail via microtask
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Unmount while the first retry timer (1000ms) is still pending
+      unmount();
+
+      // Advancing well past all retry intervals should not trigger more calls
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+
+      // Only the initial attempt should have run before unmount cancelled retries
+      expect(service).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error cleared on next run
+  // -------------------------------------------------------------------------
+
+  describe("error state lifecycle", () => {
+    it("clears error when a subsequent request succeeds", async () => {
+      expect.hasAssertions();
+      let fail = true;
+      const service = vi.fn((): Promise<string> => {
+        if (fail) return Promise.reject(new Error("temporary error"));
+        return Promise.resolve("recovered");
+      });
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      // First call — fails
+      act(() => result.current.run());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.error?.message).toBe("temporary error");
+
+      // Second call — succeeds
+      fail = false;
+      act(() => result.current.run());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.data).toBe("recovered");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // params tracking
+  // -------------------------------------------------------------------------
+
+  describe("params tracking", () => {
+    it("exposes params from the last run call", async () => {
+      expect.hasAssertions();
+      const service = vi.fn(
+        (a: string, b: number) => Promise.resolve(`${a}:${b}`)
+      );
+
+      const { result } = renderHook(() =>
+        useRequest(service, { manual: true })
+      );
+
+      act(() => result.current.run("hello", 42));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.params).toEqual(["hello", 42]);
+    });
+  });
+});

--- a/packages/rooks/src/hooks/useRequest.ts
+++ b/packages/rooks/src/hooks/useRequest.ts
@@ -1,0 +1,401 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+
+/**
+ * Global in-memory cache shared across all useRequest instances with the same cacheKey.
+ */
+const globalRequestCache = new Map<
+  string,
+  { data: unknown; timestamp: number }
+>();
+
+type UseRequestService<TData, TParams extends unknown[]> = (
+  ...params: TParams
+) => Promise<TData>;
+
+interface UseRequestOptions<TData, TParams extends unknown[]> {
+  /**
+   * If true, the request must be triggered manually via run() or runAsync().
+   * @default false
+   */
+  manual?: boolean;
+  /**
+   * Default parameters passed to the service on the initial auto-trigger.
+   */
+  defaultParams?: TParams;
+  /**
+   * Callback fired when the request succeeds.
+   */
+  onSuccess?: (data: TData, params: TParams) => void;
+  /**
+   * Callback fired when the request fails (after all retries are exhausted).
+   */
+  onError?: (error: Error, params: TParams) => void;
+  /**
+   * Callback fired when the request completes, whether success or failure.
+   */
+  onFinally?: (params: TParams, data?: TData, error?: Error) => void;
+  /**
+   * Cache key. When provided, successful responses are cached and shared
+   * across hook instances using the same key.
+   */
+  cacheKey?: string;
+  /**
+   * Duration in ms to retain a cache entry before it is evicted.
+   * @default 300000 (5 minutes)
+   */
+  cacheTime?: number;
+  /**
+   * Duration in ms during which a cached response is considered fresh and
+   * returned immediately without a network request.
+   * Set to 0 to always refetch (stale-while-revalidate disabled).
+   * @default 0
+   */
+  staleTime?: number;
+  /**
+   * When set to a positive number, the hook automatically re-runs at that
+   * interval (in ms) after each response.
+   */
+  pollingInterval?: number;
+  /**
+   * Debounce delay in ms. Calls to run() are batched; only the last call
+   * within the window triggers a request.
+   */
+  debounceWait?: number;
+  /**
+   * Number of additional retry attempts on error.
+   * @default 0
+   */
+  retryCount?: number;
+  /**
+   * Delay in ms between consecutive retry attempts.
+   * @default 1000
+   */
+  retryInterval?: number;
+}
+
+interface UseRequestResult<TData, TParams extends unknown[]> {
+  /** True while a request is in-flight (including retries). */
+  loading: boolean;
+  /** The most recent successful response. */
+  data: TData | undefined;
+  /** The error from the most recent failed request (cleared on next run). */
+  error: Error | undefined;
+  /** Parameters used in the most recent invocation. */
+  params: TParams | undefined;
+  /** Trigger the request. Swallows the returned promise rejection. */
+  run: (...params: TParams) => void;
+  /** Trigger the request and return the promise. */
+  runAsync: (...params: TParams) => Promise<TData>;
+  /** Re-trigger using the last-used parameters. */
+  refresh: () => void;
+  /** Re-trigger using the last-used parameters, returns a promise. */
+  refreshAsync: () => Promise<TData>;
+  /**
+   * Manually override the current data value without triggering a request.
+   * Accepts a new value or an updater function.
+   */
+  mutate: (
+    data: TData | ((currentData: TData | undefined) => TData | undefined)
+  ) => void;
+  /** Cancel the in-flight request and clear any pending debounce or retry. */
+  cancel: () => void;
+}
+
+/**
+ * useRequest hook
+ *
+ * @description Manages async data fetching with loading/error/data states.
+ * Supports manual and automatic triggers, caching, polling, debounce, and retry.
+ *
+ * @param service - Async function that performs the request
+ * @param options - Configuration options
+ * @see https://rooks.vercel.app/docs/hooks/useRequest
+ */
+function useRequest<TData, TParams extends unknown[]>(
+  service: UseRequestService<TData, TParams>,
+  options: UseRequestOptions<TData, TParams> = {}
+): UseRequestResult<TData, TParams> {
+  // Keep the latest service and options in refs so callbacks are always fresh
+  const serviceRef = useRef(service);
+  serviceRef.current = service;
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // Compute initial data from a non-stale cache entry (if any)
+  const getInitialCacheData = (): TData | undefined => {
+    const { cacheKey, staleTime = 0 } = options;
+    if (!cacheKey || staleTime === 0) return undefined;
+    const cached = globalRequestCache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < staleTime) {
+      return cached.data as TData;
+    }
+    return undefined;
+  };
+
+  const initialCachedData = getInitialCacheData();
+
+  const [loading, setLoading] = useState<boolean>(
+    // Start as loading only when auto-triggering and no fresh cache exists
+    !options.manual && initialCachedData === undefined
+  );
+  const [data, setData] = useState<TData | undefined>(initialCachedData);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [params, setParams] = useState<TParams | undefined>(undefined);
+
+  const isMountedRef = useRef(true);
+  const cancelledRef = useRef(false);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const pollingTimerRef = useRef<ReturnType<typeof setInterval> | undefined>(
+    undefined
+  );
+  const lastParamsRef = useRef<TParams | undefined>(undefined);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      cancelledRef.current = true;
+      if (retryTimerRef.current !== undefined) {
+        clearTimeout(retryTimerRef.current);
+      }
+      if (debounceTimerRef.current !== undefined) {
+        clearTimeout(debounceTimerRef.current);
+      }
+      if (pollingTimerRef.current !== undefined) {
+        clearInterval(pollingTimerRef.current);
+      }
+    };
+  }, []);
+
+  /**
+   * Core async executor. Stable reference — reads all options from refs.
+   */
+  const runAsync = useCallback(async (...runParams: TParams): Promise<TData> => {
+    const {
+      cacheKey,
+      cacheTime = 5 * 60 * 1000,
+      staleTime = 0,
+      retryCount = 0,
+      retryInterval: retryDelayMs = 1000,
+      onSuccess,
+      onError,
+      onFinally,
+    } = optionsRef.current;
+
+    // Cancel any pending retry from a previous call
+    if (retryTimerRef.current !== undefined) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = undefined;
+    }
+    cancelledRef.current = false;
+    lastParamsRef.current = runParams;
+
+    if (isMountedRef.current) {
+      setParams(runParams);
+    }
+
+    // Return cached data immediately if it is still within staleTime
+    if (cacheKey && staleTime > 0) {
+      const cached = globalRequestCache.get(cacheKey);
+      if (cached && Date.now() - cached.timestamp < staleTime) {
+        if (isMountedRef.current) {
+          setData(cached.data as TData);
+          setLoading(false);
+          setError(undefined);
+        }
+        return cached.data as TData;
+      }
+    }
+
+    if (isMountedRef.current) {
+      setLoading(true);
+      setError(undefined);
+    }
+
+    const executeWithRetry = async (attempt: number): Promise<TData> => {
+      try {
+        const result = await serviceRef.current(...runParams);
+
+        if (cancelledRef.current) {
+          // Request was cancelled while awaiting; propagate silently
+          throw new Error("useRequest: request cancelled");
+        }
+
+        // Populate cache
+        if (cacheKey) {
+          globalRequestCache.set(cacheKey, {
+            data: result,
+            timestamp: Date.now(),
+          });
+          setTimeout(() => {
+            const entry = globalRequestCache.get(cacheKey);
+            if (entry && Date.now() - entry.timestamp >= cacheTime) {
+              globalRequestCache.delete(cacheKey);
+            }
+          }, cacheTime);
+        }
+
+        if (isMountedRef.current) {
+          setData(result);
+          setLoading(false);
+          setError(undefined);
+        }
+
+        onSuccess?.(result, runParams);
+        onFinally?.(runParams, result, undefined);
+        return result;
+      } catch (err) {
+        if (cancelledRef.current) {
+          throw err;
+        }
+
+        const requestError =
+          err instanceof Error ? err : new Error(String(err));
+
+        if (attempt < retryCount) {
+          return new Promise<TData>((resolve, reject) => {
+            retryTimerRef.current = setTimeout(() => {
+              retryTimerRef.current = undefined;
+              if (!cancelledRef.current && isMountedRef.current) {
+                executeWithRetry(attempt + 1).then(resolve, reject);
+              } else {
+                reject(new Error("useRequest: request cancelled"));
+              }
+            }, retryDelayMs);
+          });
+        }
+
+        if (isMountedRef.current) {
+          setError(requestError);
+          setLoading(false);
+        }
+        onError?.(requestError, runParams);
+        onFinally?.(runParams, undefined, requestError);
+        throw requestError;
+      }
+    };
+
+    return executeWithRetry(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Intentionally empty: all option access is via optionsRef
+
+  /**
+   * Fire-and-forget wrapper around runAsync, with optional debounce.
+   */
+  const run = useCallback(
+    (...runParams: TParams): void => {
+      const { debounceWait } = optionsRef.current;
+
+      if (debounceWait !== undefined && debounceWait > 0) {
+        if (debounceTimerRef.current !== undefined) {
+          clearTimeout(debounceTimerRef.current);
+        }
+        debounceTimerRef.current = setTimeout(() => {
+          debounceTimerRef.current = undefined;
+          runAsync(...runParams).catch(() => {
+            // errors are surfaced via the error state
+          });
+        }, debounceWait);
+      } else {
+        runAsync(...runParams).catch(() => {
+          // errors are surfaced via the error state
+        });
+      }
+    },
+    [runAsync]
+  );
+
+  const refresh = useCallback((): void => {
+    const p = lastParamsRef.current ?? ([] as unknown as TParams);
+    run(...p);
+  }, [run]);
+
+  const refreshAsync = useCallback((): Promise<TData> => {
+    const p = lastParamsRef.current ?? ([] as unknown as TParams);
+    return runAsync(...p);
+  }, [runAsync]);
+
+  const mutate = useCallback(
+    (
+      updater: TData | ((currentData: TData | undefined) => TData | undefined)
+    ): void => {
+      setData((current) =>
+        typeof updater === "function"
+          ? (updater as (c: TData | undefined) => TData | undefined)(current)
+          : updater
+      );
+    },
+    []
+  );
+
+  const cancel = useCallback((): void => {
+    cancelledRef.current = true;
+    if (retryTimerRef.current !== undefined) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = undefined;
+    }
+    if (debounceTimerRef.current !== undefined) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = undefined;
+    }
+    if (isMountedRef.current) {
+      setLoading(false);
+    }
+  }, []);
+
+  // Auto-trigger on mount when manual=false
+  useEffect(() => {
+    if (!optionsRef.current.manual) {
+      const initParams =
+        optionsRef.current.defaultParams ?? ([] as unknown as TParams);
+      runAsync(...initParams).catch(() => {
+        // errors are surfaced via the error state
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Polling: restart the interval whenever pollingInterval changes
+  const { pollingInterval } = options;
+  useEffect(() => {
+    if (pollingInterval !== undefined && pollingInterval > 0) {
+      pollingTimerRef.current = setInterval(() => {
+        const p = lastParamsRef.current ?? ([] as unknown as TParams);
+        runAsync(...p).catch(() => {
+          // errors are surfaced via the error state
+        });
+      }, pollingInterval);
+
+      return () => {
+        if (pollingTimerRef.current !== undefined) {
+          clearInterval(pollingTimerRef.current);
+          pollingTimerRef.current = undefined;
+        }
+      };
+    }
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pollingInterval, runAsync]);
+
+  return {
+    loading,
+    data,
+    error,
+    params,
+    run,
+    runAsync,
+    refresh,
+    refreshAsync,
+    mutate,
+    cancel,
+  };
+}
+
+export { useRequest };
+export type { UseRequestOptions, UseRequestResult, UseRequestService };

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -96,6 +96,12 @@ export { usePreviousDifferent } from "./hooks/usePreviousDifferent";
 export { usePreviousImmediate } from "./hooks/usePreviousImmediate";
 export { usePromise } from "./hooks/usePromise";
 export { useQueueState } from "./hooks/useQueueState";
+export { useRequest } from "./hooks/useRequest";
+export type {
+  UseRequestOptions,
+  UseRequestResult,
+  UseRequestService,
+} from "./hooks/useRequest";
 export { useRaf } from "./hooks/useRaf";
 export { useRafState } from "./hooks/useRafState";
 export { useResizeObserverRef } from "./hooks/useResizeObserverRef";


### PR DESCRIPTION
## Summary

- Implements `useRequest` hook for async data fetching with rich feature set similar to ahooks `useRequest`
- **Auto-trigger**: fetches on mount by default; pass `manual: true` to require explicit `run()` call
- **State management**: exposes `loading`, `data`, `error`, and `params` from the last invocation
- **Full control API**: `run`, `runAsync`, `refresh`, `refreshAsync`, `mutate`, `cancel`
- **Caching**: shared in-memory cache via `cacheKey` / `cacheTime` / `staleTime`
- **Polling**: automatic re-fetch at `pollingInterval` ms, cleans up on unmount
- **Debounce**: coalesces rapid `run()` calls with `debounceWait`
- **Retry**: retries on error with configurable `retryCount` and `retryInterval`
- **Callbacks**: `onSuccess`, `onError`, `onFinally`

## Files changed

| File | Description |
|---|---|
| `packages/rooks/src/hooks/useRequest.ts` | Hook implementation |
| `packages/rooks/src/__tests__/useRequest.spec.tsx` | 31 tests covering all features |
| `apps/website/content/docs/hooks/(state)/useRequest.mdx` | Documentation page |
| `packages/rooks/src/index.ts` | Export added |

## Test plan

- [x] All 31 `useRequest` tests pass
- [x] Full suite of 140 test files passes (1528 tests, 0 failures)
- [x] Auto-trigger, manual mode, params, callbacks, refresh, mutate, cancel
- [x] Retry with fake timers (`vi.advanceTimersByTimeAsync`)
- [x] Debounce coalescing with fake timers
- [x] Polling start/stop with fake timers
- [x] Cache hit (staleTime) and cache miss (staleTime=0)
- [x] Cleanup on unmount (no state updates, retry timers cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)