### PR TITLE
test: remove useVibrate debug output

### DIFF
--- a/packages/rooks/src/__tests__/useVibrate.spec.ts
+++ b/packages/rooks/src/__tests__/useVibrate.spec.ts
@@ -81,8 +81,6 @@ describe.skip("useVibrate", () => {
       writable: true,
     });
 
-    console.log("vibrate", navigator.vibrate);
-
     renderHook(({ isEnabled, pattern }) => useVibrate({ isEnabled, pattern }), {
       initialProps: { isEnabled: true, pattern: [200, 100, 200] },
     });


### PR DESCRIPTION
## Summary\n- remove a leftover debug console.log from the skipped useVibrate spec\n\n## Tests\n- pnpm exec vitest run src/__tests__/useVibrate.spec.ts\n- pnpm test