### PR TITLE
test: isolate selectable list hook state

### DIFF
--- a/packages/rooks/src/__tests__/useSelctableList.spec.ts
+++ b/packages/rooks/src/__tests__/useSelctableList.spec.ts
@@ -4,15 +4,19 @@ import { useSelectableList } from "@/hooks/useSelectableList";
 
 vi.spyOn(console, "warn").mockImplementation(vi.fn());
 
+function renderSelectableList() {
+  return renderHook(() => useSelectableList([1, 2, 3]));
+}
+
 describe("useSelectableList", () => {
   afterEach(() => {
     (console.warn as vi.Mock).mockReset();
   });
-  const { result } = renderHook(() => useSelectableList([1, 2, 3]));
 
   describe("matchSelection", () => {
     it("console.warn", () => {
       expect.hasAssertions();
+      const { result } = renderSelectableList();
       act(() => {
         result.current[1].matchSelection({ index: 1, value: 2 });
       });
@@ -82,6 +86,7 @@ describe("useSelectableList", () => {
 
     it("set by value fail", () => {
       expect.hasAssertions();
+      const { result } = renderSelectableList();
       const [beforeIndex, beforeValue] = result.current[0];
       act(() => {
         result.current[1].updateSelection({ value: 22 })();
@@ -100,6 +105,7 @@ describe("useSelectableList", () => {
 
     it("console.warn", () => {
       expect.hasAssertions();
+      const { result } = renderSelectableList();
       act(() => {
         result.current[1].updateSelection({ index: 1, value: 2 })();
       });
@@ -189,6 +195,7 @@ describe("useSelectableList", () => {
 
     it("console.warn", () => {
       expect.hasAssertions();
+      const { result } = renderSelectableList();
       act(() => {
         result.current[1].toggleSelection({ index: 1, value: 2 })();
       });


### PR DESCRIPTION
## Summary

- Avoid sharing a module-scoped `useSelectableList` hook render across tests.
- Keep each warning-focused test isolated with its own hook state.

## Verification

- `pnpm --dir packages/rooks exec vitest run src/__tests__/useSelctableList.spec.ts src/__tests__/useSelectableList.spec.tsx`
- `pnpm --dir packages/rooks run typecheck`