### PR TITLE
[codex] remove stale useInput comment

### DIFF
--- a/packages/rooks/src/__tests__/useInput.spec.tsx
+++ b/packages/rooks/src/__tests__/useInput.spec.tsx
@@ -211,5 +211,3 @@ describe("useInput", () => {
     });
   });
 });
-
-// figure out tests


### PR DESCRIPTION
What changed:

- Removed a stale trailing comment from packages/rooks/src/__tests__/useInput.spec.tsx.


Validation:

- corepack pnpm@10.6.4 --dir packages/rooks exec vitest run src/__tests__/useInput.spec.tsx

- 1 file passed, 8 tests passed.
