### PR TITLE
test: remove geolocation debug output

### DIFF
--- a/packages/rooks/src/__tests__/useGeolocation.spec.tsx
+++ b/packages/rooks/src/__tests__/useGeolocation.spec.tsx
@@ -66,7 +66,6 @@ describe("useGeolocation", () => {
       fireEvent.click(getGeolocationButton);
     });
     const geoInfoPElement = await screen.findByTestId("geo-info");
-    screen.debug(screen.getByTestId("geo-info"));
     const geoObject = JSON.parse(geoInfoPElement.innerHTML);
     expect(`${geoObject.lat}`).toBe("51.1");
     expect(`${geoObject.lng}`).toBe("45.3");


### PR DESCRIPTION
## Summary
- remove a leftover Testing Library debug print from the useGeolocation spec

## Verification
- pnpm --dir packages/rooks exec vitest run src/__tests__/useGeolocation.spec.tsx
- pnpm --dir packages/rooks test