### PR TITLE
chore(test): remove stray clipboard spec comment

### DIFF
--- a/packages/rooks/src/__tests__/useClipboard.spec.tsx
+++ b/packages/rooks/src/__tests__/useClipboard.spec.tsx
@@ -1,6 +1,4 @@
 import { vi } from "vitest";
-/**
- */
 import { renderHook, act } from "@testing-library/react";
 import { useClipboard } from "@/hooks/useClipboard";
 


### PR DESCRIPTION
## Summary\n- remove a stray empty JSDoc block from the clipboard test file\n\n## Verification\n- corepack pnpm@10.6.4 --dir packages/rooks exec vitest run src/__tests__/useClipboard.spec.tsx