### PR TITLE
docs: clarify useDocumentVisibilityState SSR fallback comment

### DIFF
--- a/packages/rooks/src/hooks/useDocumentVisibilityState.ts
+++ b/packages/rooks/src/hooks/useDocumentVisibilityState.ts
@@ -11,15 +11,16 @@ function getVisibilityStateSnapshot(): UseDocumentVisibilityStateReturnType {
 }
 
 function getVisibilityStateSubscription(callback: () => void) {
-  // subscription function is only called on the client side
+  // useSyncExternalStore only subscribes on the client.
   if (typeof document !== "undefined") {
     document.addEventListener("visibilitychange", callback);
     return () => {
       document.removeEventListener("visibilitychange", callback);
     };
   }
-  // unreachable
-  return () => { };
+
+  // SSR fallback: no-op unsubscribe.
+  return () => {};
 }
 
 function getVisibilityStateServerSnapshot(): UseDocumentVisibilityStateReturnType {


### PR DESCRIPTION
## Summary\n- Clarifies the SSR fallback comment in useDocumentVisibilityState\n- No runtime behavior change\n\n## Verification\n- ./node_modules/.bin/vitest run src/__tests__/useDocumentVisibilityState.spec.ts -c vitest.config.ts