### PR TITLE
chore: correct stale useInput deprecation comment

### DIFF
--- a/packages/rooks/src/__tests__/useInput.spec.tsx
+++ b/packages/rooks/src/__tests__/useInput.spec.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-warning-comments
-// TODO: deprecate this hook in favor of useForm
+// TODO: deprecate this hook in favor of useFormState
 import React from "react";
 import { render, cleanup, fireEvent, act } from "@testing-library/react";
 import { renderHook, act as actHook } from "@testing-library/react";


### PR DESCRIPTION
Updates the stale `useInput` deprecation note to point at `useFormState`.\n\nVerification: `vitest run --config vitest.config.ts src/__tests__/useInput.spec.tsx` from `packages/rooks` (passed).