### PR TITLE
chore: widen useFreshCallback args typing

### DIFF
--- a/packages/rooks/src/__tests__/useFreshCallback.spec.ts
+++ b/packages/rooks/src/__tests__/useFreshCallback.spec.ts
@@ -37,4 +37,21 @@ describe("useFreshCallback", () => {
     expect(spy).toHaveBeenNthCalledWith(1, 0);
     expect(spy).toHaveBeenNthCalledWith(2, 2);
   });
+
+  it("should forward multiple arguments", () => {
+    expect.hasAssertions();
+    const spy = vi.fn();
+
+    const { result } = renderHook(() => {
+      return useFreshCallback((count: number, label: string) => {
+        spy(count, label);
+      });
+    });
+
+    act(() => {
+      result.current(3, "files");
+    });
+
+    expect(spy).toHaveBeenCalledWith(3, "files");
+  });
 });

--- a/packages/rooks/src/hooks/useDebounceFn.ts
+++ b/packages/rooks/src/hooks/useDebounceFn.ts
@@ -127,7 +127,7 @@ function useDebounceFn<F extends AnyFunction>(
     key
   );
 
-  const freshDebouncedFn = useFreshCallback(debouncedFn as any);
+  const freshDebouncedFn = useFreshCallback(debouncedFn);
 
   return [freshDebouncedFn, isTimeoutEnabled];
 }

--- a/packages/rooks/src/hooks/useFileDropRef.ts
+++ b/packages/rooks/src/hooks/useFileDropRef.ts
@@ -38,15 +38,11 @@ function useFileDropRef(
 
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
 
-  const freshOnDrop = useFreshCallback(onDrop as any);
-  const freshOnFileAccepted = useFreshCallback(onFileAccepted as any);
-  const freshOnFileRejected = useFreshCallback(onFileRejected as any);
-  const freshOnDragEnter = useFreshCallback(onDragEnter as any);
-  const freshOnDragLeave = useFreshCallback(onDragLeave as any);
-
-  useCallback((node: HTMLElement | null) => {
-    setTargetNode(node);
-  }, []);
+  const freshOnDrop = useFreshCallback(onDrop);
+  const freshOnFileAccepted = useFreshCallback(onFileAccepted);
+  const freshOnFileRejected = useFreshCallback(onFileRejected);
+  const freshOnDragEnter = useFreshCallback(onDragEnter);
+  const freshOnDragLeave = useFreshCallback(onDragLeave);
 
   const fileIsValid = useCallback(
     (file: File): { valid: boolean; reason?: string } => {

--- a/packages/rooks/src/hooks/useFreshCallback.ts
+++ b/packages/rooks/src/hooks/useFreshCallback.ts
@@ -6,7 +6,7 @@
 import { useCallback } from "react";
 import { useFreshRef } from "./useFreshRef";
 
-type CallbackType<T, R> = (...args: T[]) => R;
+type CallbackType<Args extends unknown[], R> = (...args: Args) => R;
 
 /**
  * useFreshCallback
@@ -14,11 +14,11 @@ type CallbackType<T, R> = (...args: T[]) => R;
  * @returns A fresh callback.
  * @see https://rooks.vercel.app/docs/hooks/useFreshCallback
  */
-function useFreshCallback<T, R = void>(
-  callback: CallbackType<T, R>
-): CallbackType<T, R> {
+function useFreshCallback<Args extends unknown[], R = void>(
+  callback: CallbackType<Args, R>
+): CallbackType<Args, R> {
   const freshRef = useFreshRef(callback);
-  const tick = useCallback<(...args: T[]) => R>(
+  const tick = useCallback<(...args: Args) => R>(
     (...args) => {
       return freshRef.current(...args);
     },


### PR DESCRIPTION
## Summary
- widen `useFreshCallback` to preserve tuple argument types
- remove now-unneeded `as any` casts in `useFileDropRef` and `useDebounceFn`
- add a multi-argument regression test for `useFreshCallback`

## Verification
- `packages/rooks/node_modules/.bin/vitest run src/__tests__/useFreshCallback.spec.ts src/__tests__/useFileDropRef.spec.tsx`
- `packages/rooks/node_modules/.bin/tsc -p packages/rooks/tsconfig.json --noEmit`
