### PR TITLE
Harden hook lifecycle behavior and regression coverage

### DIFF
--- a/.changeset/tough-hooks-stay-fresh.md
+++ b/.changeset/tough-hooks-stay-fresh.md
@@ -2,4 +2,6 @@
 "rooks": patch
 ---
 
-Harden hook lifecycle behavior across async requests, browser APIs, storage synchronization, timers, and collection state while preserving existing public signatures.
+Harden hook lifecycle behavior across async requests, browser APIs, storage synchronization, timers, and collection state without adding or changing public exports, parameters, or return fields.
+
+Preserve established `useFetch` overlap and render-bound callback behavior while isolating unmounted and Strict Mode request generations. Correct storage key/synchronization races, immutable batched collection updates, Picture-in-Picture ref attachment, zero-valued file limits, and exactly-once countdown completion.

--- a/.changeset/tough-hooks-stay-fresh.md
+++ b/.changeset/tough-hooks-stay-fresh.md
@@ -1,0 +1,5 @@
+---
+"rooks": patch
+---
+
+Harden hook lifecycle behavior across async requests, browser APIs, storage synchronization, timers, and collection state while preserving existing public signatures.

--- a/apps/website/content/docs/hooks/(browser)/useFetch.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useFetch.mdx
@@ -189,13 +189,15 @@ The options object extends the standard `RequestInit` interface (excluding `sign
 | `referrerPolicy` | `ReferrerPolicy`                        | -               | Referrer policy       |
 | `integrity`      | `string`                                | -               | Subresource integrity |
 | `keepalive`      | `boolean`                               | -               | Keep-alive flag       |
-| `onSuccess`      | `(data: any) => void`                   | -               | Success callback      |
+| `onSuccess`      | `(data: T) => void`                   | -               | Success callback      |
 | `onError`        | `(error: Error) => void`                | -               | Error callback        |
 | `onFetch`        | `() => void`                            | -               | Fetch start callback  |
 
 ## Notes
 
 - This hook does not cache requests - each call triggers a fresh fetch
+- Starting a request aborts any request already in progress; only the newest request may update state or invoke callbacks
+- Unmounting aborts the active request and prevents callbacks or state updates after unmount
 - The hook does not automatically fetch on mount - you must call the `startFetch` function
 - The hook automatically handles JSON parsing of responses
 - HTTP errors (4xx, 5xx) are thrown as `Error` objects with `status` and `statusText` properties

--- a/apps/website/content/docs/hooks/(browser)/useFetch.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useFetch.mdx
@@ -13,20 +13,28 @@ A hook for fetching data from URLs with proper TypeScript generics, error handli
 
 ```tsx
 import { useFetch } from "rooks";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 function UserProfile({ userId }: { userId: string }) {
+  const fetchOptions = useMemo(
+    () => ({
+      headers: { Authorization: "Bearer token" },
+      onSuccess: (data: User) => console.log("User loaded:", data),
+      onError: (error: Error) => console.error("Failed to load user:", error),
+      onFetch: () => console.log("Fetching user data..."),
+    }),
+    []
+  );
+
   const {
     data: user,
     loading,
     error,
     startFetch,
-  } = useFetch<User>(`https://api.example.com/users/${userId}`, {
-    headers: { Authorization: "Bearer token" },
-    onSuccess: (data) => console.log("User loaded:", data),
-    onError: (error) => console.error("Failed to load user:", error),
-    onFetch: () => console.log("Fetching user data..."),
-  });
+  } = useFetch<User>(
+    `https://api.example.com/users/${userId}`,
+    fetchOptions
+  );
 
   // Fetch data when component mounts
   useEffect(() => {
@@ -189,7 +197,7 @@ The options object extends the standard `RequestInit` interface (excluding `sign
 | `referrerPolicy` | `ReferrerPolicy`                        | -               | Referrer policy       |
 | `integrity`      | `string`                                | -               | Subresource integrity |
 | `keepalive`      | `boolean`                               | -               | Keep-alive flag       |
-| `onSuccess`      | `(data: T) => void`                   | -               | Success callback      |
+| `onSuccess`      | `(data: T) => void`                     | -               | Success callback      |
 | `onError`        | `(error: Error) => void`                | -               | Error callback        |
 | `onFetch`        | `() => void`                            | -               | Fetch start callback  |
 
@@ -198,6 +206,7 @@ The options object extends the standard `RequestInit` interface (excluding `sign
 - This hook does not cache requests - each call triggers a fresh fetch
 - Starting another request does not cancel earlier calls; overlapping requests may still complete and update state
 - Unmounting aborts active requests and prevents callbacks or state updates after unmount
+- `startFetch` is bound to the URL and options object from its render; memoize `options` before using `startFetch` as an effect dependency
 - The hook does not automatically fetch on mount - you must call the `startFetch` function
 - The hook automatically handles JSON parsing of responses
 - HTTP errors (4xx, 5xx) are thrown as `Error` objects with `status` and `statusText` properties

--- a/apps/website/content/docs/hooks/(browser)/useFetch.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useFetch.mdx
@@ -196,8 +196,8 @@ The options object extends the standard `RequestInit` interface (excluding `sign
 ## Notes
 
 - This hook does not cache requests - each call triggers a fresh fetch
-- Starting a request aborts any request already in progress; only the newest request may update state or invoke callbacks
-- Unmounting aborts the active request and prevents callbacks or state updates after unmount
+- Starting another request does not cancel earlier calls; overlapping requests may still complete and update state
+- Unmounting aborts active requests and prevents callbacks or state updates after unmount
 - The hook does not automatically fetch on mount - you must call the `startFetch` function
 - The hook automatically handles JSON parsing of responses
 - HTTP errors (4xx, 5xx) are thrown as `Error` objects with `status` and `statusText` properties

--- a/apps/website/content/docs/hooks/(browser)/useOnline.mdx
+++ b/apps/website/content/docs/hooks/(browser)/useOnline.mdx
@@ -60,3 +60,7 @@ function ConnectionBanner() {
 ### Return value
 
 Offline status (boolean) is returned.
+
+## Robustness and lifecycle
+
+The hook returns `null` during server rendering, then reports `navigator.onLine` after hydration. Online and offline listeners are removed when the last component instance unmounts.

--- a/apps/website/content/docs/hooks/(form)/useFileDropRef.mdx
+++ b/apps/website/content/docs/hooks/(form)/useFileDropRef.mdx
@@ -54,3 +54,7 @@ export default function ImageDropZone() {
   );
 }
 ```
+
+## Robustness and lifecycle
+
+When a drop exceeds `maxFiles`, every file is rejected. `onDrop` receives an empty accepted array and the complete rejected array, while `onFileRejected` is invoked once per file.

--- a/apps/website/content/docs/hooks/(lifecycle)/useAsyncEffect.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useAsyncEffect.mdx
@@ -340,3 +340,7 @@ The cleanup function is called when:
 - **Periodic Updates**: Setting up intervals or timeouts with automatic cleanup
 - **Complex Async Workflows**: Multi-step async operations with conditional execution
 - **Resource Management**: Managing any async resources that need cleanup
+
+## Robustness and lifecycle
+
+Only changes to `deps` restart the async effect. The latest cleanup callback is used when that generation ends, and `shouldContinueEffect()` becomes false for stale or unmounted generations.

--- a/apps/website/content/docs/hooks/(lifecycle)/useDebouncedAsyncEffect.mdx
+++ b/apps/website/content/docs/hooks/(lifecycle)/useDebouncedAsyncEffect.mdx
@@ -295,3 +295,7 @@ The `options` parameter accepts the following settings:
 - **Flexible Cleanup**: Cleanup function receives the result from the previous effect execution
 - **Error Handling**: Errors in async effects are properly propagated
 - **Configurable Timing**: Customize delay and leading/trailing execution
+
+## Robustness and lifecycle
+
+A dependency change or unmount invalidates running work immediately, including during the next debounce window. Cleanup receives a resolved generation result at most once; it receives `undefined` when that generation did not resolve while current.

--- a/apps/website/content/docs/hooks/(performance)/useThrottle.mdx
+++ b/apps/website/content/docs/hooks/(performance)/useThrottle.mdx
@@ -55,3 +55,7 @@ export default App;
 | ----------------- | -------- | ---------------------------------------------------------------------- |
 | throttledFunction | Function | A throttled function that will run at most once per timeout ms         |
 | isReady           | Boolean  | Tells whether calling throttledFunction at that point will fire or not |
+
+## Robustness and lifecycle
+
+The throttle gate closes synchronously before invoking the callback, so repeated calls in the same event or React batch still execute at most once. The returned function remains stable and invokes the latest callback.

--- a/apps/website/content/docs/hooks/(state)/useArrayState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useArrayState.mdx
@@ -531,3 +531,7 @@ type UseArrayStateReturnValue&lt;T&gt; = [T[], UseArrayStateControls&lt;T&gt;];
 - The return value is memoized with `useMemo` for optimal performance
 - For large arrays, consider implementing virtualization for rendering
 - Use the initializer function pattern for expensive initial computations
+
+## Robustness and lifecycle
+
+Array operations use immutable functional updates, so multiple controls called in the same React batch compose in call order. `push` and `unshift` accept one or more values, matching the native array methods.

--- a/apps/website/content/docs/hooks/(state)/useCountdown.mdx
+++ b/apps/website/content/docs/hooks/(state)/useCountdown.mdx
@@ -68,4 +68,4 @@ export default function AutoDismissNotice() {
 
 ## Robustness and lifecycle
 
-`onDown` receives the remaining milliseconds calculated at each tick. `onEnd` fires exactly once when a tick reaches or passes `endTime`, including an exact boundary.
+`onDown` receives the remaining milliseconds calculated at each tick. `onEnd` fires exactly once when a tick reaches or passes `endTime`, including an exact boundary or a target that has already elapsed.

--- a/apps/website/content/docs/hooks/(state)/useCountdown.mdx
+++ b/apps/website/content/docs/hooks/(state)/useCountdown.mdx
@@ -65,3 +65,7 @@ export default function AutoDismissNotice() {
 | Type   | Description                                                    |
 | ------ | -------------------------------------------------------------- |
 | number | rest amount of intervals it takes to count down to the endTime |
+
+## Robustness and lifecycle
+
+`onDown` receives the remaining milliseconds calculated at each tick. `onEnd` fires exactly once when a tick reaches or passes `endTime`, including an exact boundary.

--- a/apps/website/content/docs/hooks/(state)/useLocalstorageState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useLocalstorageState.mdx
@@ -85,4 +85,6 @@ Returns an array of following items:
 | set          | Function | set value stored in localStorage    |
 | remove       | Function | remove value stored in localStorage |
 
+## Robustness and lifecycle
 
+Changing `key` reloads that key before persistence, same-document and cross-document updates do not echo-write, and rapid functional setters compose correctly. If storage access is denied or exceeds quota, the hook keeps its in-memory state without crashing.

--- a/apps/website/content/docs/hooks/(state)/useMapState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useMapState.mdx
@@ -89,3 +89,7 @@ map methods:
 | removeAll      | `() => void`                     | remove all key value pair in map      |
 
 ---
+
+## Robustness and lifecycle
+
+`has` checks own-key presence, so a key containing `undefined` still exists. Removal also works for maps that contain a key named `hasOwnProperty`.

--- a/apps/website/content/docs/hooks/(state)/useMapState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useMapState.mdx
@@ -92,4 +92,4 @@ map methods:
 
 ## Robustness and lifecycle
 
-`has` checks own-key presence, so a key containing `undefined` still exists. Removal also works for maps that contain a key named `hasOwnProperty`.
+`has` retains its existing value-based behavior, where an `undefined` value is treated as absent. Removal also works for maps that contain a key named `hasOwnProperty`.

--- a/apps/website/content/docs/hooks/(state)/useSessionstorageState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useSessionstorageState.mdx
@@ -213,3 +213,7 @@ Returns an array with three elements:
 - Values are stored as JSON strings, so only JSON-serializable values are supported
 - sessionStorage data persists until the browser tab is closed (unlike localStorage which persists indefinitely)
 - Cross-window synchronization only works within the same domain and browser session
+
+## Robustness and lifecycle
+
+Changing `key` reloads that key before persistence, synchronized updates do not echo-write, and rapid functional setters compose correctly. If storage access is denied or exceeds quota, the hook keeps its in-memory state without crashing.

--- a/apps/website/content/docs/hooks/(state)/useSetState.mdx
+++ b/apps/website/content/docs/hooks/(state)/useSetState.mdx
@@ -124,3 +124,7 @@ Returns an array with two elements:
 | add    | Function | Add one or more values to the set        |
 | delete | Function | Delete one or more values from the set   |
 | clear  | Function | Remove all values from the set           |
+
+## Robustness and lifecycle
+
+Every operation creates a new Set before mutation. Previously returned snapshots and the caller's initial Set remain unchanged, and multiple operations in one React batch compose safely.

--- a/apps/website/content/docs/hooks/(ui)/usePictureInPictureApi.mdx
+++ b/apps/website/content/docs/hooks/(ui)/usePictureInPictureApi.mdx
@@ -552,3 +552,7 @@ For Picture-in-Picture to work, the following conditions must be met:
 - PiP operations are asynchronous and may fail (errors are captured in the `error` state)
 - Only one video can be in Picture-in-Picture mode at a time across the entire browser
 - The PiP window maintains its own controls and can be resized by the user
+
+## Robustness and lifecycle
+
+Support is evaluated after the video ref attaches, so a normal `useRef(null)` flow becomes supported without an unrelated rerender. The hook remains unsupported while no video element is attached or the browser API is unavailable.

--- a/data/docs/useArrayState.md
+++ b/data/docs/useArrayState.md
@@ -27,3 +27,7 @@ export default function App() {
 }
 
 ```
+
+## Robustness and lifecycle
+
+Array operations use immutable functional updates, so multiple controls called in the same React batch compose in call order. `push` and `unshift` accept one or more values, matching the native array methods.

--- a/data/docs/useAsyncEffect.md
+++ b/data/docs/useAsyncEffect.md
@@ -15,3 +15,7 @@ This is a version of `useEffect` that accepts an async function.
 ## Examples
 
 ### Basic example
+
+## Robustness and lifecycle
+
+Only changes to `deps` restart the async effect. The latest cleanup callback is used when that generation ends, and `shouldContinueEffect()` becomes false for stale or unmounted generations.

--- a/data/docs/useCountdown.md
+++ b/data/docs/useCountdown.md
@@ -42,4 +42,4 @@ export default function App() {
 
 ## Robustness and lifecycle
 
-`onDown` receives the remaining milliseconds calculated at each tick. `onEnd` fires exactly once when a tick reaches or passes `endTime`, including an exact boundary.
+`onDown` receives the remaining milliseconds calculated at each tick. `onEnd` fires exactly once when a tick reaches or passes `endTime`, including an exact boundary or a target that has already elapsed.

--- a/data/docs/useCountdown.md
+++ b/data/docs/useCountdown.md
@@ -39,3 +39,7 @@ export default function App() {
 | Type   | Description                                                    |
 | ------ | -------------------------------------------------------------- |
 | number | rest amount of intervals it takes to count down to the endTime |
+
+## Robustness and lifecycle
+
+`onDown` receives the remaining milliseconds calculated at each tick. `onEnd` fires exactly once when a tick reaches or passes `endTime`, including an exact boundary.

--- a/data/docs/useDebouncedAsyncEffect.md
+++ b/data/docs/useDebouncedAsyncEffect.md
@@ -1,0 +1,13 @@
+---
+id: useDebouncedAsyncEffect
+title: useDebouncedAsyncEffect
+sidebar_label: useDebouncedAsyncEffect
+---
+
+## About
+
+Runs an asynchronous effect after dependency changes settle for the configured debounce delay.
+
+## Robustness and lifecycle
+
+Dependency changes and unmount invalidate running work immediately. Cleanup receives a resolved generation result at most once and receives `undefined` when no current result resolved.

--- a/data/docs/useFetch.md
+++ b/data/docs/useFetch.md
@@ -10,4 +10,4 @@ Manually fetch JSON data while tracking data, loading, and error state.
 
 ## Robustness and lifecycle
 
-Starting a request aborts any request already in progress; only the newest request may update state or invoke callbacks. Unmounting aborts the active request. Abort cancellations are not reported as user errors.
+Starting another request does not cancel earlier calls; overlapping requests may still complete and update state. Unmounting aborts active requests and prevents callbacks or state updates after unmount.

--- a/data/docs/useFetch.md
+++ b/data/docs/useFetch.md
@@ -10,4 +10,4 @@ Manually fetch JSON data while tracking data, loading, and error state.
 
 ## Robustness and lifecycle
 
-Starting another request does not cancel earlier calls; overlapping requests may still complete and update state. Unmounting aborts active requests and prevents callbacks or state updates after unmount.
+Starting another request does not cancel earlier calls; overlapping requests may still complete and update state. Unmounting aborts active requests and prevents callbacks or state updates after unmount. `startFetch` is bound to the URL and options object from its render, so memoize `options` before using `startFetch` as an effect dependency.

--- a/data/docs/useFetch.md
+++ b/data/docs/useFetch.md
@@ -1,0 +1,13 @@
+---
+id: useFetch
+title: useFetch
+sidebar_label: useFetch
+---
+
+## About
+
+Manually fetch JSON data while tracking data, loading, and error state.
+
+## Robustness and lifecycle
+
+Starting a request aborts any request already in progress; only the newest request may update state or invoke callbacks. Unmounting aborts the active request. Abort cancellations are not reported as user errors.

--- a/data/docs/useFileDropRef.md
+++ b/data/docs/useFileDropRef.md
@@ -17,3 +17,7 @@ export default function App() {
   return null;
 }
 ```
+
+## Robustness and lifecycle
+
+When a drop exceeds `maxFiles`, every file is rejected. `onDrop` receives an empty accepted array and the complete rejected array, while `onFileRejected` is invoked once per file.

--- a/data/docs/useLocalstorageState.md
+++ b/data/docs/useLocalstorageState.md
@@ -84,4 +84,6 @@ Returns an array of following items:
 | set          | Function | set value stored in localStorage    |
 | remove       | Function | remove value stored in localStorage |
 
+## Robustness and lifecycle
 
+Changing `key` reloads that key before persistence, same-document and cross-document updates do not echo-write, and rapid functional setters compose correctly. If storage access is denied or exceeds quota, the hook keeps its in-memory state without crashing.

--- a/data/docs/useMapState.md
+++ b/data/docs/useMapState.md
@@ -91,4 +91,4 @@ map methods:
 
 ## Robustness and lifecycle
 
-`has` checks own-key presence, so a key containing `undefined` still exists. Removal also works for maps that contain a key named `hasOwnProperty`.
+`has` retains its existing value-based behavior, where an `undefined` value is treated as absent. Removal also works for maps that contain a key named `hasOwnProperty`.

--- a/data/docs/useMapState.md
+++ b/data/docs/useMapState.md
@@ -88,3 +88,7 @@ map methods:
 | removeAll      | `() => void`                     | remove all key value pair in map      |
 
 ---
+
+## Robustness and lifecycle
+
+`has` checks own-key presence, so a key containing `undefined` still exists. Removal also works for maps that contain a key named `hasOwnProperty`.

--- a/data/docs/useOnline.md
+++ b/data/docs/useOnline.md
@@ -36,3 +36,7 @@ export default App;
 ### Return value
 
 Offline status (boolean) is returned.
+
+## Robustness and lifecycle
+
+The hook returns `null` during server rendering, then reports `navigator.onLine` after hydration. Online and offline listeners are removed when the last component instance unmounts.

--- a/data/docs/usePictureInPictureApi.md
+++ b/data/docs/usePictureInPictureApi.md
@@ -334,3 +334,7 @@ export default function CustomVideoControls() {
 | toggle       | () => Promise\<void\>               | Function to toggle Picture-in-Picture mode                        |
 
 ---
+
+## Robustness and lifecycle
+
+Support is evaluated after the video ref attaches, so a normal `useRef(null)` flow becomes supported without an unrelated rerender. The hook remains unsupported while no video element is attached or the browser API is unavailable.

--- a/data/docs/useSessionstorageState.md
+++ b/data/docs/useSessionstorageState.md
@@ -30,3 +30,7 @@ export default function App() {
   );
 }
 ```
+
+## Robustness and lifecycle
+
+Changing `key` reloads that key before persistence, synchronized updates do not echo-write, and rapid functional setters compose correctly. If storage access is denied or exceeds quota, the hook keeps its in-memory state without crashing.

--- a/data/docs/useSetState.md
+++ b/data/docs/useSetState.md
@@ -17,3 +17,7 @@ export default function App() {
   return null;
 }
 ```
+
+## Robustness and lifecycle
+
+Every operation creates a new Set before mutation. Previously returned snapshots and the caller's initial Set remain unchanged, and multiple operations in one React batch compose safely.

--- a/data/docs/useThrottle.md
+++ b/data/docs/useThrottle.md
@@ -54,3 +54,7 @@ export default App;
 | ----------------- | -------- | ---------------------------------------------------------------------- |
 | throttledFunction | Function | A throttled function that will run at most once per timeout ms         |
 | isReady           | Boolean  | Tells whether calling throttledFunction at that point will fire or not |
+
+## Robustness and lifecycle
+
+The throttle gate closes synchronously before invoking the callback, so repeated calls in the same event or React batch still execute at most once. The returned function remains stable and invokes the latest callback.

--- a/packages/rooks/src/__tests__/ssr.spec.ts
+++ b/packages/rooks/src/__tests__/ssr.spec.ts
@@ -3,6 +3,33 @@
  */
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
+// Mock React hooks for SSR testing. These mocks must be declared at module
+// scope because Vitest hoists vi.mock calls before test setup.
+vi.mock("react", () => ({
+  useState: vi.fn((init) => [
+    typeof init === "function" ? init() : init,
+    vi.fn(),
+  ]),
+  useEffect: vi.fn(),
+  useInsertionEffect: vi.fn(),
+  useLayoutEffect: vi.fn(),
+  useMemo: vi.fn((fn) => fn()),
+  useCallback: vi.fn((fn) => fn),
+  useRef: vi.fn((init) => ({ current: init })),
+  useReducer: vi.fn((reducer, init) => [init, vi.fn()]),
+  useSyncExternalStore: vi.fn(
+    (subscribe, getSnapshot, getServerSnapshot) =>
+      getServerSnapshot ? getServerSnapshot() : null
+  ),
+}));
+
+vi.mock("use-sync-external-store/shim", () => ({
+  useSyncExternalStore: vi.fn(
+    (subscribe, getSnapshot, getServerSnapshot) =>
+      getServerSnapshot ? getServerSnapshot() : getSnapshot()
+  ),
+}));
+
 /**
  * SSR Environment Tests
  *
@@ -16,32 +43,6 @@ describe("SSR Environment Detection", () => {
 
   beforeEach(() => {
     consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    // Mock React hooks for SSR testing
-    vi.mock("react", () => ({
-      useState: vi.fn((init) => [
-        typeof init === "function" ? init() : init,
-        vi.fn(),
-      ]),
-      useEffect: vi.fn(),
-      useLayoutEffect: vi.fn(),
-      useMemo: vi.fn((fn) => fn()),
-      useCallback: vi.fn((fn) => fn),
-      useRef: vi.fn((init) => ({ current: init })),
-      useReducer: vi.fn((reducer, init) => [init, vi.fn()]),
-      useSyncExternalStore: vi.fn(
-        (subscribe, getSnapshot, getServerSnapshot) =>
-          getServerSnapshot ? getServerSnapshot() : null
-      ),
-    }));
-
-    // Mock use-sync-external-store/shim
-    vi.mock("use-sync-external-store/shim", () => ({
-      useSyncExternalStore: vi.fn(
-        (subscribe, getSnapshot, getServerSnapshot) =>
-          getServerSnapshot ? getServerSnapshot() : getSnapshot()
-      ),
-    }));
   });
 
   afterEach(() => {

--- a/packages/rooks/src/__tests__/useArrayState.spec.ts
+++ b/packages/rooks/src/__tests__/useArrayState.spec.ts
@@ -183,4 +183,44 @@ describe("useArrayState", () => {
 
     expect(result.current[0]).toEqual([1, 2, 3]);
   });
+
+  it("preserves multiple operations in the same batch", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useArrayState([1]));
+
+    act(() => {
+      result.current[1].push(2);
+      result.current[1].push(3);
+      result.current[1].reverse();
+    });
+
+    expect(result.current[0]).toEqual([3, 2, 1]);
+  });
+
+  it("supports variadic push and unshift as declared", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useArrayState([3]));
+
+    act(() => {
+      result.current[1].push(4, 5);
+      result.current[1].unshift(1, 2);
+    });
+
+    expect(result.current[0]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("keeps collection controls stable after updates", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useArrayState([1]));
+    const controls = result.current[1];
+
+    act(() => {
+      controls.push(2);
+    });
+
+    expect(result.current[1].push).toBe(controls.push);
+    expect(result.current[1].pop).toBe(controls.pop);
+    expect(result.current[1].reverse).toBe(controls.reverse);
+  });
+
 });

--- a/packages/rooks/src/__tests__/useAsyncEffect.spec.ts
+++ b/packages/rooks/src/__tests__/useAsyncEffect.spec.ts
@@ -280,4 +280,28 @@ describe("useAsyncEffect", () => {
     vi.useRealTimers();
     vi.clearAllMocks();
   });
+
+  it("does not restart when an inline cleanup callback changes identity", () => {
+    expect.hasAssertions();
+    const effectSpy = vi.fn(async () => 1);
+    const cleanupSpy = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ renderValue }) => {
+        useAsyncEffect(effectSpy, [], (result) => {
+          cleanupSpy(renderValue, result);
+        });
+      },
+      { initialProps: { renderValue: 1 } }
+    );
+
+    rerender({ renderValue: 2 });
+
+    expect(effectSpy).toHaveBeenCalledTimes(1);
+    expect(cleanupSpy).not.toHaveBeenCalled();
+
+    unmount();
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+    expect(cleanupSpy).toHaveBeenCalledWith(2, undefined);
+  });
+
 });

--- a/packages/rooks/src/__tests__/useCountdown.spec.tsx
+++ b/packages/rooks/src/__tests__/useCountdown.spec.tsx
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
 import { useCountdown } from "@/hooks/useCountdown";
 
 describe("useCountdown", () => {
@@ -90,6 +91,39 @@ describe("useCountdown", () => {
     expect(result.current).toBe(0);
     expect(onEnd).toHaveBeenCalledTimes(1);
     expect(onDown).toHaveBeenLastCalledWith(1_000, expect.any(Date));
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends once when several due ticks flush in the same batch", () => {
+    expect.hasAssertions();
+    const onEnd = vi.fn();
+    const endTime = new Date(Date.now() + 2_000);
+    const { result } = renderHook(() =>
+      useCountdown(endTime, { interval: 1_000, onEnd })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(result.current).toBe(0);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends once when the target is already elapsed during Strict Mode replay", () => {
+    expect.hasAssertions();
+    const onEnd = vi.fn();
+    const endTime = new Date(Date.now() - 1);
+    const { result } = renderHook(() => useCountdown(endTime, { onEnd }), {
+      wrapper: StrictMode,
+    });
+
+    expect(result.current).toBe(0);
+    expect(onEnd).toHaveBeenCalledTimes(1);
 
     act(() => {
       vi.advanceTimersByTime(5_000);

--- a/packages/rooks/src/__tests__/useCountdown.spec.tsx
+++ b/packages/rooks/src/__tests__/useCountdown.spec.tsx
@@ -71,4 +71,49 @@ describe("useCountdown", () => {
 
     expect(onEnd.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
+
+  it("ends once when a tick lands exactly on the target", () => {
+    expect.hasAssertions();
+    const onDown = vi.fn();
+    const onEnd = vi.fn();
+    const endTime = new Date(Date.now() + 2_000);
+    const { result } = renderHook(() =>
+      useCountdown(endTime, { interval: 1_000, onDown, onEnd })
+    );
+
+    expect(onDown).toHaveBeenLastCalledWith(2_000, expect.any(Date));
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    expect(result.current).toBe(0);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onDown).toHaveBeenLastCalledWith(1_000, expect.any(Date));
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the remaining time calculated for each tick", () => {
+    expect.hasAssertions();
+    const onDown = vi.fn();
+    const endTime = new Date(Date.now() + 2_500);
+    renderHook(() =>
+      useCountdown(endTime, { interval: 1_000, onDown })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    expect(onDown.mock.calls.map(([remaining]) => remaining)).toEqual([
+      2_500,
+      1_500,
+      500,
+    ]);
+  });
+
 });

--- a/packages/rooks/src/__tests__/useDebouncedAsyncEffect.spec.ts
+++ b/packages/rooks/src/__tests__/useDebouncedAsyncEffect.spec.ts
@@ -340,5 +340,64 @@ describe("useDebouncedAsyncEffect", () => {
         expect(result.current.error).toBeTruthy();
         expect((result.current.error as Error).message).toBe(ERROR_MESSAGE);
     });
+
+    it("invalidates a running generation as soon as dependencies change", async () => {
+        expect.hasAssertions();
+        let shouldContinue: (() => boolean) | undefined;
+        let resolveEffect!: (value: string) => void;
+        const asyncEffect = vi.fn(
+            async (isCurrent: () => boolean) => {
+                shouldContinue = isCurrent;
+                return await new Promise<string>((resolve) => {
+                    resolveEffect = resolve;
+                });
+            }
+        );
+
+        const { rerender, unmount } = renderHook(
+            ({ value }) =>
+                useDebouncedAsyncEffect(asyncEffect, [value], 100),
+            { initialProps: { value: 0 } }
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(100);
+        });
+        expect(asyncEffect).toHaveBeenCalledTimes(1);
+        expect(shouldContinue?.()).toBe(true);
+
+        rerender({ value: 1 });
+
+        expect(shouldContinue?.()).toBe(false);
+        expect(asyncEffect).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            resolveEffect("stale");
+            await Promise.resolve();
+        });
+        unmount();
+    });
+
+    it("passes each resolved result to cleanup at most once", async () => {
+        expect.hasAssertions();
+        const cleanup = vi.fn();
+        const asyncEffect = vi.fn(async () => "result-a");
+        const { rerender } = renderHook(
+            ({ value }) =>
+                useDebouncedAsyncEffect(asyncEffect, [value], 100, cleanup),
+            { initialProps: { value: 0 } }
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(100);
+        });
+
+        rerender({ value: 1 });
+        rerender({ value: 2 });
+
+        expect(cleanup).toHaveBeenNthCalledWith(1, "result-a");
+        expect(cleanup).toHaveBeenNthCalledWith(2, undefined);
+    });
+
 });
 

--- a/packages/rooks/src/__tests__/useFetch.spec.tsx
+++ b/packages/rooks/src/__tests__/useFetch.spec.tsx
@@ -254,12 +254,12 @@ describe("useFetch", () => {
         expect(onError).not.toHaveBeenCalled();
     });
 
-    it("should keep startFetch stable while using the latest options", async () => {
+    it("should keep startFetch tied to the render options it was created with", async () => {
         const firstOnSuccess = vi.fn();
         const latestOnSuccess = vi.fn();
         mockFetch.mockResolvedValueOnce({
             ok: true,
-            json: async () => ({ name: "Latest" }),
+            json: async () => ({ name: "First" }),
         } as Response);
 
         const { result, rerender } = renderHook(
@@ -274,20 +274,21 @@ describe("useFetch", () => {
 
         rerender({ onSuccess: latestOnSuccess });
 
-        expect(result.current.startFetch).toBe(initialStartFetch);
+        expect(result.current.startFetch).not.toBe(initialStartFetch);
 
         await act(async () => {
             await initialStartFetch();
         });
 
-        expect(firstOnSuccess).not.toHaveBeenCalled();
-        expect(latestOnSuccess).toHaveBeenCalledWith({ name: "Latest" });
+        expect(firstOnSuccess).toHaveBeenCalledWith({ name: "First" });
+        expect(latestOnSuccess).not.toHaveBeenCalled();
     });
 
-    it("should abort an older request and ignore its stale result", async () => {
+    it("should allow overlapping requests to complete", async () => {
         let resolveFirst!: (response: Response) => void;
         let resolveSecond!: (response: Response) => void;
         let firstSignal: AbortSignal | undefined;
+        let secondSignal: AbortSignal | undefined;
 
         mockFetch
             .mockImplementationOnce((_url: string, init: RequestInit) => {
@@ -296,12 +297,12 @@ describe("useFetch", () => {
                     resolveFirst = resolve;
                 });
             })
-            .mockImplementationOnce(
-                () =>
-                    new Promise<Response>((resolve) => {
-                        resolveSecond = resolve;
-                    })
-            );
+            .mockImplementationOnce((_url: string, init: RequestInit) => {
+                secondSignal = init.signal ?? undefined;
+                return new Promise<Response>((resolve) => {
+                    resolveSecond = resolve;
+                });
+            });
 
         const { result } = renderHook(() =>
             useFetch<{ request: number }>("https://api.example.com/user")
@@ -314,7 +315,8 @@ describe("useFetch", () => {
             secondRequest = result.current.startFetch();
         });
 
-        expect(firstSignal?.aborted).toBe(true);
+        expect(firstSignal?.aborted).toBe(false);
+        expect(secondSignal?.aborted).toBe(false);
 
         await act(async () => {
             resolveSecond({
@@ -333,7 +335,7 @@ describe("useFetch", () => {
             await firstRequest;
         });
 
-        expect(result.current.data).toEqual({ request: 2 });
+        expect(result.current.data).toEqual({ request: 1 });
         expect(result.current.error).toBeNull();
         expect(result.current.loading).toBe(false);
     });

--- a/packages/rooks/src/__tests__/useFetch.spec.tsx
+++ b/packages/rooks/src/__tests__/useFetch.spec.tsx
@@ -1,6 +1,6 @@
 import { vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { StrictMode } from "react";
+import { StrictMode, useEffect } from "react";
 import { useFetch } from "../hooks/useFetch";
 
 // Mock fetch globally
@@ -122,6 +122,62 @@ describe("useFetch", () => {
 
         expect(result.current.error).toBe(networkError);
         expect(result.current.data).toBe(null);
+        expect(result.current.loading).toBe(false);
+    });
+
+    it("should recover when AbortController construction fails", async () => {
+        expect.hasAssertions();
+        const descriptor = Object.getOwnPropertyDescriptor(
+            globalThis,
+            "AbortController"
+        );
+        const onError = vi.fn();
+
+        Object.defineProperty(globalThis, "AbortController", {
+            configurable: true,
+            value: undefined,
+        });
+
+        try {
+            const { result } = renderHook(() =>
+                useFetch("https://api.example.com/users/1", { onError })
+            );
+
+            await act(async () => {
+                await result.current.startFetch();
+            });
+
+            expect(mockFetch).not.toHaveBeenCalled();
+            expect(result.current.error).toBeInstanceOf(TypeError);
+            expect(onError).toHaveBeenCalledWith(result.current.error);
+            expect(result.current.loading).toBe(false);
+        } finally {
+            if (descriptor) {
+                Object.defineProperty(
+                    globalThis,
+                    "AbortController",
+                    descriptor
+                );
+            }
+        }
+    });
+
+    it("should preserve AbortError reporting while the hook is mounted", async () => {
+        expect.hasAssertions();
+        const abortError = new DOMException("Request aborted", "AbortError");
+        const onError = vi.fn();
+        mockFetch.mockRejectedValueOnce(abortError);
+
+        const { result } = renderHook(() =>
+            useFetch("https://api.example.com/users/1", { onError })
+        );
+
+        await act(async () => {
+            await result.current.startFetch();
+        });
+
+        expect(result.current.error?.message).toContain("Request aborted");
+        expect(onError).toHaveBeenCalledWith(result.current.error);
         expect(result.current.loading).toBe(false);
     });
 
@@ -389,6 +445,61 @@ describe("useFetch", () => {
         });
 
         expect(result.current.data).toEqual({ ready: true });
+    });
+
+    it("should isolate requests started by StrictMode mount-effect replay", async () => {
+        expect.hasAssertions();
+        let resolveLiveRequest!: (response: Response) => void;
+        const stableOptions = {};
+
+        mockFetch
+            .mockImplementationOnce((_url: string, init: RequestInit) => {
+                return new Promise<Response>((_resolve, reject) => {
+                    init.signal?.addEventListener("abort", () => {
+                        reject(new DOMException("Request aborted", "AbortError"));
+                    });
+                });
+            })
+            .mockImplementationOnce(() => {
+                return new Promise<Response>((resolve) => {
+                    resolveLiveRequest = resolve;
+                });
+            });
+
+        const { result } = renderHook(
+            () => {
+                const request = useFetch<{ generation: number }>(
+                    "https://api.example.com/strict-replay",
+                    stableOptions
+                );
+                const { startFetch } = request;
+                useEffect(() => {
+                    void startFetch();
+                }, [startFetch]);
+                return request;
+            },
+            { wrapper: StrictMode }
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(result.current.loading).toBe(true);
+        expect(result.current.error).toBeNull();
+
+        await act(async () => {
+            resolveLiveRequest({
+                ok: true,
+                json: async () => ({ generation: 2 }),
+            } as Response);
+            await Promise.resolve();
+        });
+
+        expect(result.current.data).toEqual({ generation: 2 });
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeNull();
     });
 
 });

--- a/packages/rooks/src/__tests__/useFetch.spec.tsx
+++ b/packages/rooks/src/__tests__/useFetch.spec.tsx
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { StrictMode } from "react";
 import { useFetch } from "../hooks/useFetch";
 
 // Mock fetch globally
@@ -252,6 +253,142 @@ describe("useFetch", () => {
         expect(onSuccess).not.toHaveBeenCalled();
         expect(onError).not.toHaveBeenCalled();
     });
+
+    it("should keep startFetch stable while using the latest options", async () => {
+        const firstOnSuccess = vi.fn();
+        const latestOnSuccess = vi.fn();
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ name: "Latest" }),
+        } as Response);
+
+        const { result, rerender } = renderHook(
+            ({ onSuccess }) =>
+                useFetch<{ name: string }>("https://api.example.com/user", {
+                    headers: { "X-Render": "inline" },
+                    onSuccess,
+                }),
+            { initialProps: { onSuccess: firstOnSuccess } }
+        );
+        const initialStartFetch = result.current.startFetch;
+
+        rerender({ onSuccess: latestOnSuccess });
+
+        expect(result.current.startFetch).toBe(initialStartFetch);
+
+        await act(async () => {
+            await initialStartFetch();
+        });
+
+        expect(firstOnSuccess).not.toHaveBeenCalled();
+        expect(latestOnSuccess).toHaveBeenCalledWith({ name: "Latest" });
+    });
+
+    it("should abort an older request and ignore its stale result", async () => {
+        let resolveFirst!: (response: Response) => void;
+        let resolveSecond!: (response: Response) => void;
+        let firstSignal: AbortSignal | undefined;
+
+        mockFetch
+            .mockImplementationOnce((_url: string, init: RequestInit) => {
+                firstSignal = init.signal ?? undefined;
+                return new Promise<Response>((resolve) => {
+                    resolveFirst = resolve;
+                });
+            })
+            .mockImplementationOnce(
+                () =>
+                    new Promise<Response>((resolve) => {
+                        resolveSecond = resolve;
+                    })
+            );
+
+        const { result } = renderHook(() =>
+            useFetch<{ request: number }>("https://api.example.com/user")
+        );
+        let firstRequest!: Promise<void>;
+        let secondRequest!: Promise<void>;
+
+        act(() => {
+            firstRequest = result.current.startFetch();
+            secondRequest = result.current.startFetch();
+        });
+
+        expect(firstSignal?.aborted).toBe(true);
+
+        await act(async () => {
+            resolveSecond({
+                ok: true,
+                json: async () => ({ request: 2 }),
+            } as Response);
+            await secondRequest;
+        });
+        expect(result.current.data).toEqual({ request: 2 });
+
+        await act(async () => {
+            resolveFirst({
+                ok: true,
+                json: async () => ({ request: 1 }),
+            } as Response);
+            await firstRequest;
+        });
+
+        expect(result.current.data).toEqual({ request: 2 });
+        expect(result.current.error).toBeNull();
+        expect(result.current.loading).toBe(false);
+    });
+
+    it("should abort the active request on unmount", async () => {
+        let resolveRequest!: (response: Response) => void;
+        let signal: AbortSignal | undefined;
+        mockFetch.mockImplementationOnce((_url: string, init: RequestInit) => {
+            signal = init.signal ?? undefined;
+            return new Promise<Response>((resolve) => {
+                resolveRequest = resolve;
+            });
+        });
+
+        const onSuccess = vi.fn();
+        const { result, unmount } = renderHook(() =>
+            useFetch("https://api.example.com/user", { onSuccess })
+        );
+        let request!: Promise<void>;
+
+        act(() => {
+            request = result.current.startFetch();
+        });
+        unmount();
+
+        expect(signal?.aborted).toBe(true);
+
+        await act(async () => {
+            resolveRequest({
+                ok: true,
+                json: async () => ({ ignored: true }),
+            } as Response);
+            await request;
+        });
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("should remain usable during StrictMode effect replay", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ ready: true }),
+        } as Response);
+
+        const { result } = renderHook(
+            () => useFetch<{ ready: boolean }>("https://api.example.com/user"),
+            { wrapper: StrictMode }
+        );
+
+        await act(async () => {
+            await result.current.startFetch();
+        });
+
+        expect(result.current.data).toEqual({ ready: true });
+    });
+
 });
 
 interface User {

--- a/packages/rooks/src/__tests__/useFileDropRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useFileDropRef.spec.tsx
@@ -145,4 +145,32 @@ describe("useFileDropRef", () => {
     expect(callbacks.onFileAccepted).toHaveBeenCalledTimes(1);
     expect(callbacks.onFileRejected).toHaveBeenCalledTimes(2);
   });
+
+  it("treats maxFiles zero as rejecting every dropped file", () => {
+    expect.hasAssertions();
+    const onDrop = vi.fn();
+    const onFileRejected = vi.fn();
+
+    function ZeroFileDropZone() {
+      const ref = useFileDropRef(
+        { maxFiles: 0 },
+        { onDrop, onFileRejected }
+      );
+      return <div ref={ref} data-testid="zero-file-drop-area" />;
+    }
+
+    const { getByTestId } = render(<ZeroFileDropZone />);
+    const file = createFileWithSize("file.txt", "text/plain", 1);
+
+    fireEvent.drop(getByTestId("zero-file-drop-area"), {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(onDrop).toHaveBeenCalledWith([], [file]);
+    expect(onFileRejected).toHaveBeenCalledWith(
+      file,
+      "Exceeded maximum number of files"
+    );
+  });
+
 });

--- a/packages/rooks/src/__tests__/useFileDropRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useFileDropRef.spec.tsx
@@ -173,4 +173,34 @@ describe("useFileDropRef", () => {
     );
   });
 
+  it("treats maxFileSize zero as an exact byte-size boundary", () => {
+    expect.hasAssertions();
+    const onDrop = vi.fn();
+    const onFileAccepted = vi.fn();
+    const onFileRejected = vi.fn();
+
+    function ZeroByteDropZone() {
+      const ref = useFileDropRef(
+        { maxFileSize: 0 },
+        { onDrop, onFileAccepted, onFileRejected }
+      );
+      return <div ref={ref} data-testid="zero-byte-drop-area" />;
+    }
+
+    const { getByTestId } = render(<ZeroByteDropZone />);
+    const emptyFile = createFileWithSize("empty.txt", "text/plain", 0);
+    const nonEmptyFile = createFileWithSize("non-empty.txt", "text/plain", 1);
+
+    fireEvent.drop(getByTestId("zero-byte-drop-area"), {
+      dataTransfer: { files: [emptyFile, nonEmptyFile] },
+    });
+
+    expect(onDrop).toHaveBeenCalledWith([emptyFile], [nonEmptyFile]);
+    expect(onFileAccepted).toHaveBeenCalledWith(emptyFile);
+    expect(onFileRejected).toHaveBeenCalledWith(
+      nonEmptyFile,
+      "File size exceeds the limit"
+    );
+  });
+
 });

--- a/packages/rooks/src/__tests__/useFileDropRef.spec.tsx
+++ b/packages/rooks/src/__tests__/useFileDropRef.spec.tsx
@@ -112,9 +112,15 @@ describe("useFileDropRef", () => {
       },
     });
 
-    expect(callbacks.onDrop).toHaveBeenCalled();
-    expect(callbacks.onFileAccepted).toHaveBeenCalledTimes(0);
+    expect(callbacks.onDrop).toHaveBeenCalledWith([], files);
+    expect(callbacks.onFileAccepted).not.toHaveBeenCalled();
     expect(callbacks.onFileRejected).toHaveBeenCalledTimes(files.length);
+    for (const file of files) {
+      expect(callbacks.onFileRejected).toHaveBeenCalledWith(
+        file,
+        "Exceeded maximum number of files"
+      );
+    }
   });
 
   it("should handle drop event with a mix of valid and rejected files", () => {

--- a/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
@@ -287,4 +287,25 @@ describe("useLocalstorageState localStorage", () => {
     expect(localStorage.setItem).not.toHaveBeenCalled();
   });
 
+
+  it("loads the new storage value when the key changes", () => {
+    expect.hasAssertions();
+    localStorage.setItem("local-key-a", JSON.stringify("value-a"));
+    localStorage.setItem("local-key-b", JSON.stringify("value-b"));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useLocalstorageState(storageKey, "fallback"),
+      { initialProps: { storageKey: "local-key-a" } }
+    );
+
+    expect(result.current[0]).toBe("value-a");
+
+    rerender({ storageKey: "local-key-b" });
+
+    expect(result.current[0]).toBe("value-b");
+    expect(localStorage.getItem("local-key-b")).toBe(
+      JSON.stringify("value-b")
+    );
+  });
+
 });

--- a/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
@@ -251,4 +251,40 @@ describe("useLocalstorageState localStorage", () => {
     );
     expect(result.current[0]).toBeUndefined();
   });
+
+  it("applies rapid functional updates without losing state", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useLocalstorageState("rapid-localstorage", 0)
+    );
+
+    act(() => {
+      const setValue = result.current[1];
+      setValue((current) => current + 1);
+      setValue((current) => current + 1);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(localStorage.getItem("rapid-localstorage")).toBe("2");
+  });
+
+  it("does not write a same-document synchronized value back to storage", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useLocalstorageState("shared-localstorage", "initial")
+    );
+    vi.mocked(localStorage.setItem).mockClear();
+
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("rooks-shared-localstorage-localstorage-update", {
+          detail: { newValue: "external" },
+        })
+      );
+    });
+
+    expect(result.current[0]).toBe("external");
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
+
 });

--- a/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useLocalstorageState.spec.tsx
@@ -268,6 +268,27 @@ describe("useLocalstorageState localStorage", () => {
     expect(localStorage.getItem("rapid-localstorage")).toBe("2");
   });
 
+  it("persists an originating update before broadcasting it", () => {
+    expect.hasAssertions();
+    const eventName = "rooks-ordered-localstorage-localstorage-update";
+    const observer = vi.fn(() => localStorage.getItem("ordered-localstorage"));
+    document.addEventListener(eventName, observer);
+
+    try {
+      const { result } = renderHook(() =>
+        useLocalstorageState("ordered-localstorage", "initial")
+      );
+
+      act(() => {
+        result.current[1]("next");
+      });
+
+      expect(observer).toHaveReturnedWith(JSON.stringify("next"));
+    } finally {
+      document.removeEventListener(eventName, observer);
+    }
+  });
+
   it("does not write a same-document synchronized value back to storage", () => {
     expect.hasAssertions();
     const { result } = renderHook(() =>
@@ -306,6 +327,155 @@ describe("useLocalstorageState localStorage", () => {
     expect(localStorage.getItem("local-key-b")).toBe(
       JSON.stringify("value-b")
     );
+  });
+
+  it("uses the active key when an older setter reference is invoked", () => {
+    expect.hasAssertions();
+    localStorage.setItem("local-key-a", JSON.stringify("value-a"));
+    localStorage.setItem("local-key-b", JSON.stringify("value-b"));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useLocalstorageState(storageKey, "fallback"),
+      { initialProps: { storageKey: "local-key-a" } }
+    );
+    const setterFromFirstRender = result.current[1];
+
+    rerender({ storageKey: "local-key-b" });
+    act(() => {
+      setterFromFirstRender("updated-b");
+    });
+
+    expect(result.current[0]).toBe("updated-b");
+    expect(localStorage.getItem("local-key-a")).toBe(
+      JSON.stringify("value-a")
+    );
+    expect(localStorage.getItem("local-key-b")).toBe(
+      JSON.stringify("updated-b")
+    );
+  });
+
+  it("uses the committed key from a descendant layout effect", () => {
+    expect.hasAssertions();
+    localStorage.setItem("layout-local-key-a", JSON.stringify("value-a"));
+    localStorage.setItem("layout-local-key-b", JSON.stringify("value-b"));
+
+    const LayoutWriter = ({
+      enabled,
+      setValue,
+    }: {
+      enabled: boolean;
+      setValue: React.Dispatch<React.SetStateAction<string>>;
+    }) => {
+      React.useLayoutEffect(() => {
+        if (enabled) {
+          setValue((current) => `${current}-layout`);
+        }
+      }, [enabled, setValue]);
+
+      return null;
+    };
+    const Harness = ({
+      storageKey,
+      writeInLayout,
+    }: {
+      storageKey: string;
+      writeInLayout: boolean;
+    }) => {
+      const [value, setValue] = useLocalstorageState(storageKey, "fallback");
+
+      return (
+        <>
+          <LayoutWriter enabled={writeInLayout} setValue={setValue} />
+          <span data-testid="layout-local-value">{value}</span>
+        </>
+      );
+    };
+
+    const { rerender } = render(
+      <Harness storageKey="layout-local-key-a" writeInLayout={false} />
+    );
+    rerender(
+      <Harness storageKey="layout-local-key-b" writeInLayout={true} />
+    );
+
+    expect(screen.getByTestId("layout-local-value")).toHaveTextContent(
+      "value-b-layout"
+    );
+    expect(localStorage.getItem("layout-local-key-a")).toBe(
+      JSON.stringify("value-a")
+    );
+    expect(localStorage.getItem("layout-local-key-b")).toBe(
+      JSON.stringify("value-b-layout")
+    );
+  });
+
+  it("persists a new key after a no-op setter update", () => {
+    expect.hasAssertions();
+    localStorage.setItem("noop-local-key-a", JSON.stringify("same"));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useLocalstorageState(storageKey, "fallback"),
+      { initialProps: { storageKey: "noop-local-key-a" } }
+    );
+
+    act(() => {
+      result.current[1]("same");
+    });
+    rerender({ storageKey: "noop-local-key-b" });
+
+    expect(result.current[0]).toBe("fallback");
+    expect(localStorage.getItem("noop-local-key-b")).toBe(
+      JSON.stringify("fallback")
+    );
+  });
+
+  it("composes same-tick updates across synchronized hook instances", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => {
+      const first = useLocalstorageState("shared-counter", 0);
+      const second = useLocalstorageState("shared-counter", 0);
+      return { first, second };
+    });
+
+    act(() => {
+      result.current.first[1](1);
+      result.current.second[1]((current) => current + 1);
+    });
+
+    expect(result.current.first[0]).toBe(2);
+    expect(result.current.second[0]).toBe(2);
+    expect(localStorage.getItem("shared-counter")).toBe("2");
+  });
+
+  it("keeps in-memory state when localStorage access is denied", () => {
+    expect.hasAssertions();
+    const descriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    const accessError = new DOMException("Access denied", "SecurityError");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get: () => {
+        throw accessError;
+      },
+    });
+
+    try {
+      const { result } = renderHook(() =>
+        useLocalstorageState("denied-localstorage", "fallback")
+      );
+
+      expect(result.current[0]).toBe("fallback");
+      act(() => {
+        result.current[1]("memory-only");
+      });
+      expect(result.current[0]).toBe("memory-only");
+      expect(consoleError).toHaveBeenCalledWith(accessError);
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(window, "localStorage", descriptor);
+      }
+    }
   });
 
 });

--- a/packages/rooks/src/__tests__/useMapState.spec.tsx
+++ b/packages/rooks/src/__tests__/useMapState.spec.tsx
@@ -199,4 +199,33 @@ describe("useMapState", () => {
     });
     expect(result.current[0]).toEqual({});
   });
+
+  it("reports own keys whose value is undefined", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useMapState<Map, keyof Map>({ a: undefined })
+    );
+
+    expect(result.current[1].has("a")).toBe(true);
+    expect(result.current[1].has("b")).toBe(false);
+  });
+
+  it("removes all keys even when hasOwnProperty is shadowed", () => {
+    expect.hasAssertions();
+    const initial = {
+      a: 1,
+      hasOwnProperty: "shadowed",
+    } as unknown as Map;
+    const { result } = renderHook(() =>
+      useMapState<Map, keyof Map>(initial)
+    );
+
+    expect(() => {
+      act(() => {
+        result.current[1].removeAll();
+      });
+    }).not.toThrow();
+    expect(result.current[0]).toEqual({});
+  });
+
 });

--- a/packages/rooks/src/__tests__/useMapState.spec.tsx
+++ b/packages/rooks/src/__tests__/useMapState.spec.tsx
@@ -200,14 +200,25 @@ describe("useMapState", () => {
     expect(result.current[0]).toEqual({});
   });
 
-  it("reports own keys whose value is undefined", () => {
+  it("preserves undefined values as absent", () => {
     expect.hasAssertions();
     const { result } = renderHook(() =>
       useMapState<Map, keyof Map>({ a: undefined })
     );
 
-    expect(result.current[1].has("a")).toBe(true);
+    expect(result.current[1].has("a")).toBe(false);
     expect(result.current[1].has("b")).toBe(false);
+  });
+
+  it("preserves inherited property lookup behavior", () => {
+    expect.hasAssertions();
+    const initialValue = Object.create({ inherited: 1 }) as Record<
+      string,
+      number
+    >;
+    const { result } = renderHook(() => useMapState(initialValue));
+
+    expect(result.current[1].has("inherited")).toBe(true);
   });
 
   it("removes all keys even when hasOwnProperty is shadowed", () => {

--- a/packages/rooks/src/__tests__/useOnline.spec.tsx
+++ b/packages/rooks/src/__tests__/useOnline.spec.tsx
@@ -1,5 +1,7 @@
 import { vi } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
 import { useOnline } from "@/hooks/useOnline";
 
 describe("useOnline", () => {
@@ -145,5 +147,35 @@ describe("useOnline", () => {
 
     expect(result1.current).toBe(false);
     expect(result2.current).toBe(false);
+  });
+
+  it("hydrates the server snapshot before reporting navigator state", async () => {
+    expect.hasAssertions();
+    onlineGetter.mockReturnValue(true);
+    const onRecoverableError = vi.fn();
+
+    function OnlineStatus() {
+      const online = useOnline();
+      return <span>{online === null ? "unknown" : String(online)}</span>;
+    }
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<OnlineStatus />);
+    expect(container).toHaveTextContent("unknown");
+
+    const root = hydrateRoot(container, <OnlineStatus />, {
+      onRecoverableError,
+    });
+
+    try {
+      await waitFor(() => {
+        expect(container).toHaveTextContent("true");
+      });
+      expect(onRecoverableError).not.toHaveBeenCalled();
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+    }
   });
 });

--- a/packages/rooks/src/__tests__/useOnline.ssr.spec.tsx
+++ b/packages/rooks/src/__tests__/useOnline.ssr.spec.tsx
@@ -1,0 +1,19 @@
+/**
+ * @vitest-environment node
+ */
+import { renderToString } from "react-dom/server";
+import { useOnline } from "@/hooks/useOnline";
+
+describe("useOnline SSR", () => {
+  it("renders with the server snapshot when browser globals are unavailable", () => {
+    expect.hasAssertions();
+
+    function TestComponent() {
+      const online = useOnline();
+      return <span>{online === null ? "unknown" : String(online)}</span>;
+    }
+
+    expect(() => renderToString(<TestComponent />)).not.toThrow();
+    expect(renderToString(<TestComponent />)).toContain("unknown");
+  });
+});

--- a/packages/rooks/src/__tests__/usePictureInPictureApi.spec.tsx
+++ b/packages/rooks/src/__tests__/usePictureInPictureApi.spec.tsx
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, render, screen } from "@testing-library/react";
 import { usePictureInPictureApi } from "@/hooks/usePictureInPictureApi";
-import { RefObject } from "react";
+import { RefObject, useRef } from "react";
 
 // Mock the Picture-in-Picture API
 const mockRequestPictureInPicture = vi.fn();
@@ -641,4 +641,37 @@ describe("usePictureInPictureApi", () => {
       expect(result.current.isSupported).toBe(false);
     });
   });
+
+  it("detects support after a normal React ref is attached", () => {
+    expect.hasAssertions();
+    Object.defineProperty(
+      HTMLVideoElement.prototype,
+      "requestPictureInPicture",
+      {
+        configurable: true,
+        value: mockRequestPictureInPicture,
+      }
+    );
+
+    function TestComponent() {
+      const videoRef = useRef<HTMLVideoElement>(null);
+      const { isSupported } = usePictureInPictureApi(videoRef);
+
+      return (
+        <>
+          <video ref={videoRef} />
+          <span data-testid="pip-supported">{String(isSupported)}</span>
+        </>
+      );
+    }
+
+    render(<TestComponent />);
+
+    expect(screen.getByTestId("pip-supported")).toHaveTextContent("true");
+
+    delete (
+      HTMLVideoElement.prototype as Partial<HTMLVideoElement>
+    ).requestPictureInPicture;
+  });
+
 });

--- a/packages/rooks/src/__tests__/usePictureInPictureApi.spec.tsx
+++ b/packages/rooks/src/__tests__/usePictureInPictureApi.spec.tsx
@@ -139,6 +139,38 @@ describe("usePictureInPictureApi", () => {
       // Should now be unsupported
       expect(result.current.isSupported).toBe(false);
     });
+
+    it("should recover when the same video element becomes supported", () => {
+      mockVideoElement.disablePictureInPicture = true;
+      const { result, rerender } = renderHook(() =>
+        usePictureInPictureApi(mockVideoRef)
+      );
+
+      expect(result.current.isSupported).toBe(false);
+
+      act(() => {
+        mockVideoElement.disablePictureInPicture = false;
+      });
+      rerender();
+
+      expect(result.current.isSupported).toBe(true);
+    });
+
+    it("should recover when document Picture-in-Picture support becomes available", () => {
+      (document as any).pictureInPictureEnabled = false;
+      const { result, rerender } = renderHook(() =>
+        usePictureInPictureApi(mockVideoRef)
+      );
+
+      expect(result.current.isSupported).toBe(false);
+
+      act(() => {
+        (document as any).pictureInPictureEnabled = true;
+      });
+      rerender();
+
+      expect(result.current.isSupported).toBe(true);
+    });
   });
 
   describe("Enter PiP Functionality", () => {
@@ -642,8 +674,12 @@ describe("usePictureInPictureApi", () => {
     });
   });
 
