### PR TITLE
chore: reuse notification options type

### DIFF
--- a/packages/rooks/src/hooks/useNotification.ts
+++ b/packages/rooks/src/hooks/useNotification.ts
@@ -5,20 +5,7 @@ import { useState, useCallback, useEffect } from "react";
  */
 type NotificationPermission = "default" | "granted" | "denied";
 
-/**
- * Options for showing a notification
- */
-interface NotificationOptions {
-  body?: string;
-  icon?: string;
-  badge?: string;
-  tag?: string;
-  data?: any;
-  requireInteraction?: boolean;
-  silent?: boolean;
-  vibrate?: number | number[];
-  image?: string;
-}
+type NotificationOptions = globalThis.NotificationOptions;
 
 /**
  * Return value for the useNotification hook


### PR DESCRIPTION
## Summary\n- reuse the DOM NotificationOptions type in useNotification instead of maintaining a duplicate local interface\n\n## Tests\n- corepack pnpm --filter rooks exec vitest run src/__tests__/useNotification.spec.tsx\n- corepack pnpm --filter rooks typecheck