### PR TITLE
fix(rooks): use safe own-property check in useMapState

### DIFF
--- a/packages/rooks/src/hooks/useMapState.ts
+++ b/packages/rooks/src/hooks/useMapState.ts
@@ -80,9 +80,7 @@ function useMapState<
     setMap((currentMap) => {
       const nextMap = { ...currentMap };
       for (const key in nextMap) {
-        // eslint-disable-next-line no-prototype-builtins
-        if (nextMap.hasOwnProperty(key)) {
-
+        if (Object.prototype.hasOwnProperty.call(nextMap, key)) {
           delete nextMap[key];
         }
       }


### PR DESCRIPTION
## Summary
- replace the `hasOwnProperty` instance call in `useMapState.removeAll` with `Object.prototype.hasOwnProperty.call`
- remove the lint suppression tied to that check

## Verification
- `node_modules/.bin/vitest run src/__tests__/useMapState.spec.tsx`
- `node_modules/.bin/eslint src/hooks/useMapState.ts`