### PR TITLE
docs: fix lifecycle logger argument typo

### DIFF
--- a/apps/website/content/docs/hooks/(lifecycle)/useLifecycleLogger.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useLifecycleLogger.mdx
@@ -40,10 +40,10 @@ export default function App() {
 
 ### Arguments
 
-| Argument value | Type   | Description                                              | Defualt     |
-| -------------- | ------ | -------------------------------------------------------- | ----------- |
-| componentName  | String | The name of component to be shown in the log             | "Component" |
-| rest           | Array  | An arry of variables to be logged in component lifecycle | undefined   |
+| Argument value | Type   | Description                                               | Defualt     |
+| -------------- | ------ | --------------------------------------------------------- | ----------- |
+| componentName  | String | The name of component to be shown in the log              | "Component" |
+| rest           | Array  | An array of variables to be logged in component lifecycle | undefined   |
 
 ### Returns
 

--- a/data/docs/useLifecycleLogger.md
+++ b/data/docs/useLifecycleLogger.md
@@ -39,10 +39,10 @@ export default function App() {
 
 ### Arguments
 
-| Argument value | Type   | Description                                              | Defualt     |
-| -------------- | ------ | -------------------------------------------------------- | ----------- |
-| componentName  | String | The name of component to be shown in the log             | "Component" |
-| rest           | Array  | An arry of variables to be logged in component lifecycle | undefined   |
+| Argument value | Type   | Description                                               | Defualt     |
+| -------------- | ------ | --------------------------------------------------------- | ----------- |
+| componentName  | String | The name of component to be shown in the log              | "Component" |
+| rest           | Array  | An array of variables to be logged in component lifecycle | undefined   |
 
 ### Returns
 


### PR DESCRIPTION
## Summary\n- fix a typo in the useLifecycleLogger argument table\n- keep the legacy data docs copy aligned\n\n## Verification\n- ./node_modules/.bin/prettier --check 'apps/website/content/docs/hooks/(lifecycle)/useLifecycleLogger.mdx' data/docs/useLifecycleLogger.md