### PR TITLE
test: type resize observer mock

### DIFF
--- a/packages/rooks/src/__tests__/useResizeObserver.spec.tsx
+++ b/packages/rooks/src/__tests__/useResizeObserver.spec.tsx
@@ -21,13 +21,14 @@ describe("useResizeObserverRef", () => {
     const observerFn = vi.fn();
     const unObserverFn = vi.fn();
     const disconnetFn = vi.fn();
-    global.ResizeObserver = vi.fn().mockImplementation(function () {
+    const ResizeObserverMock = vi.fn().mockImplementation(function () {
       return {
         observe: observerFn,
         unobserve: unObserverFn,
         disconnect: disconnetFn,
-      };
-    }) as any;
+      } as ResizeObserver;
+    }) as unknown as typeof ResizeObserver;
+    global.ResizeObserver = ResizeObserverMock;
 
     function App() {
       const [value, setValue] = useState(0);


### PR DESCRIPTION
## Summary
- add an explicit ResizeObserver constructor mock type in the useResizeObserverRef test
- remove the untyped any cast from that mock setup

## Verification
- corepack pnpm --filter rooks exec vitest run src/__tests__/useResizeObserver.spec.tsx
- corepack pnpm --filter rooks typecheck