-  it("detects support after a normal React ref is attached", () => {
+  it("tracks support after normal React ref attachment and replacement", () => {
     expect.hasAssertions();
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLVideoElement.prototype,
+      "requestPictureInPicture"
+    );
     Object.defineProperty(
       HTMLVideoElement.prototype,
       "requestPictureInPicture",
@@ -653,25 +689,64 @@ describe("usePictureInPictureApi", () => {
       }
     );
 
-    function TestComponent() {
-      const videoRef = useRef<HTMLVideoElement>(null);
-      const { isSupported } = usePictureInPictureApi(videoRef);
+    function TestComponent({ disabled = false }: { disabled?: boolean }) {
+      const videoRef = useRef<HTMLVideoElement | null>(null);
+      const { isPiPActive, isSupported } = usePictureInPictureApi(videoRef);
 
       return (
         <>
-          <video ref={videoRef} />
+          <video
+            data-testid="pip-video"
+            key={String(disabled)}
+            ref={(video) => {
+              if (video) {
+                video.disablePictureInPicture = disabled;
+              }
+              videoRef.current = video;
+            }}
+          />
+          <span data-testid="pip-active">{String(isPiPActive)}</span>
           <span data-testid="pip-supported">{String(isSupported)}</span>
         </>
       );
     }
 
-    render(<TestComponent />);
+    try {
+      const { rerender } = render(<TestComponent />);
 
-    expect(screen.getByTestId("pip-supported")).toHaveTextContent("true");
+      expect(screen.getByTestId("pip-supported")).toHaveTextContent("true");
+      const firstVideo = screen.getByTestId("pip-video");
 
-    delete (
-      HTMLVideoElement.prototype as Partial<HTMLVideoElement>
-    ).requestPictureInPicture;
+      rerender(<TestComponent disabled />);
+      expect(screen.getByTestId("pip-supported")).toHaveTextContent("false");
+      const replacementVideo = screen.getByTestId("pip-video");
+      expect(replacementVideo).not.toBe(firstVideo);
+
+      act(() => {
+        firstVideo.dispatchEvent(new Event("enterpictureinpicture"));
+      });
+      expect(screen.getByTestId("pip-active")).toHaveTextContent("false");
+
+      act(() => {
+        replacementVideo.dispatchEvent(new Event("enterpictureinpicture"));
+      });
+      expect(screen.getByTestId("pip-active")).toHaveTextContent("true");
+
+      rerender(<TestComponent />);
+      expect(screen.getByTestId("pip-supported")).toHaveTextContent("true");
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(
+          HTMLVideoElement.prototype,
+          "requestPictureInPicture",
+          originalDescriptor
+        );
+      } else {
+        delete (
+          HTMLVideoElement.prototype as Partial<HTMLVideoElement>
+        ).requestPictureInPicture;
+      }
+    }
   });
 
 });

