### PR TITLE
Remove unsafe battery cache assertions

### DIFF
--- a/packages/rooks/src/hooks/useSuspenseNavigatorBattery.ts
+++ b/packages/rooks/src/hooks/useSuspenseNavigatorBattery.ts
@@ -95,20 +95,21 @@ function useSuspenseNavigatorBattery(): BatteryManager {
         // Create new cache entry with promise
         const promise = navigator.getBattery();
 
-        cacheEntry = {
+        const newEntry: CacheEntry = {
             promise,
             status: 'pending'
         };
+        cacheEntry = newEntry;
 
         // Handle promise resolution/rejection
         promise
             .then((result) => {
-                cacheEntry!.status = 'resolved';
-                cacheEntry!.result = result;
+                newEntry.status = 'resolved';
+                newEntry.result = result;
             })
             .catch((error) => {
-                cacheEntry!.status = 'rejected';
-                cacheEntry!.error = error instanceof Error ? error : new Error(String(error));
+                newEntry.status = 'rejected';
+                newEntry.error = error instanceof Error ? error : new Error(String(error));
             });
     }
 


### PR DESCRIPTION
## Issue

The asynchronous battery cache handlers closed over the mutable `cacheEntry` binding, whose type includes `null`, and used four non-null assertions before updating it. A cache reset or later reassignment could therefore make those callbacks update the wrong value despite the newly created cache entry already being available.

## Fix

Create a concrete `CacheEntry`, assign it to the module cache, and have the promise handlers update that concrete entry directly.

## Risk

Low. The same cache-entry object is created, stored, returned, and updated at the same points; the hook API and normal runtime behavior are unchanged.

## Verification

- `pnpm --filter rooks typecheck`
- `pnpm --filter rooks exec vitest run src/__tests__/useSuspenseNavigatorBattery.spec.tsx` (16 tests passed)
- `pnpm --filter rooks exec eslint src/hooks/useSuspenseNavigatorBattery.ts` (0 errors; 1 pre-existing module-cache purity warning)
- `git diff --check origin/main...HEAD`

<!-- hourly-type-safety-fix:a57e2278-2c80-467f-9ed8-728efd176b5a:battery-cache-entry -->