### PR TITLE
test: remove clipboard ts-ignore directives

### DIFF
--- a/packages/rooks/src/__tests__/useClipboard.spec.tsx
+++ b/packages/rooks/src/__tests__/useClipboard.spec.tsx
@@ -8,6 +8,10 @@ describe("useClipboard", () => {
   let clipboardWriteText: vi.Mock;
   let clipboardReadText: vi.Mock;
 
+  function deleteClipboard() {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+
   beforeEach(() => {
     clipboardWriteText = vi.fn();
     clipboardReadText = vi.fn();
@@ -50,8 +54,7 @@ describe("useClipboard", () => {
   it("should detect when clipboard API is not supported", () => {
     expect.hasAssertions();
     const originalClipboard = navigator.clipboard;
-    // @ts-expect-error - Simulate browsers without the Clipboard API.
-    delete navigator.clipboard;
+    deleteClipboard();
 
     const { result } = renderHook(() => useClipboard());
 
@@ -118,8 +121,7 @@ describe("useClipboard", () => {
   it("should throw error when copying without clipboard support", async () => {
     expect.hasAssertions();
     const originalClipboard = navigator.clipboard;
-    // @ts-expect-error - Simulate browsers without the Clipboard API.
-    delete navigator.clipboard;
+    deleteClipboard();
 
     const { result } = renderHook(() => useClipboard());
 
@@ -196,8 +198,7 @@ describe("useClipboard", () => {
   it("should throw error when pasting without clipboard support", async () => {
     expect.hasAssertions();
     const originalClipboard = navigator.clipboard;
-    // @ts-expect-error - Simulate browsers without the Clipboard API.
-    delete navigator.clipboard;
+    deleteClipboard();
 
     const { result } = renderHook(() => useClipboard());
 


### PR DESCRIPTION
## Summary
- replace repeated @ts-ignore comments in the useClipboard tests with a typed deleteClipboard helper
- keep the unsupported Clipboard API test behavior unchanged

## Verification
- pnpm --dir packages/rooks exec vitest run src/__tests__/useClipboard.spec.tsx
- pnpm --dir packages/rooks typecheck