### PR TITLE
chore: remove selectable list debug log

### DIFF
--- a/packages/rooks/src/__tests__/useSelectableList.spec.tsx
+++ b/packages/rooks/src/__tests__/useSelectableList.spec.tsx
@@ -233,7 +233,6 @@ describe("useSelectableList", () => {
     it("should warn when toggling a value that does not exist in list", () => {
       expect.hasAssertions();
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      // Also suppress the console.log("as") debug statement in the hook
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
       const { result } = renderHook(() => useSelectableList(list));
 
@@ -247,6 +246,7 @@ describe("useSelectableList", () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("toggleSelection failed")
       );
+      expect(logSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
       logSpy.mockRestore();
     });

--- a/packages/rooks/src/hooks/useSelectableList.ts
+++ b/packages/rooks/src/hooks/useSelectableList.ts
@@ -99,8 +99,6 @@ function useSelectableList<T>(
               setCurrentIndex(valueIndex);
             }
           } else {
-            console.log("as");
-
             console.warn(
               `toggleSelection failed. Does the value ${value} exist in the list?`
             );


### PR DESCRIPTION
## Summary\n- remove a stray console.log from useSelectableList's missing-value toggle path\n- assert the missing-value warning path does not emit debug logs\n\n## Verification\n- pnpm --filter rooks exec vitest run src/__tests__/useSelectableList.spec.tsx\n- pnpm --filter rooks typecheck\n