### PR TITLE
test: tidy useTween raf mock

### DIFF
--- a/packages/rooks/src/__tests__/useTween.spec.ts
+++ b/packages/rooks/src/__tests__/useTween.spec.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from "@testing-library/react";
 import { useTween } from "../hooks/useTween";
 
 vi.mock("raf", () => {
-    const raf = (cb: any) => {
+    const raf = (cb: FrameRequestCallback) => {
         setTimeout(() => cb(performance.now()), 16);
         return 1;
     };
@@ -18,26 +18,6 @@ describe("useTween", () => {
         vi.useFakeTimers();
 
         nowSpy = vi.spyOn(performance, "now");
-
-        // We don't need to spy on requestAnimationFrame anymore since we mocked raf
-        // But we need to make sure our raf mock updates the time
-        // Wait, the raf mock defined above uses performance.now().
-        // But we need to increment currentTime inside the timeout?
-        // We can't access currentTime from the top-level mock easily.
-        // We can rely on jest.advanceTimersByTime to fire the timeout.
-        // But we need a way to increment currentTime.
-
-        // Maybe we can just use a variable in the scope if we define mock inside?
-        // No, jest.mock is hoisted.
-
-        // Alternative: Mock raf to use setTimeout.
-        // And in the test, we use an interval to increment time?
-        // Or we spy on setTimeout? No.
-
-        // Let's make performance.now() return Date.now() which jest mocks!
-        // vi.useFakeTimers() mocks Date.
-        // So if we make performance.now() return Date.now(), it should work with advanceTimersByTime.
-
         nowSpy.mockImplementation(() => Date.now());
     });
 


### PR DESCRIPTION
## Summary
- type the mocked raf callback in the useTween test
- remove stale exploratory comments from the fake-timer setup

## Verification
- corepack pnpm exec vitest run src/__tests__/useTween.spec.ts
- corepack pnpm --dir packages/rooks typecheck