### PR TITLE
test: remove useMeasure resize observer suppression

### DIFF
--- a/packages/rooks/src/__tests__/useMeasure.spec.tsx
+++ b/packages/rooks/src/__tests__/useMeasure.spec.tsx
@@ -396,11 +396,10 @@ describe("useMeasure", () => {
   describe("SSR compatibility", () => {
     test("should handle missing ResizeObserver gracefully", () => {
       expect.hasAssertions();
-      
+
       // Temporarily remove ResizeObserver
       const originalResizeObserver = global.ResizeObserver;
-      // @ts-expect-error - Intentionally testing undefined case
-      delete global.ResizeObserver;
+      global.ResizeObserver = undefined as unknown as typeof ResizeObserver;
 
       function TestComponent() {
         const [ref, { innerWidth, innerHeight }] = useMeasure();


### PR DESCRIPTION
## Summary\n- replace the useMeasure missing ResizeObserver test's ts-expect-error/delete path with an explicit undefined mock assignment\n- keep the SSR compatibility scenario covered without a TypeScript suppression\n\n## Verification\n- ./node_modules/.bin/vitest run src/__tests__/useMeasure.spec.tsx\n- ./node_modules/.bin/tsc -p ./tsconfig.json --noEmit