### PR TITLE
docs: fix document event default typo

### DIFF
--- a/apps/website/content/docs/hooks/(events)/useDocumentEventListener.mdx
+++ b/apps/website/content/docs/hooks/(events)/useDocumentEventListener.mdx
@@ -59,7 +59,7 @@ export default function DismissibleNotice() {
 
 | Arguments      | Type     | Description                                    | Default value |
 | -------------- | -------- | ---------------------------------------------- | ------------- |
-| eventName      | string   | The event to track                             | undefind      |
+| eventName      | string   | The event to track                             | undefined     |
 | callback       | function | The callback to be called on event             | undefined     |
 | conditions     | object   | The options to be passed to the event listener | {}            |
 | isLayoutEffect | boolean  | Should it use layout effect. Defaults to false | false         |


### PR DESCRIPTION
## Summary
- Fix a typo in the useDocumentEventListener arguments table default value.

## Verification
- ./node_modules/.bin/prettier --check 'apps/website/content/docs/hooks/(events)/useDocumentEventListener.mdx'
- ./node_modules/.bin/content-collections build