### PR TITLE
Improve notification option data type

### DIFF
--- a/packages/rooks/src/hooks/useNotification.ts
+++ b/packages/rooks/src/hooks/useNotification.ts
@@ -13,7 +13,7 @@ interface NotificationOptions {
   icon?: string;
   badge?: string;
   tag?: string;
-  data?: any;
+  data?: unknown;
   requireInteraction?: boolean;
   silent?: boolean;
   vibrate?: number | number[];


### PR DESCRIPTION
## Summary
- tighten `useNotification` option `data` from `any` to `unknown`

## Verification
- `corepack pnpm --filter rooks exec vitest run src/__tests__/useNotification.spec.tsx`
- `corepack pnpm --filter rooks typecheck`
