### PR TITLE
docs: clarify useUndoState default value type

### DIFF
--- a/packages/rooks/src/hooks/useUndoState.ts
+++ b/packages/rooks/src/hooks/useUndoState.ts
@@ -15,7 +15,7 @@ const defaultOptions: UseUndoStateOptions = { maxSize: 100 };
  * @typedef UndoStateOptions
  * @type {object}
  * @property {number} maxSize - Maximum number of states to keep in the undo stack.
- * @param {any} defaultValue - Default value to use for the state. This will be the first value in the undo stack.
+ * @param {ExcludeFunction<T>} defaultValue - Default value to use for the state. This will be the first value in the undo stack.
  * @param {UseUndoStateOptions} options - Options for the undo state. Currently takes the maxSize option.
  * @returns {UseUndoStateReturnValue}
  * @see https://rooks.vercel.app/docs/hooks/useUndoState


### PR DESCRIPTION
## Summary\n- clarify the useUndoState JSDoc defaultValue type to match the TypeScript signature\n\n## Verification\n- pnpm --filter rooks typecheck\n- pnpm --filter rooks exec vitest run src/__tests__/useUndoState.spec.tsx