### PR TITLE
test: remove document listener debug output

### DIFF
--- a/packages/rooks/src/__tests__/useDocumentEventListener.spec.tsx
+++ b/packages/rooks/src/__tests__/useDocumentEventListener.spec.tsx
@@ -17,9 +17,7 @@ describe("useDocumentEventListener", () => {
   it("should return a undefined", () => {
     expect.hasAssertions();
     const { result } = renderHook(() =>
-      useDocumentEventListener("click", () => {
-        console.log("clicked");
-      })
+      useDocumentEventListener("click", () => {})
     );
 
     expect(typeof result.current).toBe("undefined");


### PR DESCRIPTION
## Summary
- replace a console-printing noop callback in the useDocumentEventListener spec with an empty callback

## Verification
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm vitest run src/__tests__/useDocumentEventListener.spec.tsx
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm typecheck