### PR TITLE
test: type fullscreen mock element

### DIFF
--- a/packages/rooks/src/__tests__/useFullscreen.spec.tsx
+++ b/packages/rooks/src/__tests__/useFullscreen.spec.tsx
@@ -1,6 +1,4 @@
 import { vi } from "vitest";
-/**
- */
 import { renderHook, act } from "@testing-library/react";
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -12,13 +10,19 @@ const mockExitFullscreen = vi.fn();
 const mockAddEventListener = vi.fn();
 const mockRemoveEventListener = vi.fn();
 
+type FullscreenMockElement = Element & {
+  webkitRequestFullscreen: Element["requestFullscreen"];
+  mozRequestFullScreen: Element["requestFullscreen"];
+  msRequestFullscreen: Element["requestFullscreen"];
+};
+
 // Mock element for testing
 const mockElement = {
   requestFullscreen: mockRequestFullscreen,
   webkitRequestFullscreen: mockRequestFullscreen,
   mozRequestFullScreen: mockRequestFullscreen,
   msRequestFullscreen: mockRequestFullscreen,
-} as any;
+} as FullscreenMockElement;
 
 describe("useFullscreen", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- replace the fullscreen test mock's any cast with a local mock element type
- remove a stray empty comment block from the same test

## Verification
- pnpm --dir packages/rooks exec vitest run src/__tests__/useFullscreen.spec.tsx
- pnpm --dir packages/rooks typecheck