### PR TITLE
docs: clarify useKeys when option

### DIFF
--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -20,8 +20,7 @@ type Options = {
   | MutableRefObject<Document>
   | MutableRefObject<HTMLElement | null | undefined>;
   /**
-   * when boolean to enable and disable events, when passed false
-   * remove the eventlistener if any
+   * When false, disables events and removes any active event listener.
    */
   when?: boolean;
   /**


### PR DESCRIPTION
## Summary
- clarify the `useKeys` `when` option comment
- keep the change comment-only and scoped to one hook

## Verification
- pnpm --filter rooks exec vitest run src/__tests__/useKeys.spec.tsx
- pnpm --filter rooks typecheck