### PR TITLE
[codex] type useFetch success callback

### DIFF
--- a/packages/rooks/src/hooks/useFetch.ts
+++ b/packages/rooks/src/hooks/useFetch.ts
@@ -11,7 +11,7 @@ interface HttpError extends Error {
 /**
  * Options for the useFetch hook
  */
-interface UseFetchOptions extends Omit<RequestInit, 'signal'> {
+interface UseFetchOptions<T = unknown> extends Omit<RequestInit, 'signal'> {
     method?: string;
     headers?: Record<string, string>;
     body?: string | FormData | URLSearchParams;
@@ -23,7 +23,7 @@ interface UseFetchOptions extends Omit<RequestInit, 'signal'> {
     referrerPolicy?: ReferrerPolicy;
     integrity?: string;
     keepalive?: boolean;
-    onSuccess?: (data: any) => void;
+    onSuccess?: (data: T) => void;
     onError?: (error: Error) => void;
     onFetch?: () => void;
 }
@@ -46,7 +46,7 @@ interface UseFetchReturnValue<T> {
  */
 function createFetchPromise<T>(
     url: string,
-    options: UseFetchOptions = {}
+    options: UseFetchOptions<T> = {}
 ): Promise<T> {
     return new Promise(async (resolve, reject) => {
         try {


### PR DESCRIPTION
## Summary
- Type `useFetch`'s `onSuccess` callback with the hook generic instead of `any`
- Thread the generic through the internal fetch helper so the callback matches the resolved data type

## Validation
- `./node_modules/.pnpm/node_modules/.bin/tsc -p packages/rooks/tsconfig.json --noEmit`
- `cd packages/rooks && ../../node_modules/.pnpm/node_modules/.bin/vitest run src/__tests__/useFetch.spec.tsx`
