### PR TITLE
test: remove useShare ts-ignore suppressions

### DIFF
--- a/packages/rooks/src/__tests__/useShare.spec.tsx
+++ b/packages/rooks/src/__tests__/useShare.spec.tsx
@@ -34,8 +34,7 @@ describe("useShare", () => {
   it("should detect when Web Share API is not supported", () => {
     expect.hasAssertions();
     const originalShare = navigator.share;
-    // @ts-ignore
-    delete navigator.share;
+    Reflect.deleteProperty(navigator, "share");
 
     const { result } = renderHook(() => useShare());
 
@@ -170,8 +169,7 @@ describe("useShare", () => {
   it("should throw error when sharing without support", async () => {
     expect.hasAssertions();
     const originalShare = navigator.share;
-    // @ts-ignore
-    delete navigator.share;
+    Reflect.deleteProperty(navigator, "share");
 
     const { result } = renderHook(() => useShare());
 


### PR DESCRIPTION
## Summary
- replace two useShare test `delete navigator.share` TypeScript suppressions with `Reflect.deleteProperty`

## Verification
- `pnpm --filter rooks exec vitest run src/__tests__/useShare.spec.tsx`
- `pnpm --filter rooks typecheck`