### PR TITLE
[codex] rename resize observer disconnect mock

### DIFF
--- a/packages/rooks/src/__tests__/useResizeObserver.spec.tsx
+++ b/packages/rooks/src/__tests__/useResizeObserver.spec.tsx
@@ -20,12 +20,12 @@ describe("useResizeObserverRef", () => {
     expect.hasAssertions();
     const observerFn = vi.fn();
     const unObserverFn = vi.fn();
-    const disconnetFn = vi.fn();
+    const disconnectFn = vi.fn();
     global.ResizeObserver = vi.fn().mockImplementation(function () {
       return {
         observe: observerFn,
         unobserve: unObserverFn,
-        disconnect: disconnetFn,
+        disconnect: disconnectFn,
       };
     }) as any;
 
@@ -51,7 +51,7 @@ describe("useResizeObserverRef", () => {
     act(() => {
       unmount();
     });
-    await waitFor(() => expect(disconnetFn).toHaveBeenCalled());
+    await waitFor(() => expect(disconnectFn).toHaveBeenCalled());
     vi.restoreAllMocks();
   });
 });


### PR DESCRIPTION
## Summary\n- rename the resize observer disconnect mock in the spec for clarity\n\n## Validation\n- ./node_modules/.bin/vitest run src/__tests__/useResizeObserver.spec.tsx