### PR TITLE
[codex] restore console.error mock in useThrottle tests

### DIFF
--- a/packages/rooks/src/__tests__/useThrottle.spec.tsx
+++ b/packages/rooks/src/__tests__/useThrottle.spec.tsx
@@ -23,6 +23,10 @@ describe("useThrottle hook", () => {
     });
   });
 
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(() => {
     App = () => {
       const [number, setNumber] = useState(0);


### PR DESCRIPTION
## What changed
- Restored the `console.error` mock in `useThrottle` tests after the suite finishes.
- This keeps the warning suppression scoped to the file instead of leaking into later test runs.

## Why
- The suite intentionally silences a known React act warning during the test run, but the spy was never restored.
- Leaving the spy in place can contaminate subsequent tests in the same worker.

## Verification
- `packages/rooks/node_modules/.bin/vitest run src/__tests__/useThrottle.spec.tsx`