### PR TITLE
test: remove web worker ts-ignore suppressions

### DIFF
--- a/packages/rooks/src/__tests__/useWebWorker.spec.tsx
+++ b/packages/rooks/src/__tests__/useWebWorker.spec.tsx
@@ -52,8 +52,7 @@ describe("useWebWorker", () => {
   it("should detect when Web Workers are not supported", () => {
     expect.hasAssertions();
     const originalWorker = window.Worker;
-    // @ts-ignore
-    delete window.Worker;
+    Reflect.deleteProperty(window, "Worker");
 
     const { result } = renderHook(() => useWebWorker("/worker.js"));
 
@@ -139,8 +138,7 @@ describe("useWebWorker", () => {
   it("should not post message without support", () => {
     expect.hasAssertions();
     const originalWorker = window.Worker;
-    // @ts-ignore
-    delete window.Worker;
+    Reflect.deleteProperty(window, "Worker");
 
     const { result } = renderHook(() => useWebWorker("/worker.js"));
 


### PR DESCRIPTION
## Summary
- replace two @ts-ignore-suppressed Worker deletes with Reflect.deleteProperty in the useWebWorker tests

## Verification
- pnpm exec vitest run src/__tests__/useWebWorker.spec.tsx
- pnpm run typecheck