### PR TITLE
test: type raf mock callback in useSpring spec

### DIFF
--- a/packages/rooks/src/__tests__/useSpring.spec.ts
+++ b/packages/rooks/src/__tests__/useSpring.spec.ts
@@ -3,7 +3,7 @@ import { renderHook, act } from "@testing-library/react";
 import { useSpring } from "../hooks/useSpring";
 
 vi.mock("raf", () => {
-  const raf = (cb: any) => {
+  const raf = (cb: FrameRequestCallback) => {
     setTimeout(() => cb(performance.now()), 16);
     return 1;
   };


### PR DESCRIPTION
Small maintenance cleanup: replace an `any` in the `useSpring` test's `raf` mock with `FrameRequestCallback`. Verified with `corepack pnpm@10.6.4 exec vitest run src/__tests__/useSpring.spec.ts`.
