### PR TITLE
docs: fix window event callback descriptions

### DIFF
--- a/data/docs/useOnWindowResize.md
+++ b/data/docs/useOnWindowResize.md
@@ -30,7 +30,7 @@ export default function App() {
 
 | Arguments      | Type     | Description                                     | Default value |
 | -------------- | -------- | ----------------------------------------------- | ------------- |
-| callback       | function | Callback function which needs to run on unmount | undefined     |
+| callback       | function | Callback function which runs on window resize   | undefined     |
 | when           | boolean  | When the event handler should be active         | true          |
 | isLayoutEffect | boolean  | Should it use layout effect.                    | false         |
 

--- a/data/docs/useOnWindowScroll.md
+++ b/data/docs/useOnWindowScroll.md
@@ -52,7 +52,7 @@ export default App;
 
 | Arguments      | Type     | Description                                     | Default value |
 | -------------- | -------- | ----------------------------------------------- | ------------- |
-| callback       | function | Callback function which needs to run on unmount | undefined     |
+| callback       | function | Callback function which runs on window scroll   | undefined     |
 | when           | boolean  | When the event handler should be active         | true          |
 | isLayoutEffect | boolean  | Should it use layout effect.                    | false         |
 


### PR DESCRIPTION
## Summary
- correct stale callback descriptions for useOnWindowScroll and useOnWindowResize
- align source JSDoc with generated hook docs

## Verification
- corepack pnpm --filter rooks typecheck
- corepack pnpm --filter rooks exec vitest run src/__tests__/useOnWindowScroll.spec.ts src/__tests__/useOnWindowResize.spec.ts