### PR TITLE
test: fix selectable list spec typo

### DIFF
--- a/packages/rooks/src/__tests__/useSelectableList.warnings.spec.ts
+++ b/packages/rooks/src/__tests__/useSelectableList.warnings.spec.ts
@@ -4,7 +4,7 @@ import { useSelectableList } from "@/hooks/useSelectableList";
 
 vi.spyOn(console, "warn").mockImplementation(vi.fn());
 
-describe("useSelctableList", () => {
+describe("useSelectableList", () => {
   afterEach(() => {
     (console.warn as vi.Mock).mockReset();
   });


### PR DESCRIPTION
## Summary
- Rename the misspelled selectable-list warning spec file to match the hook name
- Fix the matching describe label typo

## Verification
- corepack pnpm@10.6.4 --dir packages/rooks exec vitest run src/__tests__/useSelectableList.warnings.spec.ts