### PR TITLE
test: type checkbox input change event

### DIFF
--- a/packages/rooks/src/__tests__/useCheckboxInputState.spec.tsx
+++ b/packages/rooks/src/__tests__/useCheckboxInputState.spec.tsx
@@ -1,6 +1,7 @@
 /**
  */
 import { renderHook, act } from "@testing-library/react";
+import type { ChangeEvent } from "react";
 import { useCheckboxInputState } from "../hooks/useCheckboxInputState";
 
 describe("useCheckboxInputState", () => {
@@ -18,74 +19,74 @@ describe("useCheckboxInputState", () => {
 
   it("should toggle the checked state", () => {
     const { result } = renderHook(() => useCheckboxInputState(false));
-    
+
     act(() => {
       result.current.toggle();
     });
-    
+
     expect(result.current.checked).toBe(true);
     expect(result.current.inputProps.checked).toBe(true);
-    
+
     act(() => {
       result.current.toggle();
     });
-    
+
     expect(result.current.checked).toBe(false);
     expect(result.current.inputProps.checked).toBe(false);
   });
 
   it("should set checked state explicitly", () => {
     const { result } = renderHook(() => useCheckboxInputState(false));
-    
+
     act(() => {
       result.current.setChecked(true);
     });
-    
+
     expect(result.current.checked).toBe(true);
     expect(result.current.inputProps.checked).toBe(true);
-    
+
     act(() => {
       result.current.setChecked(false);
     });
-    
+
     expect(result.current.checked).toBe(false);
     expect(result.current.inputProps.checked).toBe(false);
   });
 
   it("should handle onChange from input element", () => {
     const { result } = renderHook(() => useCheckboxInputState(false));
-    
+
     act(() => {
       result.current.inputProps.onChange({
-        target: { checked: true }
-      } as React.ChangeEvent<HTMLInputElement>);
+        target: { checked: true },
+      } as ChangeEvent<HTMLInputElement>);
     });
-    
+
     expect(result.current.checked).toBe(true);
     expect(result.current.inputProps.checked).toBe(true);
   });
 
   it("should return stable inputProps references", () => {
     const { result, rerender } = renderHook(() => useCheckboxInputState(false));
-    
+
     const firstInputProps = result.current.inputProps;
     rerender();
     const secondInputProps = result.current.inputProps;
-    
+
     // The references should remain stable when state hasn't changed
     expect(firstInputProps).toBe(secondInputProps);
   });
 
   it("should update inputProps when checked state changes", () => {
     const { result } = renderHook(() => useCheckboxInputState(false));
-    
+
     const initialInputProps = result.current.inputProps;
     expect(initialInputProps.checked).toBe(false);
-    
+
     act(() => {
       result.current.toggle();
     });
-    
+
     const updatedInputProps = result.current.inputProps;
     expect(updatedInputProps.checked).toBe(true);
     // The object reference should be different when state changes
@@ -94,15 +95,15 @@ describe("useCheckboxInputState", () => {
 
   it("should provide stable toggle and setChecked function references", () => {
     const { result, rerender } = renderHook(() => useCheckboxInputState(false));
-    
+
     const firstToggle = result.current.toggle;
     const firstSetChecked = result.current.setChecked;
-    
+
     rerender();
-    
+
     const secondToggle = result.current.toggle;
     const secondSetChecked = result.current.setChecked;
-    
+
     expect(firstToggle).toBe(secondToggle);
     expect(firstSetChecked).toBe(secondSetChecked);
   });


### PR DESCRIPTION
## Summary
- add an explicit ChangeEvent type import in the useCheckboxInputState test
- format the touched test file with Prettier

## Verification
- ./node_modules/.bin/vitest run src/__tests__/useCheckboxInputState.spec.tsx
- ./node_modules/.bin/tsc -p ./tsconfig.json --noEmit
- git diff --check