### PR TITLE
Remove unsafe MediaRecorder error assertion

### DIFF
--- a/packages/rooks/src/hooks/useMediaRecorder.ts
+++ b/packages/rooks/src/hooks/useMediaRecorder.ts
@@ -178,9 +178,16 @@ function useMediaRecorder(
       };
 
       mediaRecorder.onerror = (event: Event) => {
-        const err = new Error(
-          `MediaRecorder error: ${(event as any).error?.message || "Unknown error"}`
-        );
+        const error = "error" in event ? event.error : undefined;
+        const message =
+          typeof error === "object" &&
+          error !== null &&
+          "message" in error &&
+          typeof error.message === "string" &&
+          error.message
+            ? error.message
+            : "Unknown error";
+        const err = new Error(`MediaRecorder error: ${message}`);
         setError(err);
         setRecordingState("idle");
       };


### PR DESCRIPTION
## Issue

`useMediaRecorder` cast the browser error event to `any` before reading `error.message`. That bypassed TypeScript and allowed an arbitrary event payload to be dereferenced without checking its shape.

## Fix

Narrow the event's optional `error` property and its `message` field at runtime before using it. Valid non-empty string messages are preserved, and all other payloads continue to use the existing `Unknown error` fallback.

## Risk

Low. The public hook API and recording behavior are unchanged; only error-message extraction is made defensive and type-safe.

## Verification

- `pnpm --filter rooks typecheck`
- `pnpm --filter rooks exec vitest run src/__tests__/useMediaRecorder.spec.tsx` (23 tests passed)
- `git diff --check`