### PR TITLE
Remove preferred color scheme ts-ignore

### DIFF
--- a/packages/rooks/src/hooks/usePreferredColorScheme.ts
+++ b/packages/rooks/src/hooks/usePreferredColorScheme.ts
@@ -6,6 +6,11 @@ import { noop } from "@/utils/noop";
  */
 type ColorScheme = "light" | "dark" | "no-preference";
 
+type LegacyMediaQueryList = MediaQueryList & {
+  addListener: (listener: () => void) => void;
+  removeListener: (listener: () => void) => void;
+};
+
 /**
  * Return value for the usePreferredColorScheme hook
  */
@@ -66,16 +71,15 @@ function subscribe(onStoreChange: () => void): () => void {
     };
   } else {
     // Fallback for older browsers using addListener
-    // @ts-ignore - addListener exists in older browsers
-    darkModeQuery.addListener(onStoreChange);
-    // @ts-ignore
-    lightModeQuery.addListener(onStoreChange);
+    const legacyDarkModeQuery = darkModeQuery as LegacyMediaQueryList;
+    const legacyLightModeQuery = lightModeQuery as LegacyMediaQueryList;
+
+    legacyDarkModeQuery.addListener(onStoreChange);
+    legacyLightModeQuery.addListener(onStoreChange);
 
     return () => {
-      // @ts-ignore
-      darkModeQuery.removeListener(onStoreChange);
-      // @ts-ignore
-      lightModeQuery.removeListener(onStoreChange);
+      legacyDarkModeQuery.removeListener(onStoreChange);
+      legacyLightModeQuery.removeListener(onStoreChange);
     };
   }
 }


### PR DESCRIPTION
## Summary
- Replace the `@ts-ignore` fallback for legacy `MediaQueryList.addListener` with a small local compatibility type.
- Preserve the existing runtime behavior for older browser media query listeners.

## Verification
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH" pnpm --filter rooks exec vitest run src/__tests__/usePreferredColorScheme.spec.tsx`
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:$PATH" pnpm --filter rooks typecheck`