### PR TITLE
chore(test): remove stale useInput comments

### DIFF
--- a/packages/rooks/src/__tests__/useInput.spec.tsx
+++ b/packages/rooks/src/__tests__/useInput.spec.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-warning-comments
-// TODO: deprecate this hook in favor of useForm
 import React from "react";
 import { render, cleanup, fireEvent, act } from "@testing-library/react";
 import { renderHook, act as actHook } from "@testing-library/react";
@@ -211,5 +209,3 @@ describe("useInput", () => {
     });
   });
 });
-
-// figure out tests


### PR DESCRIPTION
## Summary
- Remove stale maintenance comments from `useInput` tests.

## Verification
- `./node_modules/.bin/vitest run src/__tests__/useInput.spec.tsx`