--- a/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
@@ -163,4 +163,25 @@ describe("useSessionstorageState basic", () => {
     );
   });
 
+
+  it("removes the persisted value when set to undefined", () => {
+    expect.hasAssertions();
+    const removeItem = vi.spyOn(Storage.prototype, "removeItem");
+    const { result } = renderHook(() =>
+      useSessionstorageState<string | undefined>(
+        "undefined-sessionstorage",
+        "initial"
+      )
+    );
+
+    act(() => {
+      result.current[1](undefined);
+    });
+
+    expect(result.current[0]).toBeUndefined();
+    expect(removeItem).toHaveBeenCalledWith("undefined-sessionstorage");
+    expect(sessionStorage.getItem("undefined-sessionstorage")).toBeNull();
+    removeItem.mockRestore();
+  });
+
 });

--- a/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
@@ -142,4 +142,25 @@ describe("useSessionstorageState basic", () => {
     setItem.mockRestore();
   });
 
+
+  it("loads the new storage value when the key changes", () => {
+    expect.hasAssertions();
+    sessionStorage.setItem("session-key-a", JSON.stringify("value-a"));
+    sessionStorage.setItem("session-key-b", JSON.stringify("value-b"));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useSessionstorageState(storageKey, "fallback"),
+      { initialProps: { storageKey: "session-key-a" } }
+    );
+
+    expect(result.current[0]).toBe("value-a");
+
+    rerender({ storageKey: "session-key-b" });
+
+    expect(result.current[0]).toBe("value-b");
+    expect(sessionStorage.getItem("session-key-b")).toBe(
+      JSON.stringify("value-b")
+    );
+  });
+
 });

