### PR TITLE
chore: tidy sanity check scripts

### DIFF
--- a/packages/rooks/scripts/sanity-check-eslint.ts
+++ b/packages/rooks/scripts/sanity-check-eslint.ts
@@ -1,59 +1,58 @@
 #!/usr/bin/env tsx
 
-import { execSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+import { execSync } from "child_process";
+import fs from "fs";
 
-console.log('🔍 Sanity Check: ESLint Validation');
-console.log('='.repeat(40));
+console.log("🔍 Sanity Check: ESLint Validation");
+console.log("=".repeat(40));
 
 // Check if dist directory exists
-if (!fs.existsSync('dist')) {
-  console.error('❌ Error: dist directory not found. Run `pnpm build` first.');
+if (!fs.existsSync("dist")) {
+  console.error("❌ Error: dist directory not found. Run `pnpm build` first.");
   process.exit(1);
 }
 
 // Check if ESLint config exists
-if (!fs.existsSync('.eslintrc.dist.js')) {
-  console.error('❌ Error: .eslintrc.dist.js not found.');
+if (!fs.existsSync(".eslintrc.dist.js")) {
+  console.error("❌ Error: .eslintrc.dist.js not found.");
   process.exit(1);
 }
 
-const filesToLint: string[] = [
-  'dist/esm/index.js',
-  'dist/esm/experimental.js'
-];
+const filesToLint: string[] = ["dist/esm/index.js", "dist/esm/experimental.js"];
 
-const missingFiles = filesToLint.filter(file => !fs.existsSync(file));
+const missingFiles = filesToLint.filter((file) => !fs.existsSync(file));
 if (missingFiles.length > 0) {
-  console.error('❌ Error: Missing built files:');
-  missingFiles.forEach(file => console.error(`   - ${file}`));
+  console.error("❌ Error: Missing built files:");
+  missingFiles.forEach((file) => console.error(`   - ${file}`));
   process.exit(1);
 }
 
-console.log('✅ All expected built files exist');
+console.log("✅ All expected built files exist");
 
 // Run ESLint on each file
 for (const file of filesToLint) {
   try {
     console.log(`🔍 Linting ${file}...`);
-    
-    execSync(`npx eslint "${file}" --config .eslintrc.dist.js --format compact`, {
-      stdio: 'pipe'
-    });
-    
+
+    execSync(
+      `npx eslint "${file}" --config .eslintrc.dist.js --format compact`,
+      {
+        stdio: "pipe",
+      }
+    );
+
     console.log(`✅ ${file} passed ESLint validation`);
-    
-  } catch (error: any) {
+  } catch (error) {
     // ESLint returns non-zero exit code when there are linting errors
-    const stdout = error.stdout?.toString() || '';
-    const stderr = error.stderr?.toString() || '';
-    
-    if (stdout.includes('error') || stderr.includes('error')) {
+    const output = error as { stdout?: Buffer; stderr?: Buffer };
+    const stdout = output.stdout?.toString() || "";
+    const stderr = output.stderr?.toString() || "";
+
+    if (stdout.includes("error") || stderr.includes("error")) {
       console.error(`❌ ESLint errors in ${file}:`);
       console.error(stdout || stderr);
       process.exit(1);
-    } else if (stdout.includes('warning')) {
+    } else if (stdout.includes("warning")) {
       console.warn(`⚠️  ESLint warnings in ${file}:`);
       console.warn(stdout);
       console.log(`✅ ${file} passed with warnings`);
@@ -63,4 +62,4 @@ for (const file of filesToLint) {
   }
 }
 
-console.log('🎉 All files passed ESLint validation!');
+console.log("🎉 All files passed ESLint validation!");

--- a/packages/rooks/scripts/sanity-check-types.ts
+++ b/packages/rooks/scripts/sanity-check-types.ts
@@ -1,35 +1,31 @@
 #!/usr/bin/env tsx
 
-import { execSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+import { execSync } from "child_process";
+import fs from "fs";
 
-console.log('🔍 Sanity Check: TypeScript Definition Files');
-console.log('='.repeat(50));
+console.log("🔍 Sanity Check: TypeScript Definition Files");
+console.log("=".repeat(50));
 
 // Check if dist directory exists
-if (!fs.existsSync('dist')) {
-  console.error('❌ Error: dist directory not found. Run `pnpm build` first.');
+if (!fs.existsSync("dist")) {
+  console.error("❌ Error: dist directory not found. Run `pnpm build` first.");
   process.exit(1);
 }
 
 // Check if type definition files exist
-const typeFiles = [
-  'dist/esm/index.d.ts',
-  'dist/esm/experimental.d.ts'
-];
+const typeFiles = ["dist/esm/index.d.ts", "dist/esm/experimental.d.ts"];
 
-const missingFiles = typeFiles.filter(file => !fs.existsSync(file));
+const missingFiles = typeFiles.filter((file) => !fs.existsSync(file));
 if (missingFiles.length > 0) {
-  console.error('❌ Error: Missing type definition files:');
-  missingFiles.forEach(file => console.error(`   - ${file}`));
+  console.error("❌ Error: Missing type definition files:");
+  missingFiles.forEach((file) => console.error(`   - ${file}`));
   process.exit(1);
 }
 
-console.log('✅ All expected .d.ts files exist');
+console.log("✅ All expected .d.ts files exist");
 
 // Create a temporary TypeScript file to test imports
-const testFile = 'temp-type-test.ts';
+const testFile = "temp-type-test.ts";
 const testContent = `
 // Test main exports
 import { useCounter } from './dist/esm/index.js';
@@ -47,17 +43,21 @@ console.log('Types resolved successfully');
 try {
   // Write test file
   fs.writeFileSync(testFile, testContent);
-  
+
   // Run TypeScript compiler on test file
-  console.log('🔍 Testing type resolution...');
-  execSync(`npx tsc --noEmit --skipLibCheck --moduleResolution node --esModuleInterop ${testFile}`, { 
-    stdio: 'pipe' 
-  });
-  
-  console.log('✅ TypeScript definitions are valid and imports resolve correctly');
-  
+  console.log("🔍 Testing type resolution...");
+  execSync(
+    `npx tsc --noEmit --skipLibCheck --moduleResolution node --esModuleInterop ${testFile}`,
+    {
+      stdio: "pipe",
+    }
+  );
+
+  console.log(
+    "✅ TypeScript definitions are valid and imports resolve correctly"
+  );
 } catch (error) {
-  console.error('❌ TypeScript validation failed:');
+  console.error("❌ TypeScript validation failed:");
   console.error(error.stdout?.toString() || error.message);
   process.exit(1);
 } finally {
@@ -68,27 +68,27 @@ try {
 }
 
 // Additional validation: Check for common issues in .d.ts files
-console.log('🔍 Checking for common type definition issues...');
+console.log("🔍 Checking for common type definition issues...");
 
-typeFiles.forEach(file => {
-  const content = fs.readFileSync(file, 'utf8');
-  
+typeFiles.forEach((file) => {
+  const content = fs.readFileSync(file, "utf8");
+
   // Check for missing exports
-  if (!content.includes('export')) {
+  if (!content.includes("export")) {
     console.error(`❌ Error: ${file} has no exports`);
     process.exit(1);
   }
-  
+
   // Check for syntax errors (basic check)
-  if (content.includes('export {') && !content.includes('} from')) {
+  if (content.includes("export {") && !content.includes("} from")) {
     // This is a re-export, check it's properly formatted
     const reExportRegex = /export\s*{\s*[^}]+\s*}\s*from\s*["'][^"']+["']/;
     if (!reExportRegex.test(content)) {
       console.warn(`⚠️  Warning: ${file} may have malformed re-exports`);
     }
   }
-  
+
   console.log(`✅ ${file} passed basic validation`);
 });
 
-console.log('🎉 All TypeScript definition files are valid!');
+console.log("🎉 All TypeScript definition files are valid!");


### PR DESCRIPTION
## Summary\n- remove unused path imports from rooks sanity check scripts\n- avoid an explicit any in the ESLint sanity-check catch handler\n- format the touched scripts with the repo Prettier config\n\n## Verification\n- ./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution NodeNext --module NodeNext --target ES2022 --types node packages/rooks/scripts/sanity-check-eslint.ts packages/rooks/scripts/sanity-check-types.ts\n- ./node_modules/.bin/tsc -p packages/rooks/tsconfig.json --noEmit\n- ./node_modules/.bin/prettier --check packages/rooks/scripts/sanity-check-eslint.ts packages/rooks/scripts/sanity-check-types.ts