### PR TITLE
test: remove media recorder ts ignores

### DIFF
--- a/packages/rooks/src/__tests__/useMediaRecorder.spec.tsx
+++ b/packages/rooks/src/__tests__/useMediaRecorder.spec.tsx
@@ -65,8 +65,7 @@ describe("useMediaRecorder", () => {
   it("should detect when MediaRecorder is not supported", () => {
     expect.hasAssertions();
     const originalMediaRecorder = window.MediaRecorder;
-    // @ts-ignore
-    delete window.MediaRecorder;
+    Reflect.deleteProperty(window, "MediaRecorder");
 
     const { result } = renderHook(() => useMediaRecorder(mockStream));
 
@@ -355,8 +354,7 @@ describe("useMediaRecorder", () => {
   it("should not start recording without support", () => {
     expect.hasAssertions();
     const originalMediaRecorder = window.MediaRecorder;
-    // @ts-ignore
-    delete window.MediaRecorder;
+    Reflect.deleteProperty(window, "MediaRecorder");
 
     const { result } = renderHook(() => useMediaRecorder(mockStream));
 


### PR DESCRIPTION
## Summary\n- replace two MediaRecorder test @ts-ignore deletions with Reflect.deleteProperty\n\n## Verification\n- pnpm --filter rooks exec vitest run src/__tests__/useMediaRecorder.spec.tsx\n- pnpm --filter rooks typecheck