--- a/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
@@ -8,6 +8,7 @@ import {
   getByTestId,
   fireEvent,
   act,
+  renderHook,
 } from "@testing-library/react";
 
 import { useSessionstorageState } from "@/hooks/useSessionstorageState";
@@ -89,4 +90,56 @@ describe("useSessionstorageState basic", () => {
     const valueElement = getByTestId(container as HTMLElement, "value");
     expect(valueElement.innerHTML).toBe("new value");
   });
+
+  it("applies rapid functional updates without losing state", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useSessionstorageState("rapid-sessionstorage", 0)
+    );
+
+    act(() => {
+      const setValue = result.current[1];
+      setValue((current) => current + 1);
+      setValue((current) => current + 1);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(sessionStorage.getItem("rapid-sessionstorage")).toBe("2");
+  });
+
+  it("keeps the setter stable after state updates", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() =>
+      useSessionstorageState("stable-sessionstorage", 0)
+    );
+    const setValue = result.current[1];
+
+    act(() => {
+      setValue(1);
+    });
+
+    expect(result.current[1]).toBe(setValue);
+  });
+
+  it("does not write a same-document synchronized value back to storage", () => {
+    expect.hasAssertions();
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    const { result } = renderHook(() =>
+      useSessionstorageState("shared-sessionstorage", "initial")
+    );
+    setItem.mockClear();
+
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("rooks-shared-sessionstorage-sessionstorage-update", {
+          detail: { newValue: "external" },
+        })
+      );
+    });
+
+    expect(result.current[0]).toBe("external");
+    expect(setItem).not.toHaveBeenCalled();
+    setItem.mockRestore();
+  });
+
 });

--- a/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
+++ b/packages/rooks/src/__tests__/useSessionstorageState.spec.tsx
@@ -9,6 +9,7 @@ import {
   fireEvent,
   act,
   renderHook,
+  screen,
 } from "@testing-library/react";
 
 import { useSessionstorageState } from "@/hooks/useSessionstorageState";
@@ -51,7 +52,11 @@ describe("useSessionstorageState basic", () => {
     // end
   });
 
-  afterEach(cleanup);
+  afterEach(() => {
+    sessionStorage.clear();
+    cleanup();
+    vi.restoreAllMocks();
+  });
 
   it("initializes correctly", () => {
     expect.hasAssertions();
@@ -105,6 +110,29 @@ describe("useSessionstorageState basic", () => {
 
     expect(result.current[0]).toBe(2);
     expect(sessionStorage.getItem("rapid-sessionstorage")).toBe("2");
+  });
+
+  it("persists an originating update before broadcasting it", () => {
+    expect.hasAssertions();
+    const eventName = "rooks-ordered-sessionstorage-sessionstorage-update";
+    const observer = vi.fn(() =>
+      sessionStorage.getItem("ordered-sessionstorage")
+    );
+    document.addEventListener(eventName, observer);
+
+    try {
+      const { result } = renderHook(() =>
+        useSessionstorageState("ordered-sessionstorage", "initial")
+      );
+
+      act(() => {
+        result.current[1]("next");
+      });
+
+      expect(observer).toHaveReturnedWith(JSON.stringify("next"));
+    } finally {
+      document.removeEventListener(eventName, observer);
+    }
   });
 
   it("keeps the setter stable after state updates", () => {
@@ -161,6 +189,164 @@ describe("useSessionstorageState basic", () => {
     expect(sessionStorage.getItem("session-key-b")).toBe(
       JSON.stringify("value-b")
     );
+  });
+
+  it("uses the active key when an older setter reference is invoked", () => {
+    expect.hasAssertions();
+    sessionStorage.setItem("session-key-a", JSON.stringify("value-a"));
+    sessionStorage.setItem("session-key-b", JSON.stringify("value-b"));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useSessionstorageState(storageKey, "fallback"),
+      { initialProps: { storageKey: "session-key-a" } }
+    );
+    const setterFromFirstRender = result.current[1];
+
+    rerender({ storageKey: "session-key-b" });
+    act(() => {
+      setterFromFirstRender("updated-b");
+    });
+
+    expect(result.current[0]).toBe("updated-b");
+    expect(sessionStorage.getItem("session-key-a")).toBe(
+      JSON.stringify("value-a")
+    );
+    expect(sessionStorage.getItem("session-key-b")).toBe(
+      JSON.stringify("updated-b")
+    );
+  });
+
+  it("uses the committed key from a descendant layout effect", () => {
+    expect.hasAssertions();
+    sessionStorage.setItem(
+      "layout-session-key-a",
+      JSON.stringify("value-a")
+    );
+    sessionStorage.setItem(
+      "layout-session-key-b",
+      JSON.stringify("value-b")
+    );
+
+    const LayoutWriter = ({
+      enabled,
+      setValue,
+    }: {
+      enabled: boolean;
+      setValue: React.Dispatch<React.SetStateAction<string>>;
+    }) => {
+      React.useLayoutEffect(() => {
+        if (enabled) {
+          setValue((current) => `${current}-layout`);
+        }
+      }, [enabled, setValue]);
+
+      return null;
+    };
+    const Harness = ({
+      storageKey,
+      writeInLayout,
+    }: {
+      storageKey: string;
+      writeInLayout: boolean;
+    }) => {
+      const [value, setValue] = useSessionstorageState(
+        storageKey,
+        "fallback"
+      );
+
+      return (
+        <>
+          <LayoutWriter enabled={writeInLayout} setValue={setValue} />
+          <span data-testid="layout-session-value">{value}</span>
+        </>
+      );
+    };
+
+    const { rerender } = render(
+      <Harness storageKey="layout-session-key-a" writeInLayout={false} />
+    );
+    rerender(
+      <Harness storageKey="layout-session-key-b" writeInLayout={true} />
+    );
+
+    expect(screen.getByTestId("layout-session-value")).toHaveTextContent(
+      "value-b-layout"
+    );
+    expect(sessionStorage.getItem("layout-session-key-a")).toBe(
+      JSON.stringify("value-a")
+    );
+    expect(sessionStorage.getItem("layout-session-key-b")).toBe(
+      JSON.stringify("value-b-layout")
+    );
+  });
+
+  it("persists a new key after a no-op setter update", () => {
+    expect.hasAssertions();
+    sessionStorage.setItem("noop-session-key-a", JSON.stringify("same"));
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useSessionstorageState(storageKey, "fallback"),
+      { initialProps: { storageKey: "noop-session-key-a" } }
+    );
+
+    act(() => {
+      result.current[1]("same");
+    });
+    rerender({ storageKey: "noop-session-key-b" });
+
+    expect(result.current[0]).toBe("fallback");
+    expect(sessionStorage.getItem("noop-session-key-b")).toBe(
+      JSON.stringify("fallback")
+    );
+  });
+
+  it("composes same-tick updates across synchronized hook instances", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => {
+      const first = useSessionstorageState("shared-counter", 0);
+      const second = useSessionstorageState("shared-counter", 0);
+      return { first, second };
+    });
+
+    act(() => {
+      result.current.first[1](1);
+      result.current.second[1]((current) => current + 1);
+    });
+
+    expect(result.current.first[0]).toBe(2);
+    expect(result.current.second[0]).toBe(2);
+    expect(sessionStorage.getItem("shared-counter")).toBe("2");
+  });
+
+  it("keeps in-memory state when sessionStorage access is denied", () => {
+    expect.hasAssertions();
+    const descriptor = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    const accessError = new DOMException("Access denied", "SecurityError");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get: () => {
+        throw accessError;
+      },
+    });
+
+    try {
+      const { result } = renderHook(() =>
+        useSessionstorageState("denied-sessionstorage", "fallback")
+      );
+
+      expect(result.current[0]).toBe("fallback");
+      act(() => {
+        result.current[1]("memory-only");
+      });
+      expect(result.current[0]).toBe("memory-only");
+      expect(consoleError).toHaveBeenCalledWith(accessError);
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(window, "sessionStorage", descriptor);
+      }
+    }
   });
 
 

--- a/packages/rooks/src/__tests__/useSetState.spec.ts
+++ b/packages/rooks/src/__tests__/useSetState.spec.ts
@@ -176,11 +176,9 @@ describe("useSetState", () => {
 
     rerender();
 
-    // Due to the dependency on setValue, these might not be stable
-    // This test documents the current behavior
-    expect(typeof result.current[1].add).toBe("function");
-    expect(typeof result.current[1].delete).toBe("function");
-    expect(typeof result.current[1].clear).toBe("function");
+    expect(result.current[1].add).toBe(initialAdd);
+    expect(result.current[1].delete).toBe(initialDelete);
+    expect(result.current[1].clear).toBe(initialClear);
   });
 
   it("should return correct structure", () => {

--- a/packages/rooks/src/__tests__/useSetState.spec.ts
+++ b/packages/rooks/src/__tests__/useSetState.spec.ts
@@ -207,4 +207,47 @@ describe("useSetState", () => {
     expect(result.current[0]).toEqual(new Set());
     expect(result.current[0].size).toBe(0);
   });
+
+  it("does not mutate previously returned snapshots", () => {
+    expect.hasAssertions();
+    const initial = new Set([1, 2]);
+    const { result } = renderHook(() => useSetState(initial));
+    const previousSnapshot = result.current[0];
+
+    act(() => {
+      result.current[1].add(3);
+    });
+
+    expect(initial).toEqual(new Set([1, 2]));
+    expect(previousSnapshot).toEqual(new Set([1, 2]));
+    expect(result.current[0]).toEqual(new Set([1, 2, 3]));
+  });
+
+  it("preserves multiple operations in the same batch", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useSetState(new Set([1])));
+
+    act(() => {
+      result.current[1].add(2);
+      result.current[1].add(3);
+      result.current[1].delete(1);
+    });
+
+    expect(result.current[0]).toEqual(new Set([2, 3]));
+  });
+
+  it("keeps control functions stable after state changes", () => {
+    expect.hasAssertions();
+    const { result } = renderHook(() => useSetState(new Set([1])));
+    const controls = result.current[1];
+
+    act(() => {
+      controls.add(2);
+    });
+
+    expect(result.current[1].add).toBe(controls.add);
+    expect(result.current[1].delete).toBe(controls.delete);
+    expect(result.current[1].clear).toBe(controls.clear);
+  });
+
 });

--- a/packages/rooks/src/__tests__/useThrottle.spec.tsx
+++ b/packages/rooks/src/__tests__/useThrottle.spec.tsx
@@ -178,6 +178,32 @@ describe("useThrottle hook", () => {
     vi.useRealTimers();
   });
 
