### PR TITLE
chore: remove unused callback in useFileDropRef

### DIFF
--- a/packages/rooks/src/hooks/useFileDropRef.ts
+++ b/packages/rooks/src/hooks/useFileDropRef.ts
@@ -44,10 +44,6 @@ function useFileDropRef(
   const freshOnDragEnter = useFreshCallback(onDragEnter as any);
   const freshOnDragLeave = useFreshCallback(onDragLeave as any);
 
-  useCallback((node: HTMLElement | null) => {
-    setTargetNode(node);
-  }, []);
-
   const fileIsValid = useCallback(
     (file: File): { valid: boolean; reason?: string } => {
       if (accept && !accept.includes(file.type)) {


### PR DESCRIPTION
## Summary
- Remove a dead `useCallback` expression from `useFileDropRef`

## Verification
- `pnpm vitest run src/__tests__/useFileDropRef.spec.tsx`
