### PR TITLE
Remove unsafe ResizeObserver size assertion

### DIFF
--- a/packages/rooks/src/hooks/useSize.ts
+++ b/packages/rooks/src/hooks/useSize.ts
@@ -16,6 +16,16 @@ export type UseSizeOptions = {
   onChange?: (size: Size) => void;
 };
 
+type ResizeObserverSizeValue =
+  | ReadonlyArray<ResizeObserverSize>
+  | ResizeObserverSize;
+
+function isSingleResizeObserverSize(
+  value: ResizeObserverSizeValue
+): value is ResizeObserverSize {
+  return !Array.isArray(value);
+}
+
 const defaultSize: Size = {
   width: 0,
   height: 0,
@@ -38,12 +48,10 @@ function readFallbackContentSize(node: HTMLElement): Size {
 }
 
 function readBoxSize(
-  sizes: ReadonlyArray<ResizeObserverSize> | undefined,
+  sizes: ResizeObserverSizeValue | undefined,
   node: HTMLElement
 ): Size | null {
-  const size = Array.isArray(sizes)
-    ? sizes[0]
-    : (sizes as unknown as ResizeObserverSize | undefined);
+  const size = sizes && isSingleResizeObserverSize(sizes) ? sizes : sizes?.[0];
   if (!size) {
     return null;
   }


### PR DESCRIPTION
<!-- hourly-type-safety-fix:c82997df-9d61-45b8-8b07-61fea4667464:fix-and-open-pr -->

## Issue

`useSize` supports both the standard ResizeObserver size array and the legacy singleton shape, but it handled the singleton branch with a double assertion through `unknown`. That bypassed TypeScript instead of representing the runtime inputs precisely.

## Fix

Model the internal size value as a union of the array and singleton shapes, then use a dedicated type guard to narrow the value before reading it. The hook's public API and runtime behavior are unchanged.

## Risk

Low. The change is limited to internal typing and preserves the existing behavior for arrays, empty values, and legacy singleton values.

## Verification

- `pnpm --filter rooks typecheck`
- `pnpm --filter rooks exec vitest run src/__tests__/experimentalHookRegressions.spec.tsx src/__tests__/useExperimentalBrowserHooks.spec.tsx` (36 tests)
- `pnpm --filter rooks exec eslint src/hooks/useSize.ts`
- `pnpm exec prettier --check packages/rooks/src/hooks/useSize.ts`
- `git diff --check`
