### PR TITLE
chore: type legacy media query listeners

### DIFF
--- a/packages/rooks/src/hooks/usePreferredColorScheme.ts
+++ b/packages/rooks/src/hooks/usePreferredColorScheme.ts
@@ -24,6 +24,11 @@ interface UsePreferredColorSchemeReturnValue {
   isLight: boolean;
 }
 
+type LegacyMediaQueryList = MediaQueryList & {
+  addListener: (listener: () => void) => void;
+  removeListener: (listener: () => void) => void;
+};
+
 /**
  * Get the current color scheme preference
  */
@@ -66,16 +71,15 @@ function subscribe(onStoreChange: () => void): () => void {
     };
   } else {
     // Fallback for older browsers using addListener
-    // @ts-ignore - addListener exists in older browsers
-    darkModeQuery.addListener(onStoreChange);
-    // @ts-ignore
-    lightModeQuery.addListener(onStoreChange);
+    const legacyDarkModeQuery = darkModeQuery as LegacyMediaQueryList;
+    const legacyLightModeQuery = lightModeQuery as LegacyMediaQueryList;
+
+    legacyDarkModeQuery.addListener(onStoreChange);
+    legacyLightModeQuery.addListener(onStoreChange);
 
     return () => {
-      // @ts-ignore
-      darkModeQuery.removeListener(onStoreChange);
-      // @ts-ignore
-      lightModeQuery.removeListener(onStoreChange);
+      legacyDarkModeQuery.removeListener(onStoreChange);
+      legacyLightModeQuery.removeListener(onStoreChange);
     };
   }
 }


### PR DESCRIPTION
## Summary
- replace `@ts-ignore` comments in `usePreferredColorScheme` legacy MediaQueryList fallback with a local explicit type
- keep runtime listener behavior unchanged

## Verification
- `pnpm --dir packages/rooks exec vitest run src/__tests__/usePreferredColorScheme.spec.tsx`
- `pnpm --dir packages/rooks typecheck`