### PR TITLE
chore: type alert wrapper in useKeys

### DIFF
--- a/packages/rooks/src/hooks/useKeys.ts
+++ b/packages/rooks/src/hooks/useKeys.ts
@@ -144,8 +144,7 @@ function useKeys(
     if (preventLostKeyup !== true) return noop;
     if (typeof window !== "undefined") {
       const originalAlert = window.alert;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      window.alert = (message?: any) => {
+      window.alert = (message?: Parameters<typeof window.alert>[0]) => {
         for (const identifier of keysList) {
           PressedKeyMapping[identifier] = undefined;
         }


### PR DESCRIPTION
## Summary
- replace the explicit any in the useKeys alert wrapper with the DOM alert parameter type
- remove the now-unneeded eslint suppression

## Verification
- pnpm --filter rooks exec vitest run src/__tests__/useKeys.spec.tsx
- pnpm --filter rooks typecheck