### PR TITLE
[codex] clean up useInput test comment

### DIFF
--- a/packages/rooks/src/__tests__/useInput.spec.tsx
+++ b/packages/rooks/src/__tests__/useInput.spec.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-warning-comments
-// TODO: deprecate this hook in favor of useForm
+// Regression coverage for the public useInput hook.
 import React from "react";
 import { render, cleanup, fireEvent, act } from "@testing-library/react";
 import { renderHook, act as actHook } from "@testing-library/react";
@@ -211,5 +210,3 @@ describe("useInput", () => {
     });
   });
 });
-
-// figure out tests


### PR DESCRIPTION
## What changed
- Replaced the stale `useInput` test-file TODO with a neutral coverage note.
- Removed the stray placeholder comment at the end of the spec.

## Why
- The hook is still part of the public API, so the old deprecation note was not a reliable maintenance signal.

## Validation
- `node_modules/.bin/vitest run src/__tests__/useInput.spec.tsx --config vitest.config.ts`