### PR TITLE
test: type useEasing RAF mock

### DIFF
--- a/packages/rooks/src/__tests__/useEasing.spec.ts
+++ b/packages/rooks/src/__tests__/useEasing.spec.ts
@@ -6,7 +6,7 @@ vi.mock("raf", () => {
     let nextId = 1;
     const pendingTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
 
-    const raf = (cb: any) => {
+    const raf = (cb: FrameRequestCallback) => {
         const id = nextId++;
         const timeoutId = setTimeout(() => {
             pendingTimeouts.delete(id);


### PR DESCRIPTION
## Summary
- Tighten the useEasing test RAF mock callback from any to FrameRequestCallback.

## Verification
- ./node_modules/.bin/vitest run src/__tests__/useEasing.spec.ts
- ./node_modules/.bin/tsc -p packages/rooks/tsconfig.json --noEmit
