### PR TITLE
chore: remove key test debug logs

### DIFF
--- a/packages/rooks/src/__tests__/useKey.spec.tsx
+++ b/packages/rooks/src/__tests__/useKey.spec.tsx
@@ -199,7 +199,6 @@ describe("when", () => {
   it("should not trigger whenever 'when ' value is false and trigger when 'when' is true", () => {
     expect.hasAssertions();
     const { container } = render(<App />);
-    console.log("container.innerHTML before", container.innerHTML);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const inputElement = getByTestId(container as HTMLElement, "input");
     const toggleWhenElement = getByTestId(

--- a/packages/rooks/src/__tests__/useKeyRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useKeyRef.spec.tsx
@@ -165,7 +165,6 @@ describe("when", () => {
   it("should not trigger whenever 'when ' value is false and trigger when 'when' is true", () => {
     expect.hasAssertions();
     const { container } = render(<App />);
-    console.log("container.innerHTML before", container.innerHTML);
     const valueElement = getByTestId(container as HTMLElement, "value");
     const inputElement = getByTestId(container as HTMLElement, "input");
     const toggleWhenElement = getByTestId(


### PR DESCRIPTION
## Summary\n- remove leftover debug logging from useKey and useKeyRef tests\n\n## Verification\n- pnpm --dir packages/rooks exec vitest run src/__tests__/useKey.spec.tsx src/__tests__/useKeyRef.spec.tsx