### PR TITLE
chore: type web locks query result

### DIFF
--- a/packages/rooks/src/hooks/useWebLocksApi.ts
+++ b/packages/rooks/src/hooks/useWebLocksApi.ts
@@ -82,7 +82,7 @@ type UseWebLocksApiReturn = {
   /**
    * Query the current lock state
    */
-  query: () => Promise<any>;
+  query: () => Promise<LockManagerSnapshot>;
 };
 
 /**
@@ -129,7 +129,7 @@ function useWebLocksApi(
   /**
    * Query the current lock state
    */
-  const query = useCallback(async (): Promise<any> => {
+  const query = useCallback(async (): Promise<LockManagerSnapshot> => {
     if (!isSupported) {
       const err = new Error("Web Locks API is not supported");
       setErrorState(err);
@@ -140,8 +140,8 @@ function useWebLocksApi(
       const result = await navigator.locks.query();
 
       // Update state based on query results with null checks
-      const resourceLocks = result.held?.filter((lock: any) => lock.name === resourceName) || [];
-      const pendingLocks = result.pending?.filter((lock: any) => lock.name === resourceName) || [];
+      const resourceLocks = result.held?.filter((lock) => lock.name === resourceName) || [];
+      const pendingLocks = result.pending?.filter((lock) => lock.name === resourceName) || [];
 
       setIsLocked(resourceLocks.length > 0);
       setWaitingCount(pendingLocks.length);


### PR DESCRIPTION
## Summary
- Type the Web Locks query helper as `LockManagerSnapshot`
- Let TypeScript infer the lock record type when filtering held and pending locks

## Verification
- `pnpm --filter rooks typecheck`
- `pnpm --filter rooks exec vitest run src/__tests__/useWebLocksApi.spec.tsx`