### PR TITLE
fix session storage lazy initializer

### DIFF
--- a/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
@@ -59,6 +59,23 @@ describe("useSessionstorageState basic", () => {
     expect(valueElement.innerHTML).toBe("hello");
   });
 
+  it("initializes correctly with a function initializer", () => {
+    expect.hasAssertions();
+
+    const AppWithFunctionInitializer = () => {
+      const [value] = useSessionstorageState(
+        "test-value-function",
+        () => "hello"
+      );
+
+      return <p data-testid="value-function">{value}</p>;
+    };
+
+    const { getByTestId } = render(<AppWithFunctionInitializer />);
+    const valueElement = getByTestId("value-function");
+    expect(valueElement.innerHTML).toBe("hello");
+  });
+
   it("setting the new value", () => {
     expect.hasAssertions();
     const { container } = render(<App />);

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -28,10 +28,12 @@ function saveValueToSessionStorage<S>(key: string, value: S) {
  * @param key Key of the sessionStorage object
  * @param initialState Default initial value
  */
-function initialize<S>(key: string, initialState: S) {
+function initialize<S>(key: string, initialState: S | (() => S)) {
   const valueLoadedFromSessionStorage = getValueFromSessionStorage(key);
   if (valueLoadedFromSessionStorage === null) {
-    return initialState;
+    return typeof initialState === "function"
+      ? (initialState as () => S)()
+      : initialState;
   } else {
     return valueLoadedFromSessionStorage;
   }


### PR DESCRIPTION
## Summary
- call function initializers in useSessionstorageState when sessionStorage has no value
- add a focused regression test matching local storage lazy initializer behavior

## Verification
- pnpm --filter rooks exec vitest run src/__tests__/useSessionstorageState.spec.tsx
- pnpm --filter rooks typecheck