### PR TITLE
docs: fix useTimeoutWhen default value typo

### DIFF
--- a/apps/website/content/docs/hooks/(animation)/useTimeoutWhen.mdx
+++ b/apps/website/content/docs/hooks/(animation)/useTimeoutWhen.mdx
@@ -42,7 +42,7 @@ export default App;
 
 | Arguments | Type     | Description                                              | Default value |
 | --------- | -------- | -------------------------------------------------------- | ------------- |
-| callback  | function | Function to be executed in timeout                       | undefind      |
+| callback  | function | Function to be executed in timeout                       | undefined     |
 | delay     | Number   | Number in milliseconds after which callback is to be run | 0             |
 | when      | boolean  | The condition which when true, sets the timeout          | true          |
 


### PR DESCRIPTION
## Summary
- Fix the `useTimeoutWhen` docs table default value typo from `undefind` to `undefined`.

## Verification
- `pnpm exec prettier --check 'apps/website/content/docs/hooks/(animation)/useTimeoutWhen.mdx'`
- `pnpm --filter rooks test`