+  it("does not reopen until the ready state has committed", () => {
+    expect.hasAssertions();
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const { result } = renderHook(() => useThrottle(callback, TIMEOUT));
+
+    act(() => {
+      result.current[0]();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(TIMEOUT);
+      result.current[0]();
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(result.current[1]).toBe(true);
+
+    act(() => {
+      result.current[0]();
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it("keeps the throttled function stable and calls the latest callback", () => {
     expect.hasAssertions();
     vi.useFakeTimers();
@@ -199,5 +225,4 @@ describe("useThrottle hook", () => {
     expect(latestCallback).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });
-
 });

--- a/packages/rooks/src/__tests__/useThrottle.spec.tsx
+++ b/packages/rooks/src/__tests__/useThrottle.spec.tsx
@@ -1,5 +1,11 @@
 import { vi } from "vitest";
-import { cleanup, render, act, fireEvent } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  renderHook,
+  act,
+  fireEvent,
+} from "@testing-library/react";
 import React, { useState } from "react";
 import { useThrottle } from "@/hooks/useThrottle";
 
@@ -154,4 +160,44 @@ describe("useThrottle hook", () => {
     expect(Number.parseInt(throttleValue.innerHTML)).toBe(1);
     expect(Number.parseInt(throttleValueWithParameter.innerHTML)).toBe(7);
   });
+
+  it("runs at most once for synchronous calls in the same batch", () => {
+    expect.hasAssertions();
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const { result } = renderHook(() => useThrottle(callback, TIMEOUT));
+
+    act(() => {
+      result.current[0]();
+      result.current[0]();
+      result.current[0]();
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(result.current[1]).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("keeps the throttled function stable and calls the latest callback", () => {
+    expect.hasAssertions();
+    vi.useFakeTimers();
+    const firstCallback = vi.fn();
+    const latestCallback = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ callback }) => useThrottle(callback, TIMEOUT),
+      { initialProps: { callback: firstCallback } }
+    );
+    const throttled = result.current[0];
+
+    rerender({ callback: latestCallback });
+
+    expect(result.current[0]).toBe(throttled);
+    act(() => {
+      throttled();
+    });
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(latestCallback).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
 });

--- a/packages/rooks/src/hooks/useArrayState.ts
+++ b/packages/rooks/src/hooks/useArrayState.ts
@@ -69,48 +69,39 @@ function useArrayState<T>(
 ): UseArrayStateReturnValue<T> {
   const [array, setArray] = useState(initial ?? []);
 
-  const push = useCallback<Push<T>>(
-    (value) => {
-      setArray([...array, value]);
-    },
-    [array]
-  );
+  const push = useCallback<Push<T>>((...values) => {
+    setArray((currentArray) => [...currentArray, ...values]);
+  }, []);
 
   const pop = useCallback<Pop>(() => {
-    setArray(array.slice(0, array.length - 1));
-  }, [array]);
+    setArray((currentArray) => currentArray.slice(0, -1));
+  }, []);
 
   const clear = useCallback<Clear>(() => {
     setArray([]);
   }, []);
 
-  const unshift = useCallback<Unshift<T>>(
-    (value) => {
-      setArray([value, ...array]);
-    },
-    [array]
-  );
+  const unshift = useCallback<Unshift<T>>((...values) => {
+    setArray((currentArray) => [...values, ...currentArray]);
+  }, []);
 
   const shift = useCallback<Shift>(() => {
-    setArray(array.slice(1));
-  }, [array]);
+    setArray((currentArray) => currentArray.slice(1));
+  }, []);
 
   const reverse = useCallback<Reverse>(() => {
-    setArray([...array].reverse());
-  }, [array]);
+    setArray((currentArray) => [...currentArray].reverse());
+  }, []);
 
-  const concat = useCallback<Concat<T>>(
-    (value: T[]) => {
-      setArray([...array, ...value]);
-    },
-    [array]
-  );
+  const concat = useCallback<Concat<T>>((value: T[]) => {
+    setArray((currentArray) => [...currentArray, ...value]);
+  }, []);
 
   const fill = useCallback<Fill<T>>(
     (value: T, start?: number, end?: number) => {
-      setArray([...array].fill(value, start, end));
+      setArray((currentArray) => [...currentArray].fill(value, start, end));
     },
-    [array]
+    []
   );
 
   const updateItemAtIndex = useCallback(
@@ -168,12 +159,9 @@ function useArrayState<T>(
     [setArray]
   );
 
-  const sort = useCallback<Sort<T>>(
-    (compareFn) => {
-      setArray([...array].sort(compareFn));
-    },
-    [array]
-  );
+  const sort = useCallback<Sort<T>>((compareFn) => {
+    setArray((currentArray) => [...currentArray].sort(compareFn));
+  }, []);
 
   const controls = useMemo<UseArrayStateControls<T>>(() => {
     return {

--- a/packages/rooks/src/hooks/useAsyncEffect.ts
+++ b/packages/rooks/src/hooks/useAsyncEffect.ts
@@ -8,7 +8,7 @@ type CleanupFunction<T> = (result: T | void) => void;
 /**
  * A version of useEffect that accepts an async function
  *
- * @param {Effect<T>} effect Async function that can return a cleanup function and takes in an AbortSignal
+ * @param {Effect<T>} effect Async function that receives a callback indicating whether its result is still current
  * @param {DependencyList} deps If present, effect will only activate if the values in the list change
  * @param {CleanupFunction} cleanup The destroy/cleanup function. Will be called with previous result if it exists. 
  * @see https://rooks.vercel.app/docs/hooks/useAsyncEffect
@@ -39,6 +39,7 @@ function useAsyncEffect<T>(
   const lastCallId = useRef(0);
   const getIsMounted = useGetIsMounted();
   const effectRef = useFreshRef(effect);
+  const cleanupRef = useFreshRef(cleanup);
   const callback = useCallback(async (): Promise<void | T> => {
     const callId = ++lastCallId.current;
     const shouldContinueEffect = () => {
@@ -59,9 +60,9 @@ function useAsyncEffect<T>(
       result = value;
     });
     return () => {
-      cleanup?.(result);
+      cleanupRef.current?.(result);
     };
-  }, [callback, cleanup]);
+  }, [callback, cleanupRef]);
 }
 
 export { useAsyncEffect };

--- a/packages/rooks/src/hooks/useAsyncEffect.ts
+++ b/packages/rooks/src/hooks/useAsyncEffect.ts
@@ -1,5 +1,6 @@
 import { type DependencyList, useEffect, useRef, useCallback } from "react";
 import { useFreshRef } from "./useFreshRef";
+import { useFreshCallback } from "./useFreshCallback";
 import { useGetIsMounted } from "./useGetIsMounted";
 
 type Effect<T> = (shouldContinueEffect: () => boolean) => Promise<T>;
@@ -39,17 +40,15 @@ function useAsyncEffect<T>(
   const lastCallId = useRef(0);
   const getIsMounted = useGetIsMounted();
   const effectRef = useFreshRef(effect);
-  const cleanupRef = useFreshRef(cleanup);
+  const cleanupCallback = useFreshCallback((result: void | T) => {
+    cleanup?.(result);
+  });
   const callback = useCallback(async (): Promise<void | T> => {
     const callId = ++lastCallId.current;
     const shouldContinueEffect = () => {
       return getIsMounted() && callId === lastCallId.current;
     };
-    try {
-      return await effectRef.current(shouldContinueEffect);
-    } catch (error) {
-      throw error;
-    }
+    return await effectRef.current(shouldContinueEffect);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getIsMounted, ...deps]);
@@ -60,9 +59,9 @@ function useAsyncEffect<T>(
       result = value;
     });
     return () => {
-      cleanupRef.current?.(result);
+      cleanupCallback(result);
     };
-  }, [callback, cleanupRef]);
+  }, [callback, cleanupCallback]);
 }
 
 export { useAsyncEffect };

--- a/packages/rooks/src/hooks/useCountdown.ts
+++ b/packages/rooks/src/hooks/useCountdown.ts
@@ -22,13 +22,15 @@ function useCountdown(endTime: Date, options: CountdownOptions = {}): number {
   const restTime = endTime.getTime() - time.getTime();
   const count = restTime > 0 ? Math.ceil(restTime / interval) : 0;
 
-  useIntervalWhen(onTick, count ? interval : undefined, true, true);
+  useIntervalWhen(onTick, interval, count > 0, true);
 
   return count;
 
   function onTick() {
     const newTime = new Date();
-    if (newTime > endTime) {
+    const newRestTime = endTime.getTime() - newTime.getTime();
+
+    if (newRestTime <= 0) {
       if (onEnd) {
         onEnd(newTime);
       }
@@ -39,7 +41,7 @@ function useCountdown(endTime: Date, options: CountdownOptions = {}): number {
     }
 
     if (onDown) {
-      onDown(restTime, newTime);
+      onDown(newRestTime, newTime);
     }
 
     setTime(newTime);

--- a/packages/rooks/src/hooks/useCountdown.ts
+++ b/packages/rooks/src/hooks/useCountdown.ts
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useIntervalWhen } from "./useIntervalWhen";
+import { useFreshRef } from "./useFreshRef";
 
 type CountdownOptions = {
   interval?: number;
@@ -19,20 +20,35 @@ type CountdownOptions = {
 function useCountdown(endTime: Date, options: CountdownOptions = {}): number {
   const { interval = 1_000, onDown, onEnd } = options;
   const [time, setTime] = useState<Date>(() => new Date());
-  const restTime = endTime.getTime() - time.getTime();
+  const endTimeMs = endTime.getTime();
+  const restTime = endTimeMs - time.getTime();
   const count = restTime > 0 ? Math.ceil(restTime / interval) : 0;
+  const endedAtRef = useRef<number | null>(null);
+  const onEndRef = useFreshRef(onEnd);
 
   useIntervalWhen(onTick, interval, count > 0, true);
+
+  useEffect(() => {
+    if (
+      Number.isFinite(endTimeMs) &&
+      endTimeMs <= Date.now() &&
+      endedAtRef.current !== endTimeMs
+    ) {
+      endedAtRef.current = endTimeMs;
+      onEndRef.current?.(new Date());
+    }
+  }, [endTimeMs, onEndRef]);
 
   return count;
 
   function onTick() {
     const newTime = new Date();
-    const newRestTime = endTime.getTime() - newTime.getTime();
+    const newRestTime = endTimeMs - newTime.getTime();
 
     if (newRestTime <= 0) {
-      if (onEnd) {
-        onEnd(newTime);
+      if (endedAtRef.current !== endTimeMs) {
+        endedAtRef.current = endTimeMs;
+        onEnd?.(newTime);
       }
 
       setTime(endTime);

--- a/packages/rooks/src/hooks/useDebouncedAsyncEffect.ts
+++ b/packages/rooks/src/hooks/useDebouncedAsyncEffect.ts
@@ -78,12 +78,13 @@ function useDebouncedAsyncEffect<T>(
         const currentCleanup = cleanupRef.current;
 
         return () => {
-            // Cancel any pending debounced calls
+            // Invalidate running work as soon as this generation ends.
+            lastCallId.current += 1;
             debouncedAsyncCallback.cancel();
-            // Call cleanup with the result
-            if (currentCleanup) {
-                currentCleanup(resultRef.current);
-            }
+
+            const result = resultRef.current;
+            resultRef.current = undefined;
+            currentCleanup?.(result);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, deps);

--- a/packages/rooks/src/hooks/useFetch.ts
+++ b/packages/rooks/src/hooks/useFetch.ts
@@ -75,7 +75,8 @@ async function createFetchPromise<T>(
  * provides a fetch function for manual data fetching.
  *
  * Note: This hook does not cache requests - each call triggers a fresh fetch.
- * The hook does not automatically fetch on mount - use the returned fetch function.
+ * Starting a new request aborts the previous request, and unmounting aborts any
+ * active request. The hook does not automatically fetch on mount.
  *
  * @param url - The URL to fetch data from
  * @param options - Optional fetch configuration including callbacks

--- a/packages/rooks/src/hooks/useFetch.ts
+++ b/packages/rooks/src/hooks/useFetch.ts
@@ -1,5 +1,4 @@
 import { useState, useCallback, useRef, useEffect } from "react";
-import { useFreshRef } from "./useFreshRef";
 
 /**
  * HTTP error interface extending Error with status information
@@ -50,7 +49,11 @@ async function createFetchPromise<T>(
     options: UseFetchOptions<T> = {},
     signal?: AbortSignal
 ): Promise<T> {
-    const { onSuccess, onError, onFetch, ...requestOptions } = options;
+    const requestOptions = { ...options };
+    delete requestOptions.onSuccess;
+    delete requestOptions.onError;
+    delete requestOptions.onFetch;
+
     const response = await fetch(url, {
         ...requestOptions,
         signal,
@@ -75,8 +78,8 @@ async function createFetchPromise<T>(
  * provides a fetch function for manual data fetching.
  *
  * Note: This hook does not cache requests - each call triggers a fresh fetch.
- * Starting a new request aborts the previous request, and unmounting aborts any
- * active request. The hook does not automatically fetch on mount.
+ * Unmounting aborts active requests. The hook does not automatically fetch on
+ * mount.
  *
  * @param url - The URL to fetch data from
  * @param options - Optional fetch configuration including callbacks
@@ -122,34 +125,28 @@ function useFetch<T = unknown>(
     const [loading, setLoading] = useState<boolean>(false);
     const [error, setError] = useState<Error | null>(null);
     const mountedRef = useRef(true);
-    const requestIdRef = useRef(0);
-    const abortControllerRef = useRef<AbortController | null>(null);
-    const optionsRef = useFreshRef(options, true);
+    const abortControllersRef = useRef<Set<AbortController>>(new Set());
 
     const fetchData = useCallback(async () => {
         if (!mountedRef.current) return;
 
-        const requestId = ++requestIdRef.current;
-        abortControllerRef.current?.abort();
-
         const abortController = new AbortController();
-        const currentOptions = optionsRef.current;
-        abortControllerRef.current = abortController;
+        abortControllersRef.current.add(abortController);
 
         setLoading(true);
         setError(null);
-        currentOptions.onFetch?.();
+        options.onFetch?.();
 
         try {
             const result = await createFetchPromise<T>(
                 url,
-                currentOptions,
+                options,
                 abortController.signal
             );
 
-            if (mountedRef.current && requestId === requestIdRef.current) {
+            if (mountedRef.current) {
                 setData(result);
-                currentOptions.onSuccess?.(result);
+                options.onSuccess?.(result);
             }
         } catch (err) {
             const fetchError = err instanceof Error
@@ -158,28 +155,30 @@ function useFetch<T = unknown>(
 
             if (
                 mountedRef.current &&
-                requestId === requestIdRef.current &&
                 fetchError.name !== "AbortError"
             ) {
                 setError(fetchError);
-                currentOptions.onError?.(fetchError);
+                options.onError?.(fetchError);
             }
         } finally {
-            if (mountedRef.current && requestId === requestIdRef.current) {
+            abortControllersRef.current.delete(abortController);
+
+            if (mountedRef.current) {
                 setLoading(false);
-                abortControllerRef.current = null;
             }
         }
-    }, [optionsRef, url]);
+    }, [options, url]);
 
     useEffect(() => {
         mountedRef.current = true;
+        const abortControllers = abortControllersRef.current;
 
         return () => {
             mountedRef.current = false;
-            requestIdRef.current += 1;
-            abortControllerRef.current?.abort();
-            abortControllerRef.current = null;
+            for (const abortController of abortControllers) {
+                abortController.abort();
+            }
+            abortControllers.clear();
         };
     }, []);
 

--- a/packages/rooks/src/hooks/useFetch.ts
+++ b/packages/rooks/src/hooks/useFetch.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import { useFreshRef } from "./useFreshRef";
 
 /**
  * HTTP error interface extending Error with status information
@@ -44,33 +45,26 @@ interface UseFetchReturnValue<T> {
  * @param options - The fetch options
  * @returns A promise that resolves with the parsed JSON data or rejects with an error
  */
-function createFetchPromise<T>(
+async function createFetchPromise<T>(
     url: string,
-    options: UseFetchOptions<T> = {}
+    options: UseFetchOptions<T> = {},
+    signal?: AbortSignal
 ): Promise<T> {
-    return new Promise(async (resolve, reject) => {
-        try {
-            const response = await fetch(url, {
-                ...options,
-                signal: new AbortController().signal, // Add signal for compatibility
-            });
-
-            // Throw error for non-2xx responses
-            if (!response.ok) {
-                const errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-                const httpError = new Error(errorMessage) as HttpError;
-                httpError.status = response.status;
-                httpError.statusText = response.statusText;
-                throw httpError;
-            }
-
-            // Parse JSON response
-            const result = await response.json();
-            resolve(result);
-        } catch (err) {
-            reject(err instanceof Error ? err : new Error(String(err)));
-        }
+    const { onSuccess, onError, onFetch, ...requestOptions } = options;
+    const response = await fetch(url, {
+        ...requestOptions,
+        signal,
     });
+
+    if (!response.ok) {
+        const errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+        const httpError = new Error(errorMessage) as HttpError;
+        httpError.status = response.status;
+        httpError.statusText = response.statusText;
+        throw httpError;
+    }
+
+    return await response.json() as T;
 }
 
 /**
@@ -127,41 +121,64 @@ function useFetch<T = unknown>(
     const [loading, setLoading] = useState<boolean>(false);
     const [error, setError] = useState<Error | null>(null);
     const mountedRef = useRef(true);
+    const requestIdRef = useRef(0);
+    const abortControllerRef = useRef<AbortController | null>(null);
+    const optionsRef = useFreshRef(options, true);
 
     const fetchData = useCallback(async () => {
         if (!mountedRef.current) return;
 
+        const requestId = ++requestIdRef.current;
+        abortControllerRef.current?.abort();
+
+        const abortController = new AbortController();
+        const currentOptions = optionsRef.current;
+        abortControllerRef.current = abortController;
+
         setLoading(true);
         setError(null);
-
-        // Call onFetch callback
-        options.onFetch?.();
+        currentOptions.onFetch?.();
 
         try {
-            const result = await createFetchPromise<T>(url, options);
-            if (mountedRef.current) {
+            const result = await createFetchPromise<T>(
+                url,
+                currentOptions,
+                abortController.signal
+            );
+
+            if (mountedRef.current && requestId === requestIdRef.current) {
                 setData(result);
-                // Call onSuccess callback
-                options.onSuccess?.(result);
+                currentOptions.onSuccess?.(result);
             }
         } catch (err) {
-            const error = err instanceof Error ? err : new Error(String(err));
-            if (mountedRef.current) {
-                setError(error);
-                // Call onError callback
-                options.onError?.(error);
+            const fetchError = err instanceof Error
+                ? err
+                : new Error(String(err));
+
+            if (
+                mountedRef.current &&
+                requestId === requestIdRef.current &&
+                fetchError.name !== "AbortError"
+            ) {
+                setError(fetchError);
+                currentOptions.onError?.(fetchError);
             }
         } finally {
-            if (mountedRef.current) {
+            if (mountedRef.current && requestId === requestIdRef.current) {
                 setLoading(false);
+                abortControllerRef.current = null;
             }
         }
-    }, [url, options]);
+    }, [optionsRef, url]);
 
-    // Cleanup on unmount
     useEffect(() => {
+        mountedRef.current = true;
+
         return () => {
             mountedRef.current = false;
+            requestIdRef.current += 1;
+            abortControllerRef.current?.abort();
+            abortControllerRef.current = null;
         };
     }, []);
 

--- a/packages/rooks/src/hooks/useFetch.ts
+++ b/packages/rooks/src/hooks/useFetch.ts
@@ -79,7 +79,9 @@ async function createFetchPromise<T>(
  *
  * Note: This hook does not cache requests - each call triggers a fresh fetch.
  * Unmounting aborts active requests. The hook does not automatically fetch on
- * mount.
+ * mount. The returned startFetch function is bound to the URL and options
+ * object from its render, so memoize options before using startFetch as an
+ * effect dependency.
  *
  * @param url - The URL to fetch data from
  * @param options - Optional fetch configuration including callbacks
@@ -88,14 +90,16 @@ async function createFetchPromise<T>(
  * @example
  * ```tsx
  * function UserProfile({ userId }: { userId: string }) {
+ *   const fetchOptions = useMemo(() => ({
+ *     headers: { 'Authorization': 'Bearer token' },
+ *     onSuccess: (data: User) => console.log('User loaded:', data),
+ *     onError: (error: Error) => console.error('Failed to load user:', error),
+ *     onFetch: () => console.log('Fetching user data...')
+ *   }), []);
+ *
  *   const { data: user, loading, error, startFetch } = useFetch<User>(
  *     `https://api.example.com/users/${userId}`,
- *     {
- *       headers: { 'Authorization': 'Bearer token' },
- *       onSuccess: (data) => console.log('User loaded:', data),
- *       onError: (error) => console.error('Failed to load user:', error),
- *       onFetch: () => console.log('Fetching user data...')
- *     }
+ *     fetchOptions
  *   );
  *
  *   // Fetch data when component mounts or when needed
@@ -125,26 +129,40 @@ function useFetch<T = unknown>(
     const [loading, setLoading] = useState<boolean>(false);
     const [error, setError] = useState<Error | null>(null);
     const mountedRef = useRef(true);
+    const mountGenerationRef = useRef(0);
     const abortControllersRef = useRef<Set<AbortController>>(new Set());
 
     const fetchData = useCallback(async () => {
         if (!mountedRef.current) return;
-
-        const abortController = new AbortController();
-        abortControllersRef.current.add(abortController);
+        const mountGeneration = mountGenerationRef.current;
 
         setLoading(true);
         setError(null);
         options.onFetch?.();
 
+        if (
+            !mountedRef.current ||
+            mountGeneration !== mountGenerationRef.current
+        ) {
+            return;
+        }
+
+        let abortController: AbortController | null = null;
+        const canCommitResult = () =>
+            mountedRef.current &&
+            mountGeneration === mountGenerationRef.current &&
+            !abortController?.signal.aborted;
+
         try {
+            abortController = new AbortController();
+            abortControllersRef.current.add(abortController);
             const result = await createFetchPromise<T>(
                 url,
                 options,
                 abortController.signal
             );
 
-            if (mountedRef.current) {
+            if (canCommitResult()) {
                 setData(result);
                 options.onSuccess?.(result);
             }
@@ -153,17 +171,16 @@ function useFetch<T = unknown>(
                 ? err
                 : new Error(String(err));
 
-            if (
-                mountedRef.current &&
-                fetchError.name !== "AbortError"
-            ) {
+            if (canCommitResult()) {
                 setError(fetchError);
                 options.onError?.(fetchError);
             }
         } finally {
-            abortControllersRef.current.delete(abortController);
+            if (abortController) {
+                abortControllersRef.current.delete(abortController);
+            }
 
-            if (mountedRef.current) {
+            if (canCommitResult()) {
                 setLoading(false);
             }
         }
@@ -175,6 +192,7 @@ function useFetch<T = unknown>(
 
         return () => {
             mountedRef.current = false;
+            mountGenerationRef.current += 1;
             for (const abortController of abortControllers) {
                 abortController.abort();
             }

--- a/packages/rooks/src/hooks/useFileDropRef.ts
+++ b/packages/rooks/src/hooks/useFileDropRef.ts
@@ -44,10 +44,6 @@ function useFileDropRef(
   const freshOnDragEnter = useFreshCallback(onDragEnter);
   const freshOnDragLeave = useFreshCallback(onDragLeave);
 
-  useCallback((node: HTMLElement | null) => {
-    setTargetNode(node);
-  }, []);
-
   const fileIsValid = useCallback(
     (file: File): { valid: boolean; reason?: string } => {
       if (accept && !accept.includes(file.type)) {
@@ -72,6 +68,7 @@ function useFileDropRef(
 
       if (maxFiles && files.length > maxFiles) {
         for (const file of files) {
+          rejectedFiles.push(file);
           freshOnFileRejected(file, "Exceeded maximum number of files");
         }
       } else {

--- a/packages/rooks/src/hooks/useFileDropRef.ts
+++ b/packages/rooks/src/hooks/useFileDropRef.ts
@@ -50,7 +50,7 @@ function useFileDropRef(
         return { valid: false, reason: "File type not allowed" };
       }
 
-      if (maxFileSize && file.size > maxFileSize) {
+      if (maxFileSize !== undefined && file.size > maxFileSize) {
         return { valid: false, reason: "File size exceeds the limit" };
       }
 
@@ -66,7 +66,7 @@ function useFileDropRef(
       const acceptedFiles: File[] = [];
       const rejectedFiles: File[] = [];
 
-      if (maxFiles && files.length > maxFiles) {
+      if (maxFiles !== undefined && files.length > maxFiles) {
         for (const file of files) {
           rejectedFiles.push(file);
           freshOnFileRejected(file, "Exceeded maximum number of files");

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -75,6 +75,15 @@ function useLocalstorageState<S>(
   initialState?: S | (() => S)
 ): UseLocalstorageStateReturnValue<S> {
   const [value, setValue] = useState(() => initialize(key, initialState));
+  const currentValue = useFreshRef(value, true);
+  const currentKey = useRef(key);
+
+  if (currentKey.current !== key) {
+    currentKey.current = key;
+    const nextValue = initialize(key, initialState);
+    currentValue.current = nextValue;
+    setValue(nextValue);
+  }
   const isUpdateFromCrossDocumentListener = useRef(false);
   const isUpdateFromWithinDocumentListener = useRef(false);
   const customEventTypeName = useMemo(() => {
@@ -184,8 +193,6 @@ function useLocalstorageState<S>(
     },
     [customEventTypeName]
   );
-
-  const currentValue = useFreshRef(value, true);
 
   const set = useCallback(
     (newValue: SetStateAction<S>) => {

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -201,8 +201,9 @@ function useLocalstorageState<S>(
           ? (newValue as (prevState: S) => S)(currentValue.current)
           : newValue;
       isUpdateFromCrossDocumentListener.current = false;
-      isUpdateFromWithinDocumentListener.current = false;
+      isUpdateFromWithinDocumentListener.current = true;
       currentValue.current = resolvedNewValue;
+      saveValueToLocalStorage<S>(key, resolvedNewValue);
       setValue(resolvedNewValue);
       broadcastValueWithinDocument(resolvedNewValue);
     },

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -195,6 +195,7 @@ function useLocalstorageState<S>(
           : newValue;
       isUpdateFromCrossDocumentListener.current = false;
       isUpdateFromWithinDocumentListener.current = false;
+      currentValue.current = resolvedNewValue;
       setValue(resolvedNewValue);
       broadcastValueWithinDocument(resolvedNewValue);
     },

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -114,7 +114,7 @@ function useLocalstorageState<S>(
         try {
           isUpdateFromCrossDocumentListener.current = true;
           const newValue = JSON.parse(event.newValue ?? "null");
-          setValue((currentValue) =>
+          setValue((currentValue: S) =>
             Object.is(currentValue, newValue) ? currentValue : newValue
           );
         } catch (error) {
@@ -148,7 +148,7 @@ function useLocalstorageState<S>(
       try {
         isUpdateFromWithinDocumentListener.current = true;
         const { newValue } = event.detail;
-        setValue((currentValue) =>
+        setValue((currentValue: S) =>
           Object.is(currentValue, newValue) ? currentValue : newValue
         );
       } catch (error) {

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -8,14 +8,19 @@ function getValueFromLocalStorage(key: string) {
     return null;
   }
 
-  const storedValue = localStorage.getItem(key) ?? "null";
   try {
-    return JSON.parse(storedValue);
+    const storedValue = localStorage.getItem(key) ?? "null";
+
+    try {
+      return JSON.parse(storedValue);
+    } catch (error) {
+      console.error(error);
+      return storedValue;
+    }
   } catch (error) {
     console.error(error);
+    return null;
   }
-
-  return storedValue;
 }
 
 // Saves value to localstorage
@@ -24,11 +29,16 @@ function saveValueToLocalStorage<S>(key: string, value: S) {
     return null;
   }
 
-  if (value === undefined) {
-    return localStorage.removeItem(key);
-  }
+  try {
+    if (value === undefined) {
+      return localStorage.removeItem(key);
+    }
 
-  return localStorage.setItem(key, JSON.stringify(value));
+    return localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
 }
 
 /**
@@ -79,11 +89,14 @@ function useLocalstorageState<S>(
      * storage event
      */
     if (
-      !isUpdateFromCrossDocumentListener.current ||
+      !isUpdateFromCrossDocumentListener.current &&
       !isUpdateFromWithinDocumentListener.current
     ) {
       saveValueToLocalStorage<S>(key, value);
     }
+
+    isUpdateFromCrossDocumentListener.current = false;
+    isUpdateFromWithinDocumentListener.current = false;
   }, [key, value]);
 
   const listenToCrossDocumentStorageEvents = useCallback(
@@ -92,15 +105,15 @@ function useLocalstorageState<S>(
         try {
           isUpdateFromCrossDocumentListener.current = true;
           const newValue = JSON.parse(event.newValue ?? "null");
-          if (value !== newValue) {
-            setValue(newValue);
-          }
+          setValue((currentValue) =>
+            Object.is(currentValue, newValue) ? currentValue : newValue
+          );
         } catch (error) {
           console.log(error);
         }
       }
     },
-    [key, value]
+    [key]
   );
 
   // check for changes across documents
@@ -126,14 +139,14 @@ function useLocalstorageState<S>(
       try {
         isUpdateFromWithinDocumentListener.current = true;
         const { newValue } = event.detail;
-        if (value !== newValue) {
-          setValue(newValue);
-        }
+        setValue((currentValue) =>
+          Object.is(currentValue, newValue) ? currentValue : newValue
+        );
       } catch (error) {
         console.log(error);
       }
     },
-    [value]
+    []
   );
 
   // check for changes within document
@@ -189,7 +202,11 @@ function useLocalstorageState<S>(
   );
 
   const remove = useCallback(() => {
-    localStorage.removeItem(key);
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.error(error);
+    }
   }, [key]);
 
   return [value, set, remove];

--- a/packages/rooks/src/hooks/useLocalstorageState.ts
+++ b/packages/rooks/src/hooks/useLocalstorageState.ts
@@ -1,14 +1,20 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useMemo, useState, useEffect, useCallback, useRef } from "react";
-import { useFreshRef } from "./useFreshRef";
+import {
+  useMemo,
+  useState,
+  useEffect,
+  useCallback,
+  useInsertionEffect,
+  useRef,
+} from "react";
 
 // Gets value from localstorage
 function getValueFromLocalStorage(key: string) {
-  if (typeof localStorage === "undefined") {
-    return null;
-  }
-
   try {
+    if (typeof localStorage === "undefined") {
+      return null;
+    }
+
     const storedValue = localStorage.getItem(key) ?? "null";
 
     try {
@@ -25,11 +31,11 @@ function getValueFromLocalStorage(key: string) {
 
 // Saves value to localstorage
 function saveValueToLocalStorage<S>(key: string, value: S) {
-  if (typeof localStorage === "undefined") {
-    return null;
-  }
-
   try {
+    if (typeof localStorage === "undefined") {
+      return null;
+    }
+
     if (value === undefined) {
       return localStorage.removeItem(key);
     }
@@ -75,17 +81,22 @@ function useLocalstorageState<S>(
   initialState?: S | (() => S)
 ): UseLocalstorageStateReturnValue<S> {
   const [value, setValue] = useState(() => initialize(key, initialState));
-  const currentValue = useFreshRef(value, true);
-  const currentKey = useRef(key);
+  const [stateKey, setStateKey] = useState(key);
+  const currentValueRef = useRef(value);
+  const currentKeyRef = useRef(key);
 
-  if (currentKey.current !== key) {
-    currentKey.current = key;
-    const nextValue = initialize(key, initialState);
-    currentValue.current = nextValue;
-    setValue(nextValue);
+  useInsertionEffect(() => {
+    currentValueRef.current = value;
+    currentKeyRef.current = key;
+  }, [key, value]);
+
+  if (stateKey !== key) {
+    setStateKey(key);
+    setValue(initialize(key, initialState));
   }
   const isUpdateFromCrossDocumentListener = useRef(false);
   const isUpdateFromWithinDocumentListener = useRef(false);
+  const updateSourceKeyRef = useRef<string | null>(null);
   const customEventTypeName = useMemo(() => {
     return `rooks-${key}-localstorage-update`;
   }, [key]);
@@ -97,32 +108,39 @@ function useLocalstorageState<S>(
      * to keep track of whether setValue is from another
      * storage event
      */
-    if (
-      !isUpdateFromCrossDocumentListener.current &&
-      !isUpdateFromWithinDocumentListener.current
-    ) {
+    const cameFromSynchronizedUpdate =
+      (isUpdateFromCrossDocumentListener.current ||
+        isUpdateFromWithinDocumentListener.current) &&
+      updateSourceKeyRef.current === key;
+
+    if (!cameFromSynchronizedUpdate) {
       saveValueToLocalStorage<S>(key, value);
     }
 
     isUpdateFromCrossDocumentListener.current = false;
     isUpdateFromWithinDocumentListener.current = false;
+    updateSourceKeyRef.current = null;
   }, [key, value]);
 
   const listenToCrossDocumentStorageEvents = useCallback(
     (event: StorageEvent) => {
-      if (event.storageArea === localStorage && event.key === key) {
-        try {
-          isUpdateFromCrossDocumentListener.current = true;
+      try {
+        if (event.storageArea === localStorage && event.key === key) {
           const newValue = JSON.parse(event.newValue ?? "null");
+          isUpdateFromCrossDocumentListener.current = true;
+          updateSourceKeyRef.current = key;
+          currentValueRef.current = newValue;
           setValue((currentValue: S) =>
             Object.is(currentValue, newValue) ? currentValue : newValue
           );
-        } catch (error) {
-          console.log(error);
         }
+      } catch (error) {
+        isUpdateFromCrossDocumentListener.current = false;
+        updateSourceKeyRef.current = null;
+        console.log(error);
       }
     },
-    [key]
+    [currentValueRef, key]
   );
 
   // check for changes across documents
@@ -146,16 +164,20 @@ function useLocalstorageState<S>(
   const listenToCustomEventWithinDocument = useCallback(
     (event: BroadcastCustomEvent<S>) => {
       try {
-        isUpdateFromWithinDocumentListener.current = true;
         const { newValue } = event.detail;
+        isUpdateFromWithinDocumentListener.current = true;
+        updateSourceKeyRef.current = key;
+        currentValueRef.current = newValue;
         setValue((currentValue: S) =>
           Object.is(currentValue, newValue) ? currentValue : newValue
         );
       } catch (error) {
+        isUpdateFromWithinDocumentListener.current = false;
+        updateSourceKeyRef.current = null;
         console.log(error);
       }
     },
-    []
+    [currentValueRef, key]
   );
 
   // check for changes within document
@@ -180,10 +202,10 @@ function useLocalstorageState<S>(
   }, [customEventTypeName, listenToCustomEventWithinDocument]);
 
   const broadcastValueWithinDocument = useCallback(
-    (newValue: S) => {
+    (storageKey: string, newValue: S) => {
       if (typeof document !== "undefined") {
         const event: BroadcastCustomEvent<S> = new CustomEvent(
-          customEventTypeName,
+          `rooks-${storageKey}-localstorage-update`,
           { detail: { newValue } }
         );
         document.dispatchEvent(event);
@@ -191,23 +213,25 @@ function useLocalstorageState<S>(
         console.warn("[useLocalstorageState] document is undefined.");
       }
     },
-    [customEventTypeName]
+    []
   );
 
   const set = useCallback(
     (newValue: SetStateAction<S>) => {
       const resolvedNewValue =
         typeof newValue === "function"
-          ? (newValue as (prevState: S) => S)(currentValue.current)
+          ? (newValue as (prevState: S) => S)(currentValueRef.current)
           : newValue;
+      const storageKey = currentKeyRef.current;
       isUpdateFromCrossDocumentListener.current = false;
       isUpdateFromWithinDocumentListener.current = true;
-      currentValue.current = resolvedNewValue;
-      saveValueToLocalStorage<S>(key, resolvedNewValue);
+      updateSourceKeyRef.current = storageKey;
+      currentValueRef.current = resolvedNewValue;
+      saveValueToLocalStorage<S>(storageKey, resolvedNewValue);
       setValue(resolvedNewValue);
-      broadcastValueWithinDocument(resolvedNewValue);
+      broadcastValueWithinDocument(storageKey, resolvedNewValue);
     },
-    [broadcastValueWithinDocument, currentValue]
+    [broadcastValueWithinDocument, currentKeyRef, currentValueRef]
   );
 
   const remove = useCallback(() => {

--- a/packages/rooks/src/hooks/useMapState.ts
+++ b/packages/rooks/src/hooks/useMapState.ts
@@ -36,7 +36,7 @@ function useMapState<
 
   const has = useCallback(
     (key: K) => {
-      return typeof map[key] !== "undefined";
+      return Object.prototype.hasOwnProperty.call(map, key);
     },
     [map]
   );
@@ -79,12 +79,8 @@ function useMapState<
   const removeAll = useCallback(() => {
     setMap((currentMap) => {
       const nextMap = { ...currentMap };
-      for (const key in nextMap) {
-        // eslint-disable-next-line no-prototype-builtins
-        if (nextMap.hasOwnProperty(key)) {
-
-          delete nextMap[key];
-        }
+      for (const key of Object.keys(nextMap)) {
+        delete nextMap[key];
       }
 
       return nextMap;

--- a/packages/rooks/src/hooks/useMapState.ts
+++ b/packages/rooks/src/hooks/useMapState.ts
@@ -36,7 +36,7 @@ function useMapState<
 
   const has = useCallback(
     (key: K) => {
-      return Object.prototype.hasOwnProperty.call(map, key);
+      return typeof map[key] !== "undefined";
     },
     [map]
   );

--- a/packages/rooks/src/hooks/useOnline.ts
+++ b/packages/rooks/src/hooks/useOnline.ts
@@ -36,7 +36,11 @@ function subscribe(onStoreChange: () => void): () => void {
  * @see https://rooks.vercel.app/docs/hooks/useOnline
  */
 function useOnline(): boolean | null {
-  const isOnline = useSyncExternalStore<boolean | null>(subscribe, getSnapshot);
+  const isOnline = useSyncExternalStore<boolean | null>(
+    subscribe,
+    getSnapshot,
+    () => null
+  );
 
   return isOnline;
 }

--- a/packages/rooks/src/hooks/usePictureInPictureApi.ts
+++ b/packages/rooks/src/hooks/usePictureInPictureApi.ts
@@ -19,11 +19,12 @@ type PictureInPictureApi = {
  */
 function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureInPictureApi {
   const [isPiPActive, setIsPiPActive] = useState(false);
+  const [isSupported, setIsSupported] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [pipWindow, setPipWindow] = useState<PictureInPictureWindow | null>(null);
 
   // Check if Picture-in-Picture is supported (reactive)
-  const isSupported = useCallback((): boolean => {
+  const getIsSupported = useCallback((): boolean => {
     if (!videoRef.current) return false;
     if (!document.pictureInPictureEnabled) return false;
     if (!videoRef.current.requestPictureInPicture) return false;
@@ -43,7 +44,7 @@ function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureI
 
   // Enter Picture-in-Picture mode
   const enterPiP = useCallback(async (): Promise<void> => {
-    if (!isSupported() || !videoRef.current) {
+    if (!getIsSupported() || !videoRef.current) {
       return;
     }
 
@@ -54,7 +55,7 @@ function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureI
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)));
     }
-  }, [isSupported, videoRef]);
+  }, [getIsSupported, videoRef]);
 
   // Exit Picture-in-Picture mode
   const exitPiP = useCallback(async (): Promise<void> => {
@@ -96,8 +97,12 @@ function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureI
   // Set up event listeners and handle video element changes
   useEffect(() => {
     const video = videoRef.current;
-    if (!video) return;
+    if (!video) {
+      setIsSupported(false);
+      return;
+    }
 
+    setIsSupported(getIsSupported());
     video.addEventListener("enterpictureinpicture", handleEnterPiP);
     video.addEventListener("leavepictureinpicture", handleLeavePiP);
 
@@ -108,11 +113,17 @@ function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureI
       video.removeEventListener("enterpictureinpicture", handleEnterPiP);
       video.removeEventListener("leavepictureinpicture", handleLeavePiP);
     };
-  }, [videoRef.current, handleEnterPiP, handleLeavePiP, updatePiPState]);
+  }, [
+    videoRef.current,
+    getIsSupported,
+    handleEnterPiP,
+    handleLeavePiP,
+    updatePiPState,
+  ]);
 
   return {
     isPiPActive,
-    isSupported: isSupported(),
+    isSupported: isSupported && getIsSupported(),
     error,
     pipWindow,
     enterPiP,

--- a/packages/rooks/src/hooks/usePictureInPictureApi.ts
+++ b/packages/rooks/src/hooks/usePictureInPictureApi.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState, RefObject } from "react";
+import { useCallback, useEffect, useRef, useState, RefObject } from "react";
+import { useIsomorphicEffect } from "./useIsomorphicEffect";
 
 type PictureInPictureApi = {
   isPiPActive: boolean;
@@ -22,6 +23,7 @@ function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureI
   const [isSupported, setIsSupported] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [pipWindow, setPipWindow] = useState<PictureInPictureWindow | null>(null);
+  const attachedVideoRef = useRef<HTMLVideoElement | null>(null);
 
   // Check if Picture-in-Picture is supported (reactive)
   const getIsSupported = useCallback((): boolean => {
@@ -94,36 +96,53 @@ function usePictureInPictureApi(videoRef: RefObject<HTMLVideoElement>): PictureI
     setIsPiPActive(false);
   }, []);
 
-  // Set up event listeners and handle video element changes
-  useEffect(() => {
+  // Reconcile after refs have been committed. RefObject.current can change
+  // without the RefObject identity changing.
+  useIsomorphicEffect(() => {
     const video = videoRef.current;
-    if (!video) {
-      setIsSupported(false);
+    const nextIsSupported = getIsSupported();
+    setIsSupported((current) =>
+      current === nextIsSupported ? current : nextIsSupported
+    );
+
+    if (attachedVideoRef.current === video) {
       return;
     }
 
-    setIsSupported(getIsSupported());
-    video.addEventListener("enterpictureinpicture", handleEnterPiP);
-    video.addEventListener("leavepictureinpicture", handleLeavePiP);
+    attachedVideoRef.current?.removeEventListener(
+      "enterpictureinpicture",
+      handleEnterPiP
+    );
+    attachedVideoRef.current?.removeEventListener(
+      "leavepictureinpicture",
+      handleLeavePiP
+    );
+    attachedVideoRef.current = video;
 
-    // Initialize PiP state
-    updatePiPState();
+    if (video) {
+      video.addEventListener("enterpictureinpicture", handleEnterPiP);
+      video.addEventListener("leavepictureinpicture", handleLeavePiP);
+      updatePiPState();
+    }
+  });
 
+  useEffect(() => {
     return () => {
-      video.removeEventListener("enterpictureinpicture", handleEnterPiP);
-      video.removeEventListener("leavepictureinpicture", handleLeavePiP);
+      attachedVideoRef.current?.removeEventListener(
+        "enterpictureinpicture",
+        handleEnterPiP
+      );
+      attachedVideoRef.current?.removeEventListener(
+        "leavepictureinpicture",
+        handleLeavePiP
+      );
+      attachedVideoRef.current = null;
     };
-  }, [
-    videoRef.current,
-    getIsSupported,
-    handleEnterPiP,
-    handleLeavePiP,
-    updatePiPState,
-  ]);
+  }, [handleEnterPiP, handleLeavePiP]);
 
   return {
     isPiPActive,
-    isSupported: isSupported && getIsSupported(),
+    isSupported,
     error,
     pipWindow,
     enterPiP,

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -1,19 +1,25 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
+import { useFreshRef } from "./useFreshRef";
 
 function getValueFromSessionStorage(key: string) {
   if (typeof sessionStorage === "undefined") {
     return null;
   }
 
-  const storedValue = sessionStorage.getItem(key) ?? "null";
   try {
-    return JSON.parse(storedValue);
+    const storedValue = sessionStorage.getItem(key) ?? "null";
+
+    try {
+      return JSON.parse(storedValue);
+    } catch (error) {
+      console.error(error);
+      return storedValue;
+    }
   } catch (error) {
     console.error(error);
+    return null;
   }
-
-  return storedValue;
 }
 
 function saveValueToSessionStorage<S>(key: string, value: S) {
@@ -21,7 +27,12 @@ function saveValueToSessionStorage<S>(key: string, value: S) {
     return null;
   }
 
-  return sessionStorage.setItem(key, JSON.stringify(value));
+  try {
+    return sessionStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
 }
 
 /**
@@ -72,9 +83,15 @@ function useSessionstorageState<S>(
      * to keep track of whether setValue is from another
      * storage event
      */
-    if (!isUpdateFromCrossDocumentListener.current) {
+    if (
+      !isUpdateFromCrossDocumentListener.current &&
+      !isUpdateFromWithinDocumentListener.current
+    ) {
       saveValueToSessionStorage(key, value);
     }
+
+    isUpdateFromCrossDocumentListener.current = false;
+    isUpdateFromWithinDocumentListener.current = false;
   }, [key, value]);
 
   const listenToCrossDocumentStorageEvents = useCallback(
@@ -83,15 +100,15 @@ function useSessionstorageState<S>(
         try {
           isUpdateFromCrossDocumentListener.current = true;
           const newValue = JSON.parse(event.newValue ?? "null");
-          if (value !== newValue) {
-            setValue(newValue);
-          }
+          setValue((currentValue) =>
+            Object.is(currentValue, newValue) ? currentValue : newValue
+          );
         } catch (error) {
           console.log(error);
         }
       }
     },
-    [key, value]
+    [key]
   );
 
   // check for changes across windows
@@ -118,14 +135,14 @@ function useSessionstorageState<S>(
       try {
         isUpdateFromWithinDocumentListener.current = true;
         const { newValue } = event.detail;
-        if (value !== newValue) {
-          setValue(newValue);
-        }
+        setValue((currentValue) =>
+          Object.is(currentValue, newValue) ? currentValue : newValue
+        );
       } catch (error) {
         console.log(error);
       }
     },
-    [value]
+    []
   );
 
   // check for changes within document
@@ -166,21 +183,27 @@ function useSessionstorageState<S>(
     [customEventTypeName]
   );
 
+  const currentValue = useFreshRef(value, true);
+
   const set = useCallback(
     (newValue: SetStateAction<S>) => {
       const resolvedNewValue = typeof newValue === "function"
-        ? (newValue as (prevState: S) => S)(value)
+        ? (newValue as (prevState: S) => S)(currentValue.current)
         : newValue;
       isUpdateFromCrossDocumentListener.current = false;
       isUpdateFromWithinDocumentListener.current = false;
       setValue(resolvedNewValue);
       broadcastValueWithinDocument(resolvedNewValue);
     },
-    [broadcastValueWithinDocument, value]
+    [broadcastValueWithinDocument, currentValue]
   );
 
   const remove = useCallback(() => {
-    sessionStorage.removeItem(key);
+    try {
+      sessionStorage.removeItem(key);
+    } catch (error) {
+      console.error(error);
+    }
   }, [key]);
 
   return [value, set, remove];

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -109,7 +109,7 @@ function useSessionstorageState<S>(
         try {
           isUpdateFromCrossDocumentListener.current = true;
           const newValue = JSON.parse(event.newValue ?? "null");
-          setValue((currentValue) =>
+          setValue((currentValue: S) =>
             Object.is(currentValue, newValue) ? currentValue : newValue
           );
         } catch (error) {
@@ -144,7 +144,7 @@ function useSessionstorageState<S>(
       try {
         isUpdateFromWithinDocumentListener.current = true;
         const { newValue } = event.detail;
-        setValue((currentValue) =>
+        setValue((currentValue: S) =>
           Object.is(currentValue, newValue) ? currentValue : newValue
         );
       } catch (error) {

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -202,8 +202,9 @@ function useSessionstorageState<S>(
         ? (newValue as (prevState: S) => S)(currentValue.current)
         : newValue;
       isUpdateFromCrossDocumentListener.current = false;
-      isUpdateFromWithinDocumentListener.current = false;
+      isUpdateFromWithinDocumentListener.current = true;
       currentValue.current = resolvedNewValue;
+      saveValueToSessionStorage<S>(key, resolvedNewValue);
       setValue(resolvedNewValue);
       broadcastValueWithinDocument(resolvedNewValue);
     },

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -71,6 +71,15 @@ function useSessionstorageState<S>(
   initialState?: S | (() => S)
 ): UseSessionstorageStateReturnValue<S> {
   const [value, setValue] = useState(() => initialize(key, initialState));
+  const currentValue = useFreshRef(value, true);
+  const currentKey = useRef(key);
+
+  if (currentKey.current !== key) {
+    currentKey.current = key;
+    const nextValue = initialize(key, initialState);
+    currentValue.current = nextValue;
+    setValue(nextValue);
+  }
   const isUpdateFromCrossDocumentListener = useRef(false);
   const isUpdateFromWithinDocumentListener = useRef(false);
   const customEventTypeName = useMemo(() => {
@@ -182,8 +191,6 @@ function useSessionstorageState<S>(
     },
     [customEventTypeName]
   );
-
-  const currentValue = useFreshRef(value, true);
 
   const set = useCallback(
     (newValue: SetStateAction<S>) => {

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -1,13 +1,19 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useMemo, useState, useEffect, useCallback, useRef } from "react";
-import { useFreshRef } from "./useFreshRef";
+import {
+  useMemo,
+  useState,
+  useEffect,
+  useCallback,
+  useInsertionEffect,
+  useRef,
+} from "react";
 
 function getValueFromSessionStorage(key: string) {
-  if (typeof sessionStorage === "undefined") {
-    return null;
-  }
-
   try {
+    if (typeof sessionStorage === "undefined") {
+      return null;
+    }
+
     const storedValue = sessionStorage.getItem(key) ?? "null";
 
     try {
@@ -23,11 +29,11 @@ function getValueFromSessionStorage(key: string) {
 }
 
 function saveValueToSessionStorage<S>(key: string, value: S) {
-  if (typeof sessionStorage === "undefined") {
-    return null;
-  }
-
   try {
+    if (typeof sessionStorage === "undefined") {
+      return null;
+    }
+
     if (value === undefined) {
       return sessionStorage.removeItem(key);
     }
@@ -75,17 +81,22 @@ function useSessionstorageState<S>(
   initialState?: S | (() => S)
 ): UseSessionstorageStateReturnValue<S> {
   const [value, setValue] = useState(() => initialize(key, initialState));
-  const currentValue = useFreshRef(value, true);
-  const currentKey = useRef(key);
+  const [stateKey, setStateKey] = useState(key);
+  const currentValueRef = useRef(value);
+  const currentKeyRef = useRef(key);
 
-  if (currentKey.current !== key) {
-    currentKey.current = key;
-    const nextValue = initialize(key, initialState);
-    currentValue.current = nextValue;
-    setValue(nextValue);
+  useInsertionEffect(() => {
+    currentValueRef.current = value;
+    currentKeyRef.current = key;
+  }, [key, value]);
+
+  if (stateKey !== key) {
+    setStateKey(key);
+    setValue(initialize(key, initialState));
   }
   const isUpdateFromCrossDocumentListener = useRef(false);
   const isUpdateFromWithinDocumentListener = useRef(false);
+  const updateSourceKeyRef = useRef<string | null>(null);
   const customEventTypeName = useMemo(() => {
     return `rooks-${key}-sessionstorage-update`;
   }, [key]);
@@ -96,32 +107,39 @@ function useSessionstorageState<S>(
      * to keep track of whether setValue is from another
      * storage event
      */
-    if (
-      !isUpdateFromCrossDocumentListener.current &&
-      !isUpdateFromWithinDocumentListener.current
-    ) {
+    const cameFromSynchronizedUpdate =
+      (isUpdateFromCrossDocumentListener.current ||
+        isUpdateFromWithinDocumentListener.current) &&
+      updateSourceKeyRef.current === key;
+
+    if (!cameFromSynchronizedUpdate) {
       saveValueToSessionStorage(key, value);
     }
 
     isUpdateFromCrossDocumentListener.current = false;
     isUpdateFromWithinDocumentListener.current = false;
+    updateSourceKeyRef.current = null;
   }, [key, value]);
 
   const listenToCrossDocumentStorageEvents = useCallback(
     (event: StorageEvent) => {
-      if (event.storageArea === sessionStorage && event.key === key) {
-        try {
-          isUpdateFromCrossDocumentListener.current = true;
+      try {
+        if (event.storageArea === sessionStorage && event.key === key) {
           const newValue = JSON.parse(event.newValue ?? "null");
+          isUpdateFromCrossDocumentListener.current = true;
+          updateSourceKeyRef.current = key;
+          currentValueRef.current = newValue;
           setValue((currentValue: S) =>
             Object.is(currentValue, newValue) ? currentValue : newValue
           );
-        } catch (error) {
-          console.log(error);
         }
+      } catch (error) {
+        isUpdateFromCrossDocumentListener.current = false;
+        updateSourceKeyRef.current = null;
+        console.log(error);
       }
     },
-    [key]
+    [currentValueRef, key]
   );
 
   // check for changes across windows
@@ -146,16 +164,20 @@ function useSessionstorageState<S>(
   const listenToCustomEventWithinDocument = useCallback(
     (event: BroadcastCustomEvent<S>) => {
       try {
-        isUpdateFromWithinDocumentListener.current = true;
         const { newValue } = event.detail;
+        isUpdateFromWithinDocumentListener.current = true;
+        updateSourceKeyRef.current = key;
+        currentValueRef.current = newValue;
         setValue((currentValue: S) =>
           Object.is(currentValue, newValue) ? currentValue : newValue
         );
       } catch (error) {
+        isUpdateFromWithinDocumentListener.current = false;
+        updateSourceKeyRef.current = null;
         console.log(error);
       }
     },
-    []
+    [currentValueRef, key]
   );
 
   // check for changes within document
@@ -181,11 +203,11 @@ function useSessionstorageState<S>(
   }, [customEventTypeName, listenToCustomEventWithinDocument]);
 
   const broadcastValueWithinDocument = useCallback(
-    (newValue: S) => {
+    (storageKey: string, newValue: S) => {
 
       if (typeof document !== "undefined") {
         const event: BroadcastCustomEvent<S> = new CustomEvent(
-          customEventTypeName,
+          `rooks-${storageKey}-sessionstorage-update`,
           { detail: { newValue } }
         );
         document.dispatchEvent(event);
@@ -193,22 +215,24 @@ function useSessionstorageState<S>(
         console.warn("[useSessionstorageState] document is undefined.");
       }
     },
-    [customEventTypeName]
+    []
   );
 
   const set = useCallback(
     (newValue: SetStateAction<S>) => {
       const resolvedNewValue = typeof newValue === "function"
-        ? (newValue as (prevState: S) => S)(currentValue.current)
+        ? (newValue as (prevState: S) => S)(currentValueRef.current)
         : newValue;
+      const storageKey = currentKeyRef.current;
       isUpdateFromCrossDocumentListener.current = false;
       isUpdateFromWithinDocumentListener.current = true;
-      currentValue.current = resolvedNewValue;
-      saveValueToSessionStorage<S>(key, resolvedNewValue);
+      updateSourceKeyRef.current = storageKey;
+      currentValueRef.current = resolvedNewValue;
+      saveValueToSessionStorage<S>(storageKey, resolvedNewValue);
       setValue(resolvedNewValue);
-      broadcastValueWithinDocument(resolvedNewValue);
+      broadcastValueWithinDocument(storageKey, resolvedNewValue);
     },
-    [broadcastValueWithinDocument, currentValue]
+    [broadcastValueWithinDocument, currentKeyRef, currentValueRef]
   );
 
   const remove = useCallback(() => {

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -28,6 +28,10 @@ function saveValueToSessionStorage<S>(key: string, value: S) {
   }
 
   try {
+    if (value === undefined) {
+      return sessionStorage.removeItem(key);
+    }
+
     return sessionStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
     console.error(error);

--- a/packages/rooks/src/hooks/useSessionstorageState.ts
+++ b/packages/rooks/src/hooks/useSessionstorageState.ts
@@ -192,6 +192,7 @@ function useSessionstorageState<S>(
         : newValue;
       isUpdateFromCrossDocumentListener.current = false;
       isUpdateFromWithinDocumentListener.current = false;
+      currentValue.current = resolvedNewValue;
       setValue(resolvedNewValue);
       broadcastValueWithinDocument(resolvedNewValue);
     },

--- a/packages/rooks/src/hooks/useSetState.ts
+++ b/packages/rooks/src/hooks/useSetState.ts
@@ -29,25 +29,25 @@ export type UseSetStateReturnValue<T> = [Set<T>, UseSetStateControls<T>];
 function useSetState<T>(initialSetValue: Set<T>): UseSetStateReturnValue<T> {
   const [setValue, setSetValue] = useState<Set<T>>(new Set(initialSetValue));
 
-  const add = useCallback<Add<T>>(
-    (...args): void => {
-      setSetValue(new Set(setValue.add(...args)));
-    },
-    [setValue, setSetValue]
-  );
+  const add = useCallback<Add<T>>((...args): void => {
+    setSetValue((currentSet) => {
+      const nextSet = new Set(currentSet);
+      nextSet.add(...args);
+      return nextSet;
+    });
+  }, []);
 
-  const deleteValue = useCallback<Delete<T>>(
-    (...args): void => {
-      const newSetValue = new Set(setValue);
-      newSetValue.delete(...args);
-      setSetValue(newSetValue);
-    },
-    [setValue, setSetValue]
-  );
+  const deleteValue = useCallback<Delete<T>>((...args): void => {
+    setSetValue((currentSet) => {
+      const nextSet = new Set(currentSet);
+      nextSet.delete(...args);
+      return nextSet;
+    });
+  }, []);
 
   const clear = useCallback((): void => {
     setSetValue(new Set());
-  }, [setSetValue]);
+  }, []);
 
   const controls = useMemo<UseSetStateControls<T>>(() => {
     return { add, delete: deleteValue, clear };

--- a/packages/rooks/src/hooks/useThrottle.ts
+++ b/packages/rooks/src/hooks/useThrottle.ts
@@ -37,16 +37,17 @@ function useThrottle<T>(
   );
 
   useEffect(() => {
-    if (!ready) {
-      timerRef.current = window.setTimeout(() => {
-        readyRef.current = true;
-        setReady(true);
-      }, timeout);
+    if (ready) {
+      readyRef.current = true;
 
-      return () => window.clearTimeout(timerRef.current);
+      return noop;
     }
 
-    return noop;
+    timerRef.current = window.setTimeout(() => {
+      setReady(true);
+    }, timeout);
+
+    return () => window.clearTimeout(timerRef.current);
   }, [ready, timeout]);
 
   return [throttledFunction, ready];

--- a/packages/rooks/src/hooks/useThrottle.ts
+++ b/packages/rooks/src/hooks/useThrottle.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { noop } from "@/utils/noop";
+import { useFreshRef } from "./useFreshRef";
 
 type Callback<T> = (...args: T[]) => void;
 
@@ -18,23 +19,27 @@ function useThrottle<T>(
   timeout = 300
 ): [Callback<T>, boolean] {
   const [ready, setReady] = useState(true);
+  const readyRef = useRef(true);
   const timerRef = useRef<number | undefined>(undefined);
+  const callbackRef = useFreshRef(callback, true);
 
   const throttledFunction = useCallback(
     (...args: T[]) => {
-      if (!ready) {
+      if (!readyRef.current) {
         return;
       }
 
+      readyRef.current = false;
       setReady(false);
-      callback(...args);
+      callbackRef.current(...args);
     },
-    [ready, callback]
+    [callbackRef]
   );
 
   useEffect(() => {
     if (!ready) {
       timerRef.current = window.setTimeout(() => {
+        readyRef.current = true;
         setReady(true);
       }, timeout);
 


### PR DESCRIPTION
## Summary

Comprehensive, signature-preserving robustness maintenance for stable hooks, with the experimental and Temporal surfaces audited for follow-up risks.

### Runtime fixes

- async lifecycle: `useFetch`, `useAsyncEffect`, `useDebouncedAsyncEffect`
- persistence: `useLocalstorageState`, `useSessionstorageState`
- browser/ref lifecycle: `useOnline`, `usePictureInPictureApi`, `useFileDropRef`
- state and timing: `useArrayState`, `useSetState`, `useMapState`, `useCountdown`, `useThrottle`

### Test improvements

Adds coverage for Strict Mode replay, request races and aborts, real server rendering, ref attachment, storage synchronization/key changes, batched state operations, immutable snapshots, exact countdown boundaries, zero-valued file limits, and same-tick throttling.

### Documentation

Synchronizes hook JSDoc where applicable, live website MDX, legacy `data/docs`, and adds a patch changeset.

## Hook audit

All implementations exported by `src/index.ts`, `src/experimental.ts`, and `src/temporal.ts` were reviewed by behavior family. Aliases were reviewed with their underlying implementation. Evidence-based changes are included above; sound implementations were intentionally left untouched.

High-confidence findings deliberately deferred because they need a separate behavioral review or larger internal rewrite:

- Suspense persistence cache/delete coherence and dynamic keys
- `usePromise` refresh semantics and skipped legacy suite
- `useAsyncDisposable` ErrorBoundary policy
- media recorder generation/URL ownership
- queue/stack synchronous return semantics and undo/redo atomic history
- finite RAF termination and Temporal deadline scheduling
- observer fallbacks and dimension-frame coalescing
- Idle Detection transactional retry semantics

No new hooks, exports, parameters, return fields, or public signature changes are introduced.

## Validation

- Node CI Pull request #3921: passed
- `pnpm run all-checks`: passed
- TypeScript declarations/build: passed
- ESLint: passed
- Vitest coverage suite: 1,528 passed, 21 skipped, 0 failed
- Website preview: tracked by the Vercel PR check
