### PR TITLE
ci(mergify): match queue checks to CI

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,11 +4,9 @@ queue_rules:
   - name: default
     batch_size: 1
     queue_conditions:
-      - check-success=Build (test)
-      - check-success=Test (pnpm test)
+      - check-success=build
     merge_conditions:
-      - check-success=Build (test)
-      - check-success=Test (pnpm test)
+      - check-success=build
 pull_request_rules:
   - name: update out-of-sync PR
     conditions:


### PR DESCRIPTION
Update the default Mergify queue and merge conditions to require the actual PR check name, `build`. That job runs `pnpm run all-checks`, so manually queued PRs can enter the queue again.