### PR TITLE
docs: fix useQueueState default value typo

### DIFF
--- a/apps/website/content/docs/hooks/(state)/useQueueState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useQueueState.mdx
@@ -68,7 +68,7 @@ export function StackDiv({ children, ...props }) {
   );
 }
 
-export const StackItem = styled(motion.div).attrs(props => ({
+export const StackItem = styled(motion.div).attrs((props) => ({
   variants,
   initial: "appear",
   animate: "visible",
@@ -155,7 +155,7 @@ export default function App() {
     <Root>
       <div>
         <StackDiv>
-          {list.map(item => {
+          {list.map((item) => {
             return <StackItem key={item}>{item}</StackItem>;
           })}
         </StackDiv>
@@ -175,7 +175,7 @@ export default function App() {
 
 | Arguments   | Type  | Description | Default value |
 | ----------- | ----- | ----------- | ------------- |
-| initialList | any[] | An array    | undefind      |
+| initialList | any[] | An array    | undefined     |
 
 ### Returned array items
 


### PR DESCRIPTION
## Summary
- fix the useQueueState docs default value typo from `undefind` to `undefined`
- format the touched MDX example with Prettier

## Verification
- `pnpm exec prettier --check "apps/website/content/docs/hooks/(state)/useQueueState.mdx"`
- `git diff --check`