### PR TITLE
test: type useInViewRef observer mock

### DIFF
--- a/packages/rooks/src/__tests__/useInViewRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useInViewRef.spec.tsx
@@ -26,7 +26,7 @@ describe("useInViewRef", () => {
         disconnect: vi.fn(),
         callback,
         options,
-      };
+      } as MockIntersectionObserverInstance;
       observerInstances.push(instance);
       return instance;
     });


### PR DESCRIPTION
## Summary
- add a typed mock IntersectionObserver shape in the useInViewRef test
- replace loose any callback/options types in that test setup

## Verification
- pnpm --dir packages/rooks exec vitest run src/__tests__/useInViewRef.spec.tsx
- pnpm --dir packages/rooks run typecheck