### PR TITLE
[codex] type useFetch onSuccess to payload

### DIFF
--- a/packages/rooks/src/hooks/useFetch.ts
+++ b/packages/rooks/src/hooks/useFetch.ts
@@ -11,7 +11,7 @@ interface HttpError extends Error {
 /**
  * Options for the useFetch hook
  */
-interface UseFetchOptions extends Omit<RequestInit, 'signal'> {
+interface UseFetchOptions<T = unknown> extends Omit<RequestInit, 'signal'> {
     method?: string;
     headers?: Record<string, string>;
     body?: string | FormData | URLSearchParams;
@@ -23,7 +23,7 @@ interface UseFetchOptions extends Omit<RequestInit, 'signal'> {
     referrerPolicy?: ReferrerPolicy;
     integrity?: string;
     keepalive?: boolean;
-    onSuccess?: (data: any) => void;
+    onSuccess?: (data: T) => void;
     onError?: (error: Error) => void;
     onFetch?: () => void;
 }
@@ -46,7 +46,7 @@ interface UseFetchReturnValue<T> {
  */
 function createFetchPromise<T>(
     url: string,
-    options: UseFetchOptions = {}
+    options: UseFetchOptions<T> = {}
 ): Promise<T> {
     return new Promise(async (resolve, reject) => {
         try {
@@ -121,7 +121,7 @@ function createFetchPromise<T>(
  */
 function useFetch<T = unknown>(
     url: string,
-    options: UseFetchOptions = {}
+    options: UseFetchOptions<T> = {}
 ): UseFetchReturnValue<T> {
     const [data, setData] = useState<T | null>(null);
     const [loading, setLoading] = useState<boolean>(false);


### PR DESCRIPTION
## What changed
- Type `useFetch`'s `onSuccess` callback to the fetched payload instead of `any`.
- Thread the generic option type through the fetch helper so the callback stays aligned with the returned data.

## Why
- This removes an avoidable `any` from the public hook API and keeps the callback signature consistent with `useFetch<T>`.

## Verification
- `./node_modules/.bin/vitest run src/__tests__/useFetch.spec.tsx`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
