### PR TITLE
chore: remove unused highlight wrapper import

### DIFF
--- a/apps/website/src/components/ClientHightlightWrapper.tsx
+++ b/apps/website/src/components/ClientHightlightWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 import dynamic from "next/dynamic";
-import { ComponentProps, PropsWithoutRef } from "react";
+import { ComponentProps } from "react";
 
 const ClientHighlight = dynamic(
     () => import('./ClientHighlight').then(mod => mod.ClientHighlight),


### PR DESCRIPTION
## Summary
- remove the unused React type import from the website highlight wrapper
- leave wrapper props behavior unchanged

## Verification
- ./node_modules/.bin/tsc --noEmit --skipLibCheck apps/website/src/components/ClientHightlightWrapper.tsx --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --esModuleInterop --allowSyntheticDefaultImports
- ./node_modules/.bin/eslint src/components/ClientHightlightWrapper.tsx (from apps/website)
- ./node_modules/.bin/content-collections build && ./node_modules/.bin/tsc -p tsconfig.json --noEmit (from apps/website)