### PR TITLE
test: type useSpring raf mock callback

### DIFF
--- a/packages/rooks/src/__tests__/useSpring.spec.ts
+++ b/packages/rooks/src/__tests__/useSpring.spec.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from "@testing-library/react";
 import { useSpring } from "../hooks/useSpring";
 
 vi.mock("raf", () => {
-  const raf = (cb: any) => {
+  const raf = (cb: (timestamp: number) => void) => {
     setTimeout(() => cb(performance.now()), 16);
     return 1;
   };


### PR DESCRIPTION
## Summary
- type the mocked raf callback in the useSpring test instead of using any

## Verification
- cd packages/rooks && ./node_modules/.bin/vitest run src/__tests__/useSpring.spec.ts
- pnpm --dir packages/rooks typecheck