### PR TITLE
chore: tighten notification data option type

### DIFF
--- a/packages/rooks/src/hooks/useNotification.ts
+++ b/packages/rooks/src/hooks/useNotification.ts
@@ -13,7 +13,7 @@ interface NotificationOptions {
   icon?: string;
   badge?: string;
   tag?: string;
-  data?: any;
+  data?: unknown;
   requireInteraction?: boolean;
   silent?: boolean;
   vibrate?: number | number[];


### PR DESCRIPTION
## Summary
- tighten the useNotification options data field from any to unknown

## Verification
- pnpm --dir packages/rooks exec vitest run src/__tests__/useNotification.spec.tsx
- pnpm --dir packages/rooks run typecheck