### PR TITLE
Remove unsafe video element assertions

### DIFF
--- a/packages/rooks/src/__tests__/useVideo.spec.tsx
+++ b/packages/rooks/src/__tests__/useVideo.spec.tsx
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 /**
  */
-import { renderHook, act } from "@testing-library/react";
+import { render, renderHook, act } from "@testing-library/react";
 import { useVideo } from "@/hooks/useVideo";
 
 describe("useVideo", () => {
@@ -275,47 +275,48 @@ describe("useVideo", () => {
   });
 
   it("should update state on timeupdate event", () => {
-    const { result } = renderHook(() => useVideo());
-    const [videoRef] = result.current;
-
-    Object.defineProperty(videoRef, "current", {
-      value: mockVideoElement,
-      writable: true,
-    });
-
-    // Re-render to trigger useEffect
-    const { rerender } = renderHook(() => useVideo());
-    rerender();
-
-    // Simulate timeupdate event
-    act(() => {
-      mockVideoElement.currentTime = 25;
-      mockVideoElement.dispatchEvent(new Event("timeupdate"));
-    });
-
-    // Note: Due to how useEffect works with refs, we need to test with a component
-    // that actually attaches the video element to the ref during render
-  });
-
-  it("should handle event listeners correctly", () => {
-    // Create a mock video element with event listener tracking
-    const addEventListenerSpy = vi.spyOn(mockVideoElement, "addEventListener");
-    const removeEventListenerSpy = vi.spyOn(mockVideoElement, "removeEventListener");
-
-    const { unmount } = renderHook(() => {
-      const [videoRef] = useVideo();
-      // Simulate the video element being set on ref
+    const TestComponent = () => {
+      const [videoRef, state] = useVideo();
       Object.defineProperty(videoRef, "current", {
         value: mockVideoElement,
         writable: true,
         configurable: true,
       });
-      return videoRef;
+      return <span data-testid="current-time">{state.currentTime}</span>;
+    };
+
+    const { getByTestId } = render(<TestComponent />);
+
+    act(() => {
+      mockVideoElement.currentTime = 25;
+      mockVideoElement.dispatchEvent(new Event("timeupdate"));
     });
 
-    // Event listeners should be added (but due to ref timing, this is tricky to test)
-    // At least verify cleanup doesn't throw
+    expect(getByTestId("current-time")).toHaveTextContent("25");
+  });
+
+  it("should handle event listeners correctly", () => {
+    const addEventListenerSpy = vi.spyOn(mockVideoElement, "addEventListener");
+    const removeEventListenerSpy = vi.spyOn(
+      mockVideoElement,
+      "removeEventListener"
+    );
+
+    const TestComponent = () => {
+      const result = useVideo();
+      Object.defineProperty(result[0], "current", {
+        value: mockVideoElement,
+        writable: true,
+        configurable: true,
+      });
+      return null;
+    };
+
+    const { unmount } = render(<TestComponent />);
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(4);
     unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(4);
   });
 
   it("should update state on durationchange event", () => {

--- a/packages/rooks/src/hooks/useVideo.ts
+++ b/packages/rooks/src/hooks/useVideo.ts
@@ -27,7 +27,7 @@ type VideoControls = {
 const useVideo = (): [
   RefObject<HTMLVideoElement | null>,
   VideoState,
-  VideoControls
+  VideoControls,
 ] => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [state, setState] = useState<VideoState>({
@@ -95,17 +95,21 @@ const useVideo = (): [
   useEffect(() => {
     const video = videoRef.current;
 
+    if (!video) {
+      return;
+    }
+
     const handleTimeUpdate = () => {
       setState((prevState) => ({
         ...prevState,
-        currentTime: video!.currentTime,
+        currentTime: video.currentTime,
       }));
     };
 
     const handleDurationChange = () => {
       setState((prevState) => ({
         ...prevState,
-        duration: video!.duration,
+        duration: video.duration,
       }));
     };
 
@@ -123,20 +127,16 @@ const useVideo = (): [
       }));
     };
 
-    if (video) {
-      video.addEventListener("timeupdate", handleTimeUpdate);
-      video.addEventListener("durationchange", handleDurationChange);
-      video.addEventListener("pause", handlePause);
-      video.addEventListener("play", handlePlay);
-    }
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    video.addEventListener("durationchange", handleDurationChange);
+    video.addEventListener("pause", handlePause);
+    video.addEventListener("play", handlePlay);
 
     return () => {
-      if (video) {
-        video.removeEventListener("timeupdate", handleTimeUpdate);
-        video.removeEventListener("durationchange", handleDurationChange);
-        video.removeEventListener("pause", handlePause);
-        video.removeEventListener("play", handlePlay);
-      }
+      video.removeEventListener("timeupdate", handleTimeUpdate);
+      video.removeEventListener("durationchange", handleDurationChange);
+      video.removeEventListener("pause", handlePause);
+      video.removeEventListener("play", handlePlay);
     };
   }, [videoRef]);
 

--- a/packages/rooks/src/hooks/useVideo.ts
+++ b/packages/rooks/src/hooks/useVideo.ts
@@ -93,8 +93,10 @@ const useVideo = (): [
   };
 
   useEffect(() => {
+    // Keep handlers and cleanup tied to the same element if the ref changes.
     const video = videoRef.current;
 
+    // The ref may still be unattached during the hook's initial effect.
     if (!video) {
       return;
     }


### PR DESCRIPTION
<!-- hourly-type-safety-fix:9d4c646a-9365-4f84-9929-af18ab81cc6f:fix-and-open-pr -->

## Issue

`useVideo` captured the current video element inside its effect but used non-null assertions when reading `currentTime` and `duration` from event handlers. Those assertions bypassed TypeScript even though the effect can establish the element's presence once for listener registration and cleanup.

## Fix

Return early when no video element is mounted, then register the handlers against the narrowed element. The event handlers and cleanup now share the same proven non-null element without unchecked assertions.

## Risk

Low. The change is internal to the effect and preserves listener registration, state updates, and cleanup behavior for mounted elements; the no-element path remains a no-op.

## Verification

- `pnpm --filter rooks typecheck`
- `pnpm --filter rooks exec vitest run src/__tests__/useVideo.spec.tsx` (17 tests)
- `pnpm --filter rooks exec eslint src/hooks/useVideo.ts`
- `pnpm exec prettier --check packages/rooks/src/hooks/useVideo.ts`
- `git diff --check`
