### PR TITLE
Remove unsafe user agent cache assertions

### DIFF
--- a/packages/rooks/src/hooks/useSuspenseNavigatorUserAgentData.ts
+++ b/packages/rooks/src/hooks/useSuspenseNavigatorUserAgentData.ts
@@ -134,22 +134,23 @@ function useSuspenseNavigatorUserAgentData(
     // Create new cache entry with promise
     const promise = navigator.userAgentData.getHighEntropyValues(hints);
     
-    entry = {
+    const cacheEntry: CacheEntry = {
       promise,
       status: 'pending'
     };
     
-    cache.set(cacheKey, entry);
+    cache.set(cacheKey, cacheEntry);
+    entry = cacheEntry;
     
     // Handle promise resolution/rejection
     promise
       .then((result) => {
-        entry!.status = 'resolved';
-        entry!.result = result;
+        cacheEntry.status = 'resolved';
+        cacheEntry.result = result;
       })
       .catch((error) => {
-        entry!.status = 'rejected';
-        entry!.error = error instanceof Error ? error : new Error(String(error));
+        cacheEntry.status = 'rejected';
+        cacheEntry.error = error instanceof Error ? error : new Error(String(error));
       });
   }
   


### PR DESCRIPTION
## Issue

The asynchronous cache handlers closed over the mutable `entry` binding, whose type includes `undefined`, and used four non-null assertions to suppress that possibility. This made the callbacks depend on an unchecked assumption even though the newly created cache entry was already available.

## Fix

Create a concrete `CacheEntry`, store it in the cache, assign it to the outer binding for the current render, and have the promise handlers update that concrete entry directly.

## Risk

Low. The same cache-entry object is created, stored, returned, and updated at the same points; the public API and runtime behavior are unchanged.

## Verification

- `pnpm --filter rooks typecheck`
- `pnpm --filter rooks exec vitest run src/__tests__/useSuspenseNavigatorUserAgentData.spec.tsx` (9 tests passed)
- `pnpm --filter rooks exec eslint src/hooks/useSuspenseNavigatorUserAgentData.ts`
- `git diff --check origin/main`

<!-- hourly-type-safety-fix:0b0fa6e0-d29f-4fb0-920a-76a14e3bc487:user-agent-cache-entry -->