### PR TITLE
test: harden useThrottle act warning mock

### DIFF
--- a/packages/rooks/src/__tests__/useThrottle.spec.tsx
+++ b/packages/rooks/src/__tests__/useThrottle.spec.tsx
@@ -8,13 +8,13 @@ describe("useThrottle hook", () => {
   const TIMEOUT = 300;
   const consoleError = console.error;
 
-  // This is a temporary fix for weird error in testing library. It has something to do with react-dom.
-  // There's a ticket here - https://github.com/facebook/react/issues/14769
-  // Tests are passing correctly, so that's just for clean console.
+  // Suppress the known act warning from this throttled callback test.
+  // Keep all other console errors visible so real regressions still fail loudly.
   beforeAll(() => {
     vi.spyOn(console, "error").mockImplementation((...args) => {
+      const message = String(args[0] ?? "");
       if (
-        !args[0].includes(
+        !message.includes(
           "Warning: An update to %s inside a test was not wrapped in act"
         )
       ) {


### PR DESCRIPTION
Summary
- stringify console payloads before matching the act warning in useThrottle tests
- keep unrelated console errors visible

Verification
- pnpm --filter rooks exec vitest run src/__tests__/useThrottle.spec.tsx
- pnpm --filter rooks exec prettier --check src/__tests__/useThrottle.spec.tsx