### PR TITLE
test: fix stale useOnWindowScroll spec description

### DIFF
--- a/packages/rooks/src/__tests__/useOnWindowScroll.spec.ts
+++ b/packages/rooks/src/__tests__/useOnWindowScroll.spec.ts
@@ -11,7 +11,7 @@ describe("useOnWindowScroll", () => {
 
   describe("basic", () => {
     const mockCallback = vi.fn(() => {});
-    it("should call callback after resize", () => {
+    it("should call callback after scroll", () => {
       expect.hasAssertions();
       renderHook(() => useOnWindowScroll(mockCallback));
       fireEvent(window, new Event("scroll"));


### PR DESCRIPTION
### Summary\n- Update the stale scroll hook test description so it matches the event being exercised.\n\n### Verification\n- ./node_modules/.bin/vitest run src/__tests__/useOnWindowScroll.spec.ts\n