### PR TITLE
[codex] ci: enable mergify in-place checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,12 @@
+merge_queue:
+  max_parallel_checks: 1
 queue_rules:
   - name: default
-    # speculative_checks: 3
-    # batch_size: 2
-    conditions:
+    batch_size: 1
+    queue_conditions:
+      - check-success=Build (test)
+      - check-success=Test (pnpm test)
+    merge_conditions:
       - check-success=Build (test)
       - check-success=Test (pnpm test)
 pull_request_rules:


### PR DESCRIPTION
## Summary

This updates the Mergify queue configuration to be compatible with GitHub branch protection when `Require branches to be up to date before merging` is enabled.

## What changed

- add `merge_queue.max_parallel_checks: 1`
- set the default queue rule `batch_size` to `1`
- replace the legacy queue `conditions` field with explicit `queue_conditions`
- add identical `merge_conditions` so Mergify does not require a second CI phase after queue admission

## Root cause

The existing Mergify config still used the older queue rule shape and allowed room for speculative or batched queue behavior. That conflicts with GitHub's up-to-date branch protection when draft PR checks are involved unless Mergify is configured for in-place checks.

## Impact

Queued PRs can now satisfy the up-to-date branch protection requirement without disabling that protection.

## Validation

- parsed `.mergify.yml` successfully with `ruby -e 'require "yaml"; YAML.load_file(".mergify.yml")'`
- confirmed the diff only changes `.mergify.yml`
