### PR TITLE
Add Screen Details API window type

### DIFF
--- a/packages/rooks/src/hooks/useScreenDetailsApi.ts
+++ b/packages/rooks/src/hooks/useScreenDetailsApi.ts
@@ -27,6 +27,10 @@ interface ScreenDetails {
   removeEventListener: (event: string, handler: (event: Event) => void) => void;
 }
 
+type ScreenDetailsWindow = Window & {
+  getScreenDetails?: () => Promise<ScreenDetails>;
+};
+
 interface UseScreenDetailsApiOptions {
   /**
    * Whether to automatically request permission on mount
@@ -83,7 +87,13 @@ function useScreenDetailsApi(options: UseScreenDetailsApiOptions = {}): UseScree
   
   // Check if Screen Details API is supported
   const isSupported = useMemo(() => {
-    return typeof window !== "undefined" && typeof (window as any).getScreenDetails === "function";
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    const screenDetailsWindow = window as ScreenDetailsWindow;
+
+    return typeof screenDetailsWindow.getScreenDetails === "function";
   }, []);
   
   // Computed properties
@@ -103,7 +113,13 @@ function useScreenDetailsApi(options: UseScreenDetailsApiOptions = {}): UseScree
     setError(null);
     
     try {
-      const screenDetails = await (window as any).getScreenDetails();
+      const screenDetailsWindow = window as ScreenDetailsWindow;
+      const screenDetails = await screenDetailsWindow.getScreenDetails?.();
+
+      if (!screenDetails) {
+        throw new Error("Screen Details API is not supported");
+      }
+
       screenDetailsRef.current = screenDetails;
       setScreens(screenDetails.screens);
       setCurrentScreen(screenDetails.currentScreen);


### PR DESCRIPTION
## Summary
- add a narrow local `ScreenDetailsWindow` type for `window.getScreenDetails`
- preserve the SSR-safe support check and avoid the prior `window as any` call path

## Verification
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/vitest run src/__tests__/useScreenDetailsApi.spec.ts` from `packages/rooks`
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/tsc -p ./tsconfig.json --noEmit` from `packages/rooks`

Note: `pnpm install --frozen-lockfile` is currently blocked by an existing lockfile override mismatch; `pnpm install --no-frozen-lockfile` populated dependencies but exits nonzero under pnpm's build-script approval policy. No install-generated file changes are included.