### PR TITLE
fix: preserve tuple args in useFreshCallback

### DIFF
--- a/packages/rooks/src/__tests__/useFreshCallback.spec.ts
+++ b/packages/rooks/src/__tests__/useFreshCallback.spec.ts
@@ -37,4 +37,21 @@ describe("useFreshCallback", () => {
     expect(spy).toHaveBeenNthCalledWith(1, 0);
     expect(spy).toHaveBeenNthCalledWith(2, 2);
   });
+
+  it("should preserve the full argument list", () => {
+    expect.hasAssertions();
+    const spy = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFreshCallback((query: string, page: number) => {
+        spy(query, page);
+      })
+    );
+
+    act(() => {
+      result.current("search", 3);
+    });
+
+    expect(spy).toHaveBeenCalledWith("search", 3);
+  });
 });


### PR DESCRIPTION
## Summary\n- widen useFreshCallback to preserve full parameter tuples\n- remove the remaining any cast from useDebounceFn\n- add a regression test for multi-argument forwarding\n\n## Verification\n- ./node_modules/.bin/vitest run src/__tests__/useFreshCallback.spec.ts src/__tests__/useDebounceFn.spec.ts\n- ./node_modules/.bin/tsc -p ./tsconfig.json --noEmit