### PR TITLE
chore: type media recorder error events

### DIFF
--- a/packages/rooks/src/hooks/useMediaRecorder.ts
+++ b/packages/rooks/src/hooks/useMediaRecorder.ts
@@ -5,6 +5,10 @@ import { useState, useCallback, useRef, useEffect, useMemo } from "react";
  */
 type RecordingState = "idle" | "recording" | "paused" | "stopped";
 
+type MediaRecorderErrorEvent = Event & {
+  error?: Error | DOMException;
+};
+
 /**
  * Options for media recording
  */
@@ -177,9 +181,9 @@ function useMediaRecorder(
         chunksRef.current = [];
       };
 
-      mediaRecorder.onerror = (event: Event) => {
+      mediaRecorder.onerror = (event: MediaRecorderErrorEvent) => {
         const err = new Error(
-          `MediaRecorder error: ${(event as any).error?.message || "Unknown error"}`
+          `MediaRecorder error: ${event.error?.message || "Unknown error"}`
         );
         setError(err);
         setRecordingState("idle");


### PR DESCRIPTION
## Summary
- add a narrow `MediaRecorderErrorEvent` shape for recorder error callbacks
- remove the `any` cast when reading the recorder error message

## Verification
- `corepack pnpm --filter rooks exec vitest run src/__tests__/useMediaRecorder.spec.tsx`
- `corepack pnpm --filter rooks typecheck`