### PR TITLE
chore: tighten broadcast channel default types

### DIFF
--- a/packages/rooks/src/hooks/useBroadcastChannel.ts
+++ b/packages/rooks/src/hooks/useBroadcastChannel.ts
@@ -11,7 +11,7 @@ function isEventLike(error: unknown): error is Event | Error {
 /**
  * Options for the useBroadcastChannel hook
  */
-type UseBroadcastChannelOptions<T = any> = {
+type UseBroadcastChannelOptions<T = unknown> = {
   /**
    * Callback function called when a message is received
    */
@@ -26,7 +26,7 @@ type UseBroadcastChannelOptions<T = any> = {
 /**
  * Return type for the useBroadcastChannel hook
  */
-type UseBroadcastChannelReturn<T = any> = {
+type UseBroadcastChannelReturn<T = unknown> = {
   /**
    * Function to send a message to the broadcast channel
    */
@@ -52,7 +52,7 @@ type UseBroadcastChannelReturn<T = any> = {
  * @returns Object with postMessage function, close function, and isSupported flag
  * @see {@link https://rooks.vercel.app/docs/hooks/useBroadcastChannel}
  */
-function useBroadcastChannel<T = any>(
+function useBroadcastChannel<T = unknown>(
   channelName: string,
   options?: UseBroadcastChannelOptions<T>
 ): UseBroadcastChannelReturn<T> {


### PR DESCRIPTION
## Summary
- Default useBroadcastChannel payload generics to unknown instead of any
- Preserve explicit payload generics and runtime behavior

## Verification
- corepack pnpm@10.6.4 --filter rooks exec vitest run src/__tests__/useBroadcastChannel.spec.tsx
- corepack pnpm@10.6.4 --filter rooks typecheck