### PR TITLE
docs: clarify useKeys event listener comments

### DIFF
--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -24,7 +24,7 @@ type Options = {
    */
   when?: boolean;
   /**
-   * opt-in to prevent alert, confirm and prompt from causing the eventlistener to lose track of keyup events.
+   * opt-in to prevent alert, confirm and prompt from causing the event listener to lose track of keyup events.
    */
   preventLostKeyup?: boolean;
 };


### PR DESCRIPTION
## Summary
- Clarify two `useKeys` option comments by spelling `event listener` consistently.

## Verification
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node_modules/.bin/tsc -p tsconfig.json --noEmit` from `packages/rooks`
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node_modules/.bin/vitest run src/__tests__/useKeys.spec.tsx` from `packages/rooks`