### PR TITLE
docs: fix useStackState default value typo

### DIFF
--- a/data/docs/useStackState.md
+++ b/data/docs/useStackState.md
@@ -176,7 +176,7 @@ export default function App() {
 
 | Arguments   | Type  | Description | Default value |
 | ----------- | ----- | ----------- | ------------- |
-| initialList | any[] | An array    | undefind      |
+| initialList | any[] | An array    | undefined     |
 
 ### Returned array items
 


### PR DESCRIPTION
## Summary
- fix the useStackState docs default value typo from `undefind` to `undefined`
- keep the generated docs copy in sync

## Verification
- `pnpm exec prettier --check 'apps/website/content/docs/hooks/(state)/useStackState.mdx'`
- `pnpm --filter rooks exec vitest run src/__tests__/useStackState.spec.ts`