### PR TITLE
[codex] harden throttle console spy

### DIFF
--- a/packages/rooks/src/__tests__/useThrottle.spec.tsx
+++ b/packages/rooks/src/__tests__/useThrottle.spec.tsx
@@ -8,13 +8,13 @@ describe("useThrottle hook", () => {
   const TIMEOUT = 300;
   const consoleError = console.error;
 
-  // This is a temporary fix for weird error in testing library. It has something to do with react-dom.
-  // There's a ticket here - https://github.com/facebook/react/issues/14769
-  // Tests are passing correctly, so that's just for clean console.
+  // Suppress the expected act warning from this legacy throttle test setup.
   beforeAll(() => {
     vi.spyOn(console, "error").mockImplementation((...args) => {
+      const [message] = args;
       if (
-        !args[0].includes(
+        typeof message !== "string" ||
+        !message.includes(
           "Warning: An update to %s inside a test was not wrapped in act"
         )
       ) {


### PR DESCRIPTION
This tightens the `useThrottle` test spy so it only suppresses the expected act warning and does not throw when `console.error` receives a non-string payload.

The old comment referred to a temporary workaround and an old React issue without describing the current intent.

This keeps the test helper resilient and reduces the chance of the spy masking unrelated console output.

Root cause: the spy assumed `console.error` always received a string and called `includes` unconditionally.

Checks: `./node_modules/.bin/vitest run src/__tests__/useThrottle.spec.tsx` in `packages/rooks`.
