### PR TITLE
[codex] debounce type cleanup

### DIFF
--- a/packages/rooks/src/hooks/useDebounce.ts
+++ b/packages/rooks/src/hooks/useDebounce.ts
@@ -4,7 +4,6 @@ import { useRef, useCallback } from "react";
 import { useFreshRef } from "./useFreshRef";
 import { useWillUnmount } from "./useWillUnmount";
 
-// Define the types inline if we can't import them
 export interface DebounceSettings {
   leading?: boolean;
   maxWait?: number;
@@ -12,7 +11,7 @@ export interface DebounceSettings {
 }
 
 // This is a simpler version that matches what we're using
-type DebouncedFunction<T extends (...args: any[]) => any> = T & {
+type DebouncedFunction<T extends AnyFunction> = T & {
   cancel(): void;
   flush(): ReturnType<T> | undefined;
 };


### PR DESCRIPTION
## Summary
- Remove a stale comment in `useDebounce` and tighten the local debounced function type to use the shared `AnyFunction` alias.

## Why
- The inline note was outdated, and the type alias can reuse the existing shared function type instead of repeating an ad hoc function signature.

## Validation
- `./node_modules/.bin/vitest run src/__tests__/useDebounce.spec.tsx` (from `packages/rooks`)
