### PR TITLE
chore(test): remove stale useInput TODO

### DIFF
--- a/packages/rooks/src/__tests__/useInput.spec.tsx
+++ b/packages/rooks/src/__tests__/useInput.spec.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-warning-comments
-// TODO: deprecate this hook in favor of useForm
 import React from "react";
 import { render, cleanup, fireEvent, act } from "@testing-library/react";
 import { renderHook, act as actHook } from "@testing-library/react";


### PR DESCRIPTION
## Summary\n- remove a stale TODO and obsolete warning-comment suppression from the useInput spec\n\n## Verification\n- ./node_modules/.bin/vitest run src/__tests__/useInput.spec.tsx