### PR TITLE
fix: add missing exports in index.ts

### DIFF
--- a/.changeset/smart-canyons-turn.md
+++ b/.changeset/smart-canyons-turn.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+Added missing exports in index.ts

--- a/packages/rooks/src/index.ts
+++ b/packages/rooks/src/index.ts
@@ -130,4 +130,6 @@ export { useWillUnmount } from "./hooks/useWillUnmount";
 export { useWindowEventListener } from "./hooks/useWindowEventListener";
 export { useWindowScrollPosition } from "./hooks/useWindowScrollPosition";
 export { useWindowSize } from "./hooks/useWindowSize";
+export { useWarningOnMountInDevelopment } from "./hooks/useWarningOnMountInDevelopment";
 export { useOnStartTyping } from "./hooks/useOnStartTyping";
+export { useGlobalObjectEventListener } from "./hooks/useGlobalObjectEventListener";


### PR DESCRIPTION

## Summary

- This PR adds missing `useWarningOnMountInDevelopment` and `useGlobalObjectEventListener` to `index.ts`

## Files changed

| File | Description |
|---|---|
| `packages/rooks/src/index.ts` | Exports added |