### PR TITLE
docs: fix useOnWindowScroll comment

### DIFF
--- a/packages/rooks/src/hooks/useOnWindowScroll.ts
+++ b/packages/rooks/src/hooks/useOnWindowScroll.ts
@@ -5,7 +5,7 @@ import { useGlobalObjectEventListener } from "./useGlobalObjectEventListener";
  * useOnWindowScroll hook
  * Fires a callback when window scroll
  *
- * @param {Function} callback Callback to be called before unmount
+ * @param {Function} callback Callback to be called when the window scrolls
  * @param {boolean} when When the handler should be applied
  * @param {boolean} isLayoutEffect Should it use layout effect. Defaults to false
  * @see https://rooks.vercel.app/docs/hooks/useOnWindowScroll


### PR DESCRIPTION
## Summary\n- Correct the stale callback comment in useOnWindowScroll so it matches the hook behavior.\n\n## Verification\n- ./node_modules/.bin/vitest run src/__tests__/useOnWindowScroll.spec.ts