### PR TITLE
docs: clarify useInput validator params

### DIFF
--- a/packages/rooks/src/hooks/useInput.ts
+++ b/packages/rooks/src/hooks/useInput.ts
@@ -23,8 +23,8 @@ type Options<T> = {
    *
    * Validator function which can be used to prevent updates
    *
-   * @param {any} New value
-   * @param {any} Current value
+   * @param newValue New value
+   * @param currentValue Current value
    * @returns {boolean} Whether an update should happen or not
    */
   validate?: (newValue: T, currentValue: T) => boolean;


### PR DESCRIPTION
## Summary
- clarify the useInput validator JSDoc parameter names to match the typed function signature

## Verification
- pnpm --filter rooks typecheck
- pnpm --filter rooks exec vitest run src/__tests__/useInput.spec.ts src/__tests__/useInput.spec.tsx