### PR TITLE
[codex] remove RAF SSR test ts-expect-error

### DIFF
--- a/packages/rooks/src/__tests__/useRafState.spec.tsx
+++ b/packages/rooks/src/__tests__/useRafState.spec.tsx
@@ -105,9 +105,11 @@ describe("useRafState", () => {
 
   it("should fall back to synchronous setState when requestAnimationFrame is undefined (SSR)", () => {
     expect.hasAssertions();
-    const originalRaf = globalThis.requestAnimationFrame;
-    // @ts-expect-error — simulating SSR environment
-    delete globalThis.requestAnimationFrame;
+    const globalWithMutableRaf = globalThis as typeof globalThis & {
+      requestAnimationFrame?: typeof requestAnimationFrame;
+    };
+    const originalRaf = globalWithMutableRaf.requestAnimationFrame;
+    delete globalWithMutableRaf.requestAnimationFrame;
 
     try {
       const { result } = renderHook(() => useRafState(0));
@@ -119,7 +121,7 @@ describe("useRafState", () => {
       // No rAF needed — state should be updated synchronously
       expect(result.current[0]).toBe(77);
     } finally {
-      globalThis.requestAnimationFrame = originalRaf;
+      globalWithMutableRaf.requestAnimationFrame = originalRaf;
     }
   });
 


### PR DESCRIPTION
## What changed
- Replaced the `@ts-expect-error` in the `useRafState` SSR test with a typed mutable view of `globalThis.requestAnimationFrame`.
- The test behavior is unchanged; it still simulates a missing `requestAnimationFrame` and verifies the synchronous fallback.

## Validation
- `./node_modules/.bin/vitest run src/__tests__/useRafState.spec.tsx`

## Notes
- This is a test-only maintenance cleanup with no runtime code change.