### PR TITLE
docs: add useRenderCount example

### DIFF
--- a/data/docs/useRenderCount.md
+++ b/data/docs/useRenderCount.md
@@ -10,4 +10,17 @@ Get the render count of a component
 
 ## Examples
 
-TODO: Add an example here.
+```jsx
+import { useRenderCount } from "rooks";
+
+export default function App() {
+  const renderCount = useRenderCount();
+
+  return (
+    <div>
+      <h1>Component render count</h1>
+      <p>This component has rendered {renderCount} times.</p>
+    </div>
+  );
+}
+```


### PR DESCRIPTION
## Summary
- Replace the stale useRenderCount docs TODO with a minimal usage example.

## Verification
- ./packages/rooks/node_modules/.bin/vitest run src/__tests__/useRenderCount.spec.ts (from packages/rooks)
- ./node_modules/.bin/prettier --check data/docs/useRenderCount.md