### PR TITLE
[codex] clarify outside click hook comments

### DIFF
--- a/packages/rooks/src/hooks/useOutsideClick.ts
+++ b/packages/rooks/src/hooks/useOutsideClick.ts
@@ -8,7 +8,7 @@ import { noop } from "@/utils/noop";
  *
  * @param ref Ref whose outside click needs to be listened to
  * @param handler Callback to fire on outside click
- * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
+ * @param when A boolean which activates the hook only when it is true. Useful for conditionally enabling the outside click
  * @see https://rooks.vercel.app/docs/hooks/useOutsideClick
  * @example
  * ```tsx

--- a/packages/rooks/src/hooks/useOutsideClickRef.ts
+++ b/packages/rooks/src/hooks/useOutsideClickRef.ts
@@ -7,7 +7,7 @@ import { noop } from "@/utils/noop";
  * Checks if a click happened outside a Ref. Handy for dropdowns, modals and popups etc.
  *
  * @param handler Callback to fire on outside click
- * @param when A boolean which which activates the hook only when it is true. Useful for conditionally enable the outside click
+ * @param when A boolean which activates the hook only when it is true. Useful for conditionally enabling the outside click
  * @returns An array with first item being ref
  * @see https://rooks.vercel.app/docs/hooks/useOutsideClick
  */


### PR DESCRIPTION
## Summary
- Clarifies duplicated wording in outside-click hook JSDoc comments.

## Validation
- pnpm --filter rooks typecheck
