### PR TITLE
test: fix selectable list suite name

### DIFF
--- a/packages/rooks/src/__tests__/useSelctableList.spec.ts
+++ b/packages/rooks/src/__tests__/useSelctableList.spec.ts
@@ -4,7 +4,7 @@ import { useSelectableList } from "@/hooks/useSelectableList";
 
 vi.spyOn(console, "warn").mockImplementation(vi.fn());
 
-describe("useSelctableList", () => {
+describe("useSelectableList", () => {
   afterEach(() => {
     (console.warn as vi.Mock).mockReset();
   });


### PR DESCRIPTION
## Summary
- Fix the selectable list test suite label to match the hook name under test.

## Verification
- ./node_modules/.bin/vitest run src/__tests__/useSelctableList.spec.ts
- ./node_modules/.bin/tsc -p ./tsconfig.json --noEmit