### PR TITLE
chore: tighten vitest setup globals

### DIFF
--- a/packages/rooks/src/vitest.setup.ts
+++ b/packages/rooks/src/vitest.setup.ts
@@ -17,5 +17,7 @@ class SpeechSynthesisUtteranceMock {
   onboundary: (() => void) | null = null;
 }
 
-(global as any).SpeechSynthesisUtterance = SpeechSynthesisUtteranceMock;
-(global as any).fetch = vi.fn();
+const testGlobal = globalThis as Record<string, unknown>;
+
+testGlobal.SpeechSynthesisUtterance = SpeechSynthesisUtteranceMock;
+testGlobal.fetch = vi.fn();


### PR DESCRIPTION
## Summary
- replace test setup global `any` casts with a typed unknown record
- keep the speech synthesis and fetch mocks behavior unchanged

## Verification
- `pnpm --dir packages/rooks exec tsc --noEmit --skipLibCheck --module ESNext --moduleResolution Bundler --target ES2022 --lib es2022,DOM,DOM.Iterable --types vitest/globals,node,@testing-library/jest-dom src/vitest.setup.ts`
- `pnpm --dir packages/rooks exec vitest run src/__tests__/useSpeech.spec.ts 2>&1 | tee /tmp/rooks-useSpeech.log; grep 'Test Files' /tmp/rooks-useSpeech.log | grep -qv 'failed'`
- `pnpm --dir packages/rooks exec eslint src/vitest.setup.ts`
