### PR TITLE
test: tighten useSpring movement assertion

### DIFF
--- a/packages/rooks/src/__tests__/useSpring.spec.ts
+++ b/packages/rooks/src/__tests__/useSpring.spec.ts
@@ -43,9 +43,7 @@ describe("useSpring", () => {
       vi.advanceTimersByTime(100);
     });
 
-    // Should have moved from 0 towards 100
-    expect(result.current).not.toBe(0);
-    // expect(result.current).toBeGreaterThan(0); // This might be flaky if 100ms isn't enough for spring to move significantly with default config, but it should move.
+    expect(result.current).toBeGreaterThan(0);
   });
 
   it("should move toward the target with a custom spring config", () => {


### PR DESCRIPTION
## Summary
- replace the broad non-zero useSpring animation assertion with a positive movement assertion
- remove the stale flakiness comment now that the fake-timer test is deterministic

## Verification
- pnpm --filter rooks exec vitest run src/__tests__/useSpring.spec.ts
- pnpm --filter rooks typecheck
- pnpm --filter rooks lint