### PR TITLE
docs: fix useStackState default typo

### DIFF
--- a/apps/website/content/docs/hooks/(state)/useStackState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useStackState.mdx
@@ -213,7 +213,7 @@ export default function UploadQueue() {
 
 | Arguments   | Type  | Description | Default value |
 | ----------- | ----- | ----------- | ------------- |
-| initialList | any[] | An array    | undefind      |
+| initialList | any[] | An array    | undefined     |
 
 ### Returned array items
 


### PR DESCRIPTION
## Summary
- fix the `useStackState` docs default value typo from `undefind` to `undefined`

## Verification
- `corepack pnpm --filter website exec content-collections build`