### PR TITLE
docs: clarify bounding client rect comments

### DIFF
--- a/packages/rooks/src/hooks/useBoundingclientrect.ts
+++ b/packages/rooks/src/hooks/useBoundingclientrect.ts
@@ -4,7 +4,7 @@ import { useDidMount } from "./useDidMount";
 import { useMutationObserver } from "./useMutationObserver";
 
 /**
- * @param element HTML element whose boundingclientrect is needed
+ * @param element HTML element whose bounding client rect is needed
  * @returns DOMRect
  */
 function getBoundingClientRect(element: HTMLElement): DOMRect | null {
@@ -12,11 +12,11 @@ function getBoundingClientRect(element: HTMLElement): DOMRect | null {
 }
 
 /**
- * useBoundingclientRect hook
+ * useBoundingclientrect hook
  *
- * @param ref The React ref whose ClientRect is needed
+ * @param ref The React ref whose DOMRect is needed
  * @returns DOMRect | null
- * @see https://rooks.vercel.app/docs/hooks/useBoundingclientRect
+ * @see https://rooks.vercel.app/docs/hooks/useBoundingclientrect
  */
 function useBoundingclientrect(
   ref: MutableRefObject<HTMLElement | null>

--- a/packages/rooks/src/hooks/useBoundingclientrectRef.ts
+++ b/packages/rooks/src/hooks/useBoundingclientrectRef.ts
@@ -4,7 +4,7 @@ import { useForkRef } from "./useForkRef";
 import { useMutationObserverRef } from "./useMutationObserverRef";
 
 /**
- * @param element HTML element whose boundingclientrect is needed
+ * @param element HTML element whose bounding client rect is needed
  * @returns DOMRect
  */
 function getBoundingClientRect(element: HTMLElement): DOMRect {
@@ -13,10 +13,10 @@ function getBoundingClientRect(element: HTMLElement): DOMRect {
 
 /**
  * useBoundingclientrectRef hook
- * Tracks the boundingclientrect of a React Ref and fires a callback when the element's size changes.
+ * Tracks the bounding client rect of a React ref and fires a callback when the element's size changes.
  *
  * @returns [CallbackRef | null, DOMRect | null, () => void]
- * @see https://rooks.vercel.app/docs/hooks/useBoundingclientRectRef
+ * @see https://rooks.vercel.app/docs/hooks/useBoundingclientrectRef
  */
 function useBoundingclientrectRef(): [
   CallbackRef | null,


### PR DESCRIPTION
## Summary\n- Clarify JSDoc wording for bounding client rect helpers\n- Fix hook name casing and docs links in comments\n\n## Verification\n- corepack pnpm --dir packages/rooks exec vitest run src/__tests__/useBoundingclientrect.spec.tsx src/__tests__/useBoundingclientrectRef.spec.tsx\n- corepack pnpm --dir packages/rooks exec tsc -p ./tsconfig.json --noEmit