### PR TITLE
test: type screen details async resolver

### DIFF
--- a/packages/rooks/src/__tests__/useScreenDetailsApi.spec.ts
+++ b/packages/rooks/src/__tests__/useScreenDetailsApi.spec.ts
@@ -462,8 +462,8 @@ describe("useScreenDetailsApi", () => {
   it("should handle loading state correctly", async () => {
     expect.hasAssertions();
     
-    let resolveGetScreenDetails: (value: TestScreenDetails) => void;
-    const screenDetailsPromise = new Promise(resolve => {
+    let resolveGetScreenDetails: (value: typeof mockScreenDetails) => void;
+    const screenDetailsPromise = new Promise<typeof mockScreenDetails>(resolve => {
       resolveGetScreenDetails = resolve;
     });
     


### PR DESCRIPTION
## Summary
- Type the deferred `getScreenDetails` resolver in the Screen Details API loading-state test
- Keep the mocked promise aligned with the existing `mockScreenDetails` shape

## Verification
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/vitest run src/__tests__/useScreenDetailsApi.spec.ts`
- `PATH="/Users/bhargavponnapalli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/tsc -p ./tsconfig.json --noEmit`