### PR TITLE
fix(rooks): preserve fresh callback parameter types

### DIFF
--- a/packages/rooks/src/hooks/useDebounceFn.ts
+++ b/packages/rooks/src/hooks/useDebounceFn.ts
@@ -127,7 +127,7 @@ function useDebounceFn<F extends AnyFunction>(
     key
   );
 
-  const freshDebouncedFn = useFreshCallback(debouncedFn as any);
+  const freshDebouncedFn = useFreshCallback(debouncedFn);
 
   return [freshDebouncedFn, isTimeoutEnabled];
 }

--- a/packages/rooks/src/hooks/useFileDropRef.ts
+++ b/packages/rooks/src/hooks/useFileDropRef.ts
@@ -38,13 +38,13 @@ function useFileDropRef(
 
   const [targetNode, setTargetNode] = useState<HTMLElement | null>(null);
 
-  const freshOnDrop = useFreshCallback(onDrop as any);
-  const freshOnFileAccepted = useFreshCallback(onFileAccepted as any);
-  const freshOnFileRejected = useFreshCallback(onFileRejected as any);
-  const freshOnDragEnter = useFreshCallback(onDragEnter as any);
-  const freshOnDragLeave = useFreshCallback(onDragLeave as any);
+  const freshOnDrop = useFreshCallback(onDrop);
+  const freshOnFileAccepted = useFreshCallback(onFileAccepted);
+  const freshOnFileRejected = useFreshCallback(onFileRejected);
+  const freshOnDragEnter = useFreshCallback(onDragEnter);
+  const freshOnDragLeave = useFreshCallback(onDragLeave);
 
-  useCallback((node: HTMLElement | null) => {
+  const dropRef = useCallback((node: HTMLElement | null) => {
     setTargetNode(node);
   }, []);
 
@@ -129,9 +129,7 @@ function useFileDropRef(
     freshOnDragLeave,
   ]);
 
-  return useCallback((node: HTMLElement | null) => {
-    setTargetNode(node);
-  }, []);
+  return dropRef;
 }
 
 export { useFileDropRef };

--- a/packages/rooks/src/hooks/useFreshCallback.ts
+++ b/packages/rooks/src/hooks/useFreshCallback.ts
@@ -6,7 +6,7 @@
 import { useCallback } from "react";
 import { useFreshRef } from "./useFreshRef";
 
-type CallbackType<T, R> = (...args: T[]) => R;
+type CallbackType<Args extends unknown[], R> = (...args: Args) => R;
 
 /**
  * useFreshCallback
@@ -14,11 +14,11 @@ type CallbackType<T, R> = (...args: T[]) => R;
  * @returns A fresh callback.
  * @see https://rooks.vercel.app/docs/hooks/useFreshCallback
  */
-function useFreshCallback<T, R = void>(
-  callback: CallbackType<T, R>
-): CallbackType<T, R> {
+function useFreshCallback<Args extends unknown[], R = void>(
+  callback: CallbackType<Args, R>
+): CallbackType<Args, R> {
   const freshRef = useFreshRef(callback);
-  const tick = useCallback<(...args: T[]) => R>(
+  const tick = useCallback<CallbackType<Args, R>>(
     (...args) => {
       return freshRef.current(...args);
     },


### PR DESCRIPTION
## Summary
- Make `useFreshCallback` preserve full callback parameter tuples
- Remove now-unnecessary `as any` casts in `useDebounceFn` and `useFileDropRef`

## Verification
- `./node_modules/.bin/vitest run src/__tests__/useFreshCallback.spec.ts src/__tests__/useDebounceFn.spec.ts src/__tests__/useFileDropRef.spec.tsx`
- `./node_modules/.bin/tsc -p ./tsconfig.json --noEmit`