### PR TITLE
test: tighten clipboard unsupported api suppressions

### DIFF
--- a/packages/rooks/src/__tests__/useClipboard.spec.tsx
+++ b/packages/rooks/src/__tests__/useClipboard.spec.tsx
@@ -50,7 +50,7 @@ describe("useClipboard", () => {
   it("should detect when clipboard API is not supported", () => {
     expect.hasAssertions();
     const originalClipboard = navigator.clipboard;
-    // @ts-ignore
+    // @ts-expect-error - Simulate browsers without the Clipboard API.
     delete navigator.clipboard;
 
     const { result } = renderHook(() => useClipboard());
@@ -118,7 +118,7 @@ describe("useClipboard", () => {
   it("should throw error when copying without clipboard support", async () => {
     expect.hasAssertions();
     const originalClipboard = navigator.clipboard;
-    // @ts-ignore
+    // @ts-expect-error - Simulate browsers without the Clipboard API.
     delete navigator.clipboard;
 
     const { result } = renderHook(() => useClipboard());
@@ -196,7 +196,7 @@ describe("useClipboard", () => {
   it("should throw error when pasting without clipboard support", async () => {
     expect.hasAssertions();
     const originalClipboard = navigator.clipboard;
-    // @ts-ignore
+    // @ts-expect-error - Simulate browsers without the Clipboard API.
     delete navigator.clipboard;
 
     const { result } = renderHook(() => useClipboard());


### PR DESCRIPTION
## Summary
- replace useClipboard test `@ts-ignore` comments with `@ts-expect-error` for unsupported Clipboard API scenarios
- document that the delete operations intentionally simulate browsers without Clipboard API support

## Tests
- `pnpm --dir packages/rooks exec vitest run src/__tests__/useClipboard.spec.tsx`
- `pnpm --dir packages/rooks run typecheck`