### PR TITLE
test: type useSpring raf mock callback

### DIFF
--- a/packages/rooks/src/__tests__/useSpring.spec.ts
+++ b/packages/rooks/src/__tests__/useSpring.spec.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from "@testing-library/react";
 import { useSpring } from "../hooks/useSpring";
 
 vi.mock("raf", () => {
-  const raf = (cb: any) => {
+  const raf = (cb: (timestamp: number) => void) => {
     setTimeout(() => cb(performance.now()), 16);
     return 1;
   };


### PR DESCRIPTION
## Summary
- replace the `any` callback in the `useSpring` raf mock with an explicit timestamp callback type

## Verification
- pnpm --dir packages/rooks exec vitest run src/__tests__/useSpring.spec.ts
- pnpm --dir packages/rooks run typecheck
