### PR TITLE
test: type fullscreen mock element

### DIFF
--- a/packages/rooks/src/__tests__/useFullscreen.spec.tsx
+++ b/packages/rooks/src/__tests__/useFullscreen.spec.tsx
@@ -12,13 +12,20 @@ const mockExitFullscreen = vi.fn();
 const mockAddEventListener = vi.fn();
 const mockRemoveEventListener = vi.fn();
 
+type MockFullscreenElement = {
+  requestFullscreen: typeof mockRequestFullscreen;
+  webkitRequestFullscreen: typeof mockRequestFullscreen;
+  mozRequestFullScreen: typeof mockRequestFullscreen;
+  msRequestFullscreen: typeof mockRequestFullscreen;
+};
+
 // Mock element for testing
-const mockElement = {
+const mockElement: MockFullscreenElement = {
   requestFullscreen: mockRequestFullscreen,
   webkitRequestFullscreen: mockRequestFullscreen,
   mozRequestFullScreen: mockRequestFullscreen,
   msRequestFullscreen: mockRequestFullscreen,
-} as any;
+};
 
 describe("useFullscreen", () => {
   beforeEach(() => {


### PR DESCRIPTION
Replace an unnecessary as any fullscreen mock in the useFullscreen test with a narrow local type.

Verification: ./node_modules/.bin/vitest run src/__tests__/useFullscreen.spec.tsx in packages/rooks passed (13 passed, 1 skipped